### PR TITLE
Fix: sticky header behaviour in small viewports

### DIFF
--- a/inc/assets/js/parts/bootstrap.js
+++ b/inc/assets/js/parts/bootstrap.js
@@ -1687,6 +1687,7 @@ var TCParams = TCParams || {};
       //@tc adddon
       if ( TCParams && 1 != TCParams.dropdowntoViewport && 1 == TCParams.stickyHeader ) {
         $('body').addClass('tc-sticky-header');
+        $(window).trigger('resize');
       }
     }
 

--- a/inc/assets/js/parts/main.js
+++ b/inc/assets/js/parts/main.js
@@ -479,7 +479,7 @@ jQuery(function ($) {
             if ( 580 < $_window.width() )
                 initialOffset = $wpadminbar.height();
             else
-                initialOffset = ! _is_scrolling() ? $wpadminbar.height() : 0;
+                initialOffset = ! $_window.scrollTop() ? $wpadminbar.height() : 0;
         }
         return initialOffset + customOffset;
     }


### PR DESCRIPTION
against 572e75679e
rib of the closed #160

Both reproducible when window's width <= 600px.

How to reproduce the bug fixed by bootstrap.js change:
-   adminbar on , tc-sticky-header on, dropdowntoViewport off, so "In responsive mode, limit the height of the dropdown menu block to the visible viewport" unchecked.
-   scroll down the page for a certain amount (so the header top will be set to 0), click on the menu button, page will scrolled up and menu will be shown (sticky disabled)
-   click again on the menu, sticky re-enabled but top is set to 0 so the adminbar will overlap the header, or if you prefer the header will go behind the adminbar :D I trigger a resize so the header's offset will be set again. We might consider to make custom signals so we can better control this stuff without trigger a window resize.

How to reproduce the bug fixed by the main.js change:
-   adminbar on, tc-sticky-header on
-   scroll down the page just ONE step, you'll see the sticky header enabled having an useless top property = adminbar height, so blank gap
  My solution is to refer to the window scrollTop in that case instead of relying on _is_scrolling()
