### PR TITLE
Fix: remove link in post thumbs

### DIFF
--- a/inc/parts/class-content-post.php
+++ b/inc/parts/class-content-post.php
@@ -237,11 +237,9 @@ if ( ! class_exists( 'TC_post' ) ) :
     * @since Customizr 3.2.0
     */
     function tc_set_thumb_shape( $thumb_wrapper, $thumb_img ) {
-      return sprintf('<div class="%4$s"><a class="tc-rectangular-thumb" href="%1$s" title="%2s">%3$s</a></div>',
-            get_permalink( get_the_ID() ),
-            esc_attr( strip_tags( get_the_title( get_the_ID() ) ) ),
+      return sprintf('<div class="%2$s">%1$s</div>',
             $thumb_img,
-            implode( " ", apply_filters( 'tc_thumb_wrapper_class', array() ) )
+            implode( " ", apply_filters( 'tc_thumb_wrapper_class', array('tc-rectangular-thumb') ) )
       );
     }
 


### PR DESCRIPTION
Why do we wrap the image in a link to the same page?
mmm

against a655944574
