### PR TITLE
Fix: add third param for preg_match_all (required by PHP<5.4.0)

### DIFF
--- a/inc/class-fire-placeholders.php
+++ b/inc/class-fire-placeholders.php
@@ -285,7 +285,7 @@ if ( ! class_exists( 'TC_placeholders' ) ) :
         ! is_user_logged_in() || ! current_user_can('edit_theme_options'),
         ! self::$instance -> tc_is_front_help_enabled(),
         'disabled' == get_transient("tc_img_smartload_help"),
-        apply_filters('tc_img_smartload_help_n_images', 2 ) > preg_match_all( '/(<img[^>]+>)/i', $text ),
+        apply_filters('tc_img_smartload_help_n_images', 2 ) > preg_match_all( '/(<img[^>]+>)/i', $text, $matches ),
         is_admin(),
         ! is_singular()
       );


### PR DESCRIPTION
Anyway most likely we have to change this way to process multiple bool conditions, 'cause we process some of them even when not needed.
Ex:
`a || b`
If a is true the expression above exits with true without evaluating b
But 
$cond = array(a,b); (bool)array_sum($cond); 
b is always evaluated.

Right?

p.s.
push the master :P