### PR TITLE
Fix: rtl colophon fixes

### DIFF
--- a/inc/assets/less/tc_custom.less
+++ b/inc/assets/less/tc_custom.less
@@ -3043,7 +3043,10 @@ footer#footer .colophon {
 footer#footer .colophon a, footer#footer .colophon p {
   color:@FooterBg;
 }
-
+footer#footer .colophon .credits span[class*=text],
+footer#footer .colophon .credits a{
+  display: inline-block;
+}
 
 
 footer .widget_recent_entries li:after {
@@ -3078,7 +3081,12 @@ footer ul, footer ol {
   width: 45px;
   height: 43px;
   line-height: 43px;
-  right: 30px;
+  & when (@is_rtl = true) {
+    left: 30px;
+  }
+  & when (@is_rtl = false) {
+    right: 30px;
+  }
   bottom: 25px;
   padding-top: 2px;
   border-top-left-radius: 10px;

--- a/inc/parts/class-footer-footer_main.php
+++ b/inc/parts/class-footer-footer_main.php
@@ -21,9 +21,6 @@ if ( ! class_exists( 'TC_footer_main' ) ) :
 
       // Sticky footer style
       add_filter( 'tc_user_options_style' , array( $this , 'tc_write_sticky_footer_inline_css' ) );
-      //Handles RTL block order
-      //takes 2 parameters : priority, location
-      add_filter( 'tc_rtl_colophon_priority' , array( $this , 'tc_set_rtl_colophon_priority'), 10, 2 );
     }
 
 
@@ -58,9 +55,9 @@ if ( ! class_exists( 'TC_footer_main' ) ) :
       add_action ( '__footer'         , array( $this , 'tc_colophon_display' ), 20 );
 
       //colophon actions => some priorities are rtl dependants
-      add_action ( '__colophon'       , array( $this , 'tc_colophon_left_block' ), apply_filters( 'tc_rtl_colophon_priority', 10, 'left' ) );
+      add_action ( '__colophon'       , array( $this , 'tc_colophon_left_block' ), 10 );
       add_action ( '__colophon'       , array( $this , 'tc_colophon_center_block' ), 20 );
-      add_action ( '__colophon'       , array( $this , 'tc_colophon_right_block' ), apply_filters( 'tc_rtl_colophon_priority', 30 , 'right') );
+      add_action ( '__colophon'       , array( $this , 'tc_colophon_right_block' ), 30 );
 
       //since v3.2.0, Show back to top from the Customizer option panel
       add_action ( '__after_footer'       , array( $this , 'tc_render_back_to_top') );
@@ -217,7 +214,7 @@ if ( ! class_exists( 'TC_footer_main' ) ) :
 	      	echo apply_filters(
 	      		'tc_colophon_left_block',
 	      		sprintf('<div class="%1$s">%2$s</div>',
-	      			apply_filters( 'tc_colophon_left_block_class', 'span3 social-block pull-left' ),
+	      			implode( ' ', apply_filters( 'tc_colophon_left_block_class', array( 'span3', 'social-block', is_rtl() ? 'pull-right' : 'pull-left' ) ) ),
 	      			( ! $_nothing_to_render ) ? sprintf('<span class="tc-footer-social-links-wrapper" %1$s>%2$s</span>',
 	      				( $_hide_socials ) ? 'style="display:none"' : '',
 	      				tc__f( '__get_socials' )
@@ -243,9 +240,9 @@ if ( ! class_exists( 'TC_footer_main' ) ) :
 	    		sprintf('<div class="%1$s">%2$s</div>',
 		    		apply_filters( 'tc_colophon_center_block_class', 'span6 credits' ),
 		    		sprintf( '<p>%1$s %2$s %3$s</p>',
-						    apply_filters( 'tc_copyright_link', sprintf( '&middot; &copy; %1$s <a href="%2$s" title="%3$s" rel="bookmark">%3$s</a>', esc_attr( date( 'Y' ) ), esc_url( home_url() ), esc_attr( get_bloginfo() ) ) ),
-                            apply_filters( 'tc_credit_link', sprintf( '&middot; Designed by %1$s', '<a href="'.TC_WEBSITE.'">Press Customizr</a>' ) ),
-                            apply_filters( 'tc_wp_powered', sprintf( '&middot; %1$s <a class="icon-wordpress" target="_blank" href="https://wordpress.org" title="%2$s"></a> &middot;',
+						    apply_filters( 'tc_copyright_link', sprintf( '&middot; <span class="tc-copyright-text">&copy; %1$s</span> <a href="%2$s" title="%3$s" rel="bookmark">%3$s</a>', esc_attr( date( 'Y' ) ), esc_url( home_url() ), esc_attr( get_bloginfo() ) ) ),
+                            apply_filters( 'tc_credit_link', sprintf( '&middot; <span class="tc-credits-text">Designed by</span> %1$s', '<a href="'.TC_WEBSITE.'">Press Customizr</a>' ) ),
+                            apply_filters( 'tc_wp_powered', sprintf( '&middot; <span class="tc-wp-powered-text">%1$s</span> <a class="icon-wordpress" target="_blank" href="https://wordpress.org" title="%2$s"></a> &middot;',
                               __('Powered by', 'customizr'),
                               __('Powered by Wordpress', 'customizr')
                             ))
@@ -268,9 +265,10 @@ if ( ! class_exists( 'TC_footer_main' ) ) :
 
     	echo apply_filters(
     		'tc_colophon_right_block',
-    		sprintf('<div class="%1$s"><p class="pull-right"><a class="back-to-top" href="#">%2$s</a></p></div>',
-    			apply_filters( 'tc_colophon_right_block_class', 'span3 backtop' ),
-    			__( 'Back to top' , 'customizr' )
+    		sprintf('<div class="%1$s"><p class="%3$s"><a class="back-to-top" href="#">%2$s</a></p></div>',
+    			implode( ' ', apply_filters( 'tc_colophon_right_block_class', array( 'span3', 'backtop' ) ) ),
+                __( 'Back to top' , 'customizr' ),
+                is_rtl() ? 'pull-left' : 'pull-right'
     		)
     	);
 		}


### PR DESCRIPTION
1) php : as in RTL we change the bootstrap column floating from left to
right, there's no need of the blocks reordering. Though we change
some blocks classes according to direction
(pull-left to pull-right, and vice versa)
2) css: in RTL btt button should be shown on the left (mirroring)
3) php/css: fix the messy RTL credits performed by:
- wrap credit texts in span tags (php)
- display span tags above and links as "inline-blocks"
fixes #440