### PR TITLE
Fix: typo in front-js: fix referring to the global variable self

### DIFF
--- a/inc/assets/js/parts/_main_jquery_plugins.part.js
+++ b/inc/assets/js/parts/_main_jquery_plugins.part.js
@@ -34,7 +34,7 @@ var czrapp = czrapp || {};
     
       //simple-load event on holders needs to be needs to be triggered with a certain delay otherwise holders will be misplaced (centering)
       if ( 1 == TCParams.centerAllImg ) {
-        self = this;
+        var self = this;
         setTimeout( function(){ 
             self.triggerSimpleLoad( _.filter( $_to_center, function( img ) { 
                 return $(img).hasClass('tc-holder-img'); 


### PR DESCRIPTION
use local scoped instead
fixes #404
( Bug introduced in a5417cac09f9326d4432db563174a88405eeddd0 )