### PR TITLE
Fix: exclude links wrapped in an underlined span from the eligible

### DIFF
--- a/inc/assets/js/parts/jqueryextLinks.js
+++ b/inc/assets/js/parts/jqueryextLinks.js
@@ -35,6 +35,7 @@
       if ( this.options.addIcon && 0 === $_external_icon.length ) {
         this.$_el.after('<span class="tc-external">');
       }
+        
 
       //add the target _blank, if not already there
       if ( this.options.newTab && '_blank' != this.$_el.attr('target') )
@@ -59,7 +60,20 @@
       if ( 2 != ( ['ids', 'classes'].filter( function( sel_type) { return self._is_selector_allowed(sel_type); } ) ).length )
         return;
 
-      return true;
+      //is wrapped in an underlined span?
+      var $_link_parents_span = this.$_el.parents('span[style*=text-decoration]'),
+          _is_eligible = true;  
+
+      // we want to exit as soon as we find a parent with the underlined text-decoration
+      if ( $_link_parents_span.length )
+        $_link_parents_span.each( function() {
+          if ( $(this).attr('style').indexOf('underline') ){
+            _is_eligible = false;  
+            return;    
+          }
+        });
+
+      return true && _is_eligible;
     };
 
 


### PR DESCRIPTION
externals

fixes issue #311

I used the jQuery each instead of an underscore filter 'cause I wanted
to break as soon as a parent matching the condition was found

Maybe we want to extend the case also to non-span parents? Pretty uncommon..