### PR TITLE
Fix: slider-controls always visible in ie9-

### DIFF
--- a/inc/assets/less/tc_custom.less
+++ b/inc/assets/less/tc_custom.less
@@ -1602,6 +1602,7 @@ footer#footer .colophon .social-block a {
   width: 10%;
   opacity: 0;
   color: #999;
+  z-index: 10;
 }
 .tc-slid-hover .tc-slider-controls {
   opacity: 1;

--- a/inc/assets/less/tc_custom.less
+++ b/inc/assets/less/tc_custom.less
@@ -1602,7 +1602,7 @@ footer#footer .colophon .social-block a {
   width: 10%;
   opacity: 0;
   color: #999;
-  z-index: 10;
+  z-index: 10\9; /* controls visible and clickable in IE 9 and below */
 }
 .tc-slid-hover .tc-slider-controls {
   opacity: 1;


### PR DESCRIPTION
In such browsers the opacity+transition doesn't really work fine,
let's make them always visible.

Also even when visible without specifying the z-index actual links were not reachable.