### PR TITLE
Fix: better rendering of the slider loading gif

### DIFF
--- a/inc/assets/js/parts/_main_jquery_plugins.part.js
+++ b/inc/assets/js/parts/_main_jquery_plugins.part.js
@@ -120,14 +120,18 @@ var czrapp = czrapp || {};
     centerImages : function() {
       //SLIDER IMG + VARIOUS
       setTimeout( function() {
-        $( '.carousel .carousel-inner').centerImages( {
-          enableCentering : 1 == TCParams.centerSliderImg,
-          imgSel : '.item .carousel-image img',
-          oncustom : ['slid', 'simple_load'],
-          defaultCSSVal : { width : '100%' , height : 'auto' },
-          useImgAttr : true
-        });
-        $('.tc-slider-loader-wrapper').hide();
+        //centering per slider
+        $.each( $( '.carousel .carousel-inner') , function() {  
+          $( this ).centerImages( {
+            enableCentering : 1 == TCParams.centerSliderImg,
+            imgSel : '.item .carousel-image img',
+            oncustom : ['slid', 'simple_load'],
+            defaultCSSVal : { width : '100%' , height : 'auto' },
+            useImgAttr : true
+          });
+          //fade out the loading icon per slider
+          $( this ).prevAll('.tc-slider-loader-wrapper').fadeOut();
+        });  
       } , 50);
 
       //Featured Pages

--- a/inc/assets/less/tc_custom.less
+++ b/inc/assets/less/tc_custom.less
@@ -1725,20 +1725,16 @@ footer#footer .colophon .credits a[class*=icon-] {
 
 /* Gif Loader if center slide option is checked */
 .tc-slider-loader-wrapper {
-  height: 500px;
+  height: 100%;
   width: 100%;
-  line-height: 500px;
   position: absolute;
-  z-index: 1000;
-  text-align: center;
+  z-index: 99;/*less than the default sticky-header z-index */
   background: #FAFAFA;
 }
 .tc-img-gif-loader {
-  line-height: 15px;
-  vertical-align: middle;
   width: 100%;
   display: inline-block;
-  position: relative;
+  height: 100%;
 }
 /* CUSTOM SLIDER HEIGHT */
 .custom-slider-height .carousel-inner .item {

--- a/inc/parts/class-content-slider.php
+++ b/inc/parts/class-content-slider.php
@@ -742,12 +742,12 @@ class TC_slider {
   *
   */
   function tc_render_slider_loader_view( $slider_name_id ) {
-    if ( 'demo' != $slider_name_id && ( 1 != esc_attr( TC_utils::$inst->tc_opt( 'tc_display_slide_loader') ) || ! apply_filters( 'tc_display_slider_loader' , true ) ) )
+    if ( ! $this -> tc_is_slider_loader_active( $slider_name_id ) )
       return;
+
     ?>
       <div id="tc-slider-loader-wrapper-<?php echo self::$rendered_sliders ?>" class="tc-slider-loader-wrapper" style="display:none;">
         <div class="tc-img-gif-loader">
-          <img data-no-retina alt="loading" src="<?php echo apply_filters('tc_slider_loader_src' , sprintf( '%1$s/%2$s' , TC_BASE_URL , 'inc/assets/img/slider-loader.gif') ) ?>">
         </div>
       </div>
 
@@ -1112,6 +1112,21 @@ class TC_slider {
     return apply_filters( 'tc_slider_active_status', false , $queried_id );
   }
 
+  /**
+  * helper
+  * returns whether or not the slider loading icon must be displayed
+  * @return  boolean
+  *
+  */
+  private function tc_is_slider_loader_active( $slider_name_id ) {
+    //The slider loader must be printed when
+    //a) we have to render the demo slider  
+    //b) display slider loading option is enabled (can be filtered) 
+    return ( 'demo' == $slider_name_id 
+        || apply_filters( 'tc_display_slider_loader', 1 == esc_attr( TC_utils::$inst->tc_opt( 'tc_display_slide_loader') ), $slider_name_id )
+    );
+  }
+
 
   /**
   * hook : tc_slider_height, fired in tc_user_options_style
@@ -1147,6 +1162,17 @@ class TC_slider {
   * @since Customizr 3.2.6
   */
   function tc_write_slider_inline_css( $_css ) {
+    //custom css for the slider loader gif
+    if ( $this -> tc_is_slider_loader_active( $this -> tc_get_current_slider( $this -> tc_get_real_id() ) ) ) {
+      $_slider_loader_src = apply_filters( 'tc_slider_loader_src' , sprintf( '%1$s/%2$s' , TC_BASE_URL , 'inc/assets/img/slider-loader.gif') );
+      if ( $_slider_loader_src )
+        $_css = sprintf( "$_css\n%s",
+         ".tc-slider-loader-wrapper .tc-img-gif-loader {
+            background: url('$_slider_loader_src') no-repeat center center;
+         }"      
+        );
+    }
+
     // 1) Do we have a custom height ?
     // 2) check if the setting must be applied to all context
     $_custom_height     = apply_filters( 'tc_slider_height' , esc_attr( TC_utils::$inst->tc_opt( 'tc_slider_default_height') ) );


### PR DESCRIPTION
This includes:
1) js
A fadingOut when disposing the loading div. Also, since we can have
more than one slider per page, there's no reason to wait for all the
slides of all the sliders have been parsed by the centerImages plugin
so we dispose the loading div per slider.
2) php/css
The loading image is now rendered as background. This allow us to get
rid of some CSS code but keeping the possibility for a user to specifiy
a different loading icon using the same filter.
Alternatively we might move this small CSS code to the main CSS file
and if users want to use a different gif they have to override it.