### PR TITLE
Imp: link smooth scroll, exclude wc-tabs only in woocommerce contexts

### DIFF
--- a/inc/assets/js/parts/tc-js-params.js
+++ b/inc/assets/js/parts/tc-js-params.js
@@ -18,7 +18,7 @@ var TCParams = TCParams || {
 	anchorSmoothScroll: "linear",
   anchorSmoothScrollExclude : {
       simple : ['[class*=edd]', '.tc-carousel-control', '.carousel-control', '[data-toggle="modal"]', '[data-toggle="dropdown"]', '[data-toggle="tooltip"]', '[data-toggle="popover"]', '[data-toggle="collapse"]', '[data-toggle="tab"]', '[class*=upme]', '[class*=um-]'],
-      deep : { classes : ['wc-tabs'], ids : [] }
+      deep : { classes : [], ids : [] }
     },
 	stickyCustomOffset: { _initial : 0, _scrolling : 0, options : { _static : true, _element : "" } },
 	stickyHeader: 1,

--- a/inc/class-fire-plugins_compat.php
+++ b/inc/class-fire-plugins_compat.php
@@ -533,11 +533,14 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
          return ( function_exists('is_woocommerce') && is_woocommerce() ) ? false : $bool;
       }
 
-
-      //disable link smooth scroll;
-      add_filter( 'tc_opt_tc_link_scroll', 'tc_woocommerce_disable_link_scroll' );
-      function tc_woocommerce_disable_link_scroll( $bool ){
-        return ( function_exists('is_woocommerce') && is_woocommerce() ) ? false : $bool;
+      //link smooth scroll: exclude woocommerce tabs
+      add_filter( 'tc_anchor_smoothscroll_excl', 'tc_woocommerce_disable_link_scroll' );
+      function tc_woocommerce_disable_link_scroll( $excl ){
+        if ( false == TC_utils::$inst->tc_opt('tc_link_scroll') ) return $excl;
+        
+        if ( function_exists('is_woocommerce') && is_woocommerce() ) 
+          $excl['deep']['classes'][] = 'wc-tabs';
+        return $excl;
       }
 
 

--- a/inc/class-fire-resources.php
+++ b/inc/class-fire-resources.php
@@ -205,7 +205,7 @@ if ( ! class_exists( 'TC_resources' ) ) :
             $anchor_smooth_scroll_exclude =  apply_filters( 'tc_anchor_smoothscroll_excl' , array(
                 'simple' => array( '[class*=edd]' , '.tc-carousel-control', '.carousel-control', '[data-toggle="modal"]', '[data-toggle="dropdown"]', '[data-toggle="tooltip"]', '[data-toggle="popover"]', '[data-toggle="collapse"]', '[data-toggle="tab"]', '[class*=upme]', '[class*=um-]' ),
                 'deep'   => array(
-                  'classes' => array('wc-tabs'),
+                  'classes' => array(),
                   'ids'     => array()
                 ) 
             ));


### PR DESCRIPTION
Is this what you meant?
Or did you mean to completely get rid of the deep param and build it up only when needed?
Let me know ;)