### PR TITLE
Fix: Select a submenu expansion option disappears #340

### DIFF
--- a/inc/admin/js/parts/_control.js
+++ b/inc/admin/js/parts/_control.js
@@ -450,6 +450,36 @@
         return '1' == to;
       }
     },
+    'tc_display_second_menu' : {
+      show : {
+        controls: [
+          'nav_menu_locations[secondary]',
+          'tc_second_menu_position',
+          'tc_second_menu_resp_setting',
+          'tc_menu_type',
+          'tc_menu_submenu_fade_effect',
+          'tc_menu_submenu_item_move_effect'
+        ],
+        //the menu style must be aside for secondary menu controls
+        callback: function (to, targetSetId, changedSetId) {
+          //second menu speicifics
+          if ( _.contains( ['nav_menu_locations[secondary]', 'tc_second_menu_resp_setting'], targetSetId ) )
+            return '1' == to && 'aside' == api( _build_setId( 'tc_menu_style' )).get();
+          //effects common to regular menu and second horizontal menu
+          if ( _.contains( ['tc_menu_submenu_fade_effect', 'tc_menu_submenu_item_move_effect'], targetSetId ) )
+            return ( '1' == to && 'aside' == api( _build_setId( 'tc_menu_style' )).get() ) || ('1' != to && 'aside' != api( _build_setId( 'tc_menu_style' )).get() );
+          return '1' == to;
+        }
+      }
+      // hide : {
+      //   controls: [
+      //     'tc_display_menu_label'
+      //   ],
+      //   callback: function (to) {
+      //     return 'aside' != to;
+      //   }
+      // }
+    },
     'tc_menu_style' : {
       show : {
         controls: [
@@ -457,7 +487,6 @@
           'tc_menu_submenu_fade_effect',
           'tc_menu_submenu_item_move_effect',
           'tc_menu_resp_dropdown_limit_to_viewport',
-
           'tc_display_menu_label',
           'tc_display_second_menu',
           'tc_second_menu_position',
@@ -501,36 +530,6 @@
           }
         }
       }
-    },
-    'tc_display_second_menu' : {
-      show : {
-        controls: [
-          'nav_menu_locations[secondary]',
-          'tc_second_menu_position',
-          'tc_second_menu_resp_setting',
-          'tc_menu_type',
-          'tc_menu_submenu_fade_effect',
-          'tc_menu_submenu_item_move_effect'
-        ],
-        //the menu style must be aside for secondary menu controls
-        callback: function (to, targetSetId, changedSetId) {
-          //second menu speicifics
-          if ( _.contains( ['nav_menu_locations[secondary]', 'tc_second_menu_resp_setting'], targetSetId ) )
-            return '1' == to && 'aside' == api( _build_setId( 'tc_menu_style' )).get();
-          //effects common to regular menu and second horizontal menu
-          if ( _.contains( ['tc_menu_submenu_fade_effect', 'tc_menu_submenu_item_move_effect'], targetSetId ) )
-            return ( '1' == to && 'aside' == api( _build_setId( 'tc_menu_style' )).get() ) || ('1' != to && 'aside' != api( _build_setId( 'tc_menu_style' )).get() );
-          return '1' == to;
-        }
-      }
-      // hide : {
-      //   controls: [
-      //     'tc_display_menu_label'
-      //   ],
-      //   callback: function (to) {
-      //     return 'aside' != to;
-      //   }
-      // }
     }
   };
 


### PR DESCRIPTION
Solved swapping the order of the 'tc_menu_style' and 'tc_display_second_menu'
visibility controls definition.
This 'cause the visibility set by tc_display_second_menu is always subordered
to the menu_style