### PR TITLE
Fix: do not display colophon's btt text when btt arrow button enabled

### DIFF
--- a/inc/parts/class-footer-footer_main.php
+++ b/inc/parts/class-footer-footer_main.php
@@ -262,8 +262,9 @@ if ( ! class_exists( 'TC_footer_main' ) ) :
 		* @package Customizr
 		* @since Customizr 3.0.10
 		*/
-		function tc_colophon_right_block() {
-      if ( ! apply_filters('tc_show_text_btt', true) )
+        function tc_colophon_right_block() {
+          //since 3.4.16 BTT button excludes BTT text
+      if ( ! apply_filters('tc_show_text_btt', 0 == esc_attr( TC_utils::$inst->tc_opt( 'tc_show_back_to_top' ) ) ) )
         return;
 
     	echo apply_filters(


### PR DESCRIPTION
fixes #394