### PR TITLE
Fix: avoid navbar-wrapper overlapping title/logo in mobiles when no

### DIFF
--- a/inc/assets/less/tc_custom_responsive.less
+++ b/inc/assets/less/tc_custom_responsive.less
@@ -120,6 +120,7 @@
     float:none;
     text-align: center;
     width: 100%;
+    clear: both;
   }
   .container.navbar-wrapper {
     margin-bottom: 0;


### PR DESCRIPTION
site-description is shown for ww<767px

Fixes #309 introduced in 7b18e59

this is an alternative to #310