### PR TITLE
Fix: when allowing logo's transitions use actual logo dimensions

### DIFF
--- a/inc/assets/js/parts/_main_sticky_header.part.js
+++ b/inc/assets/js/parts/_main_sticky_header.part.js
@@ -196,11 +196,11 @@ var czrapp = czrapp || {};
       if ( ! ( czrapp.$_html.hasClass('csstransitions') && ( this.logo && 0 !== this.logo._logo.length ) ) )
         return;
 
-      var logoW = this.logo._logo.originalWidth(),
-          logoH = this.logo._logo.originalHeight();
+      var logoW = this.logo._logo.outerWidth(),
+          logoH = this.logo._logo.outerHeight();
 
       //check that all numbers are valid before using division
-      if ( 0 === _.size( _.filter( [ logoW, logoH ], function(num){ return _.isNumber( parseInt(num, 10) ) && 0 !== num; } ) ) )
+      if ( 2 !== _.size( _.filter( [ logoW, logoH ], function(num){ return _.isNumber( parseInt(num, 10) ) && 0 !== num; } ) ) )
         return;
 
       this.logo._ratio = logoW / logoH;


### PR DESCRIPTION
when sticky enabled and transitions allowed, set the logo dimensions
as the actual ones (not the original ones).
fixes #433
Also, we should avoid setting them not just when both width and height
are not valid numbers, but also when one them is not a valid number.
This simply means change the exit condition from

0 === _.size(w,h)

to

2 !== _.size(w,h)