### PR TITLE
Fix: allow logo transition only when both w,h are available.

### DIFF
--- a/inc/assets/js/parts/_main_sticky_header.part.js
+++ b/inc/assets/js/parts/_main_sticky_header.part.js
@@ -200,7 +200,7 @@ var czrapp = czrapp || {};
           logoH = this.logo._logo.originalHeight();
 
       //check that all numbers are valid before using division
-      if ( 0 === _.size( _.filter( [ logoW, logoH ], function(num){ return _.isNumber( parseInt(num, 10) ) && 0 !== num; } ) ) )
+      if ( 2 != _.size( _.filter( [ logoW, logoH ], function(num){ return _.isNumber( parseInt(num, 10) ) && 0 !== num; } ) ) )
         return;
 
       this.logo._ratio = logoW / logoH;


### PR DESCRIPTION
We should avoid setting them not just when both width and height
are not valid numbers, but also when one them is not a valid number.
This simply means change the exit condition from

0 === _.size(w,h)

to

2 != _.size(w,h)

I never met this issue, but still I think this should be the correct
condition.