### PR TITLE
Fix: fix preview settings bind for wp versions <4.1

### DIFF
--- a/inc/admin/class-admin-customize.php
+++ b/inc/admin/class-admin-customize.php
@@ -352,6 +352,8 @@ if ( ! class_exists( 'TC_customize' ) ) :
 		 */
 
 		function tc_customize_preview_js() {
+			global $wp_version;
+
 			wp_enqueue_script(
 				'tc-customizer-preview' ,
 				sprintf('%1$s/inc/admin/js/theme-customizer-preview%2$s.js' , get_template_directory_uri(), ( defined('WP_DEBUG') && true === WP_DEBUG ) ? '' : '.min' ),
@@ -371,7 +373,9 @@ if ( ! class_exists( 'TC_customize' ) ) :
                 //array( 'skinName' => 'custom-skin-#40542.css', 'fullPath' => 'http://....' )
                 'customSkin'      => apply_filters( 'tc_custom_skin_preview_params' , array( 'skinName' => '', 'fullPath' => '' ) ),
                 'fontPairs'       => TC_utils::$inst -> tc_get_font( 'list' ),
-                'fontSelectors'   => TC_init::$instance -> font_selectors
+                'fontSelectors'   => TC_init::$instance -> font_selectors,
+                //patch for old wp versions which don't trigger preview-ready signal
+                'wp_before_4_1'   => version_compare( $wp_version, '4.1' , '<' )
 			        )
 			       )
 	        );

--- a/inc/admin/js/theme-customizer-preview.js
+++ b/inc/admin/js/theme-customizer-preview.js
@@ -23,7 +23,11 @@
         } );
       };
 
-  api.bind( 'preview-ready', fireCzrPrev );
+  //Patch for wp versions before 4.1 => preview-ready signal isn't triggered
+  if ( TCPreviewParams && TCPreviewParams.wp_before_4_1 ) 
+    $(document).ready(fireCzrPrev);
+  else
+    api.bind( 'preview-ready', fireCzrPrev );
 
   /******************************************
   * GLOBAL SETTINGS


### PR DESCRIPTION
fixes #327
I went for a conservative way, we'll see if in the future we might need more info on the wp version.