### PR TITLE
Fix: smartload and jetpack's photon - load imgs from cdn

### DIFF
--- a/inc/class-fire-plugins_compat.php
+++ b/inc/class-fire-plugins_compat.php
@@ -43,7 +43,6 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
       add_theme_support( 'polylang' );
       add_theme_support( 'woocommerce' );
       add_theme_support( 'the-events-calendar' );
-      add_theme_support( 'nextgen-gallery' );
       add_theme_support( 'optimize-press' );
       add_theme_support( 'sensei' );
     }
@@ -94,10 +93,6 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
       /* Woocommerce */
       if ( current_theme_supports( 'woocommerce' ) && $this -> tc_is_plugin_active('woocommerce/woocommerce.php') )
         $this -> tc_set_woocomerce_compat();
-
-      /* Nextgen gallery */
-      if ( current_theme_supports( 'nextgen-gallery') && $this -> tc_is_plugin_active('nextgen-gallery/nggallery.php') )
-        $this -> tc_set_nggallery_compat();
 
       /* Sensei woocommerce addon */
       if ( current_theme_supports( 'sensei') && $this -> tc_is_plugin_active('woothemes-sensei/woothemes-sensei.php') )
@@ -376,25 +371,6 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
       }//end Front
     }//end polylang compat
 
-
-    /**
-    * NextGen Gallery compat hooks
-    * @package Customizr
-    * @since Customizr 3.3+
-    */
-    private function tc_set_nggallery_compat() {
-      /* Make Customizr smart load work with nextgen galleries and fix small bug which resulted in displaying plain image attributes */
-     add_action('wp_head', 'tc_content_parse_imgs_rehook');
-     function tc_content_parse_imgs_rehook(){
-       // smartload doesn't work at all for nggalleries in pages, looks like they add "data-src" to their images in pages .. mah
-       if ( is_page() || is_admin() || 0 == esc_attr( TC_utils::$inst->tc_opt( 'tc_img_smart_load' ) ) )
-        return;
-
-       remove_filter('the_content', array(TC_utils::$instance, 'tc_parse_imgs'), 20 );
-       // they add the actual images filtering the content with priority PHP_INT_MAX -1
-       add_filter('the_content'   , array(TC_utils::$instance, 'tc_parse_imgs'), PHP_INT_MAX );
-     }
-    }
 
 
     /**

--- a/inc/class-fire-utils.php
+++ b/inc/class-fire-utils.php
@@ -95,7 +95,7 @@ if ( ! class_exists( 'TC_utils' ) ) :
       function tc_wp_filters() {
         add_filter( 'the_content'                         , array( $this , 'tc_fancybox_content_filter' ) );
         if ( esc_attr( TC_utils::$inst->tc_opt( 'tc_img_smart_load' ) ) ) {
-          add_filter( 'the_content'                       , array( $this , 'tc_parse_imgs' ), 20 );
+          add_filter( 'the_content'                       , array( $this , 'tc_parse_imgs' ), PHP_INT_MAX );
           add_filter( 'tc_thumb_html'                     , array( $this , 'tc_parse_imgs' ) );
         }
         add_filter( 'wp_title'                            , array( $this , 'tc_wp_title' ), 10, 2 );


### PR DESCRIPTION
fixes #334

p.s.
tested with photon.
tested ngggallery without the comp code of course.