### PR TITLE
Add: disqus comment system compatibility

### DIFF
--- a/inc/class-fire-plugins_compat.php
+++ b/inc/class-fire-plugins_compat.php
@@ -50,6 +50,7 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
       add_theme_support( 'optimize-press' );
       add_theme_support( 'sensei' );
       add_theme_support( 'visual-composer' );//or js-composer as they call it
+      add_theme_support( 'disqus' );
     }
 
 
@@ -116,6 +117,11 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
       /* Visual Composer */
       if ( current_theme_supports( 'visual-composer') && $this -> tc_is_plugin_active('js_composer/js_composer.php') )
         $this -> tc_set_vc_compat();
+
+      /* Disqus Comment System */
+      if ( current_theme_supports( 'disqus') && $this -> tc_is_plugin_active('disqus-comment-system/disqus.php') )
+        $this -> tc_set_disqus_compat();
+
     }//end of plugin compatibility function
 
 
@@ -1112,6 +1118,39 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
       }
     }//end woocommerce compat
 
+
+    /**
+    * Disqus Comment System compat hooks
+    *
+    * @package Customizr
+    * @since Customizr 3.4+
+    */
+    private function tc_set_disqus_compat() {
+      if ( ! function_exists( 'tc_disqus_comments_enabled' ) ) {
+        function tc_disqus_comments_enabled() {
+          return function_exists( 'dsq_is_installed' ) && function_exists( 'dsq_can_replace' )
+                 && dsq_is_installed() && dsq_can_replace();
+        }
+      }
+      //replace the default comment link anchor with a more descriptive disqus anchor
+      add_filter( 'tc_bubble_comment_anchor', 'tc_disqus_bubble_comment_anchor' );
+      function tc_disqus_bubble_comment_anchor( $anchor ) {
+        return tc_disqus_comments_enabled() ? '#tc-disqus-comments' : $anchor;
+      }
+      //wrap disqus comments template in a convenient div
+      add_action( 'tc_before_comments_template' , 'tc_disqus_comments_wrapper' );
+      add_action( 'tc_after_comments_template'  , 'tc_disqus_comments_wrapper' );
+      function tc_disqus_comments_wrapper() {
+        if ( ! tc_disqus_comments_enabled() )
+          return;
+
+        switch ( current_filter() ) {
+          case 'tc_before_comments_template' : echo '<div id="tc-disqus-comments">';
+                                               break;
+          case 'tc_after_comments_template'  : echo '</div>';
+        }    
+      }
+    }//end woocommerce compat
 
     /**
     * CUSTOMIZR WRAPPERS

--- a/inc/parts/class-content-comments.php
+++ b/inc/parts/class-content-comments.php
@@ -73,8 +73,9 @@ if ( ! class_exists( 'TC_comments' ) ) :
       function tc_comments() {
         if ( ! $this -> tc_are_comments_enabled() )
           return;
-
-        comments_template( '' , true );
+        do_action('tc_before_comments_template');
+          comments_template( '' , true );
+        do_action('tc_after_comments_template');
       }
 
 
@@ -338,9 +339,10 @@ if ( ! class_exists( 'TC_comments' ) ) :
 
       global $post;
       //checks if comments are opened AND if there are any comments to display
-      return sprintf('%1$s <span class="comments-link"><a href="%2$s#tc-comment-title" title="%3$s %4$s">%5$s</a></span>',
+      return sprintf('%1$s <span class="comments-link"><a href="%2$s%3$s" title="%4$s %5$s" data-disqus-identifier="javascript:this.page.identifier">%6$s</a></span>',
         $_title,
         is_singular() ? '' : get_permalink(),
+        apply_filters( 'tc_bubble_comment_anchor', '#tc-comment-title'),
         sprintf( '%1$s %2$s' , get_comments_number(), __( 'Comment(s) on' , 'customizr' ) ),
         is_null($_title) ? esc_attr( strip_tags( $post -> post_title ) ) : esc_attr( strip_tags( $_title ) ),
         0 != get_comments_number() ? apply_filters( 'tc_bubble_comment' , '' , esc_attr( TC_utils::$inst->tc_opt( 'tc_comment_bubble_shape' ) ) ) : ''


### PR DESCRIPTION
This consists in two steps:
1) change the hash (anchor) used in the comment link to a more
descriptive one.
A new filter has been added for this purpose:
tc_bubble_comment_anchor
2) wrap the disqus comments template in a convenient div which
has an id attribute (html) used as anchor (see bullet 1).
two new actions have been added for this purpose:
tc_before_comments_template
tc_after_comments_template

fixes #402