### PR TITLE
Fix: remove unneeded css code for the secondary menu dropdown top arrow

### DIFF
--- a/inc/parts/class-header-menu.php
+++ b/inc/parts/class-header-menu.php
@@ -567,14 +567,6 @@ if ( ! class_exists( 'TC_menu' ) ) :
             -moz-background-clip: padding;
             background-clip: padding-box;
           }
-          .tc-second-menu-on .navbar .nav>li>.dropdown-menu:before {
-            border-left: 7px solid transparent;
-            border-right: 7px solid transparent;
-            border-bottom: 7px solid #ccc;
-            border-bottom-color: rgba(0,0,0,.2);
-            top: -7px;
-            left: 9px;
-          }
           .tc-second-menu-on .navbar .nav>li>.dropdown-menu:after, .navbar .nav>li>.dropdown-menu:before{
             content: '';
             display: inline-block;


### PR DESCRIPTION
This is unneeded 'cause we just need to make the :before pseudo element visible (we do it), the other rules will be taken from the main css.
Also this caused an issue in RTL websites as the actual property to set at 9px will be "right" and not "left"