### PR TITLE
Fix: some CSS fixes for parent dropdown submenus in secondary menu

### DIFF
--- a/inc/assets/less/tc_custom_responsive.less
+++ b/inc/assets/less/tc_custom_responsive.less
@@ -223,7 +223,7 @@
     text-align: @textAlign;
     position: relative;
   }
-  .tc-hover-menu.nav a:after {
+  .tc-header:not(.tc-second-menu-on) .tc-hover-menu.nav a:after {
     border-top: none;
     border-right: none;
     border-left: none;

--- a/inc/parts/class-header-menu.php
+++ b/inc/parts/class-header-menu.php
@@ -566,6 +566,7 @@ if ( ! class_exists( 'TC_menu' ) ) :
             -webkit-background-clip: padding-box;
             -moz-background-clip: padding;
             background-clip: padding-box;
+            padding: 5px 0;
           }
           .tc-second-menu-on .navbar .nav>li>.dropdown-menu:after, .navbar .nav>li>.dropdown-menu:before{
             content: '';
@@ -621,7 +622,7 @@ if ( ! class_exists( 'TC_menu' ) ) :
             border-radius: 6px;
           }
           .tc-second-menu-on .dropdown-submenu>a:after {
-            content: '';
+            content: ' ';
           }
         }\n
 


### PR DESCRIPTION
1) when responsive an dropdowns opening on hover limit the hiding of
the right arrow just to regular menu
or the side nav menu (exclude secondary menu)
involved file: tc_custom_responsive.less
2) when responsive give some padding to the dropdown menu for better
rendering (same not-resp padding)
involved file: class-header-menu.php