### PR TITLE
Fix: alternate layout is available only if thumb position is right/left

### DIFF
--- a/inc/admin/js/parts/_control.js
+++ b/inc/admin/js/parts/_control.js
@@ -285,6 +285,22 @@
         }
       }
     },
+    'tc_post_list_thumb_shape' : {
+      controls: [
+        'tc_post_list_thumb_height'
+      ],
+      callback: function (to) {
+        return to.indexOf('rectangular') > -1;
+      }
+    },
+    'tc_post_list_thumb_position' : {
+      controls: [
+        'tc_post_list_thumb_alternate'
+      ],
+      callback: function (to) {
+        return _.contains( [ 'left', 'right'], to );
+      }
+    },
     'tc_post_list_show_thumb' : {
       controls: [
         'tc_post_list_use_attachment_as_thumb',
@@ -301,14 +317,7 @@
       //display dependant if master setting value == value
       cross: {
         tc_post_list_thumb_height : { master : 'tc_post_list_thumb_shape' , callback : function (to) { return to.indexOf('rectangular') > -1; } },
-      }
-    },
-    'tc_post_list_thumb_shape' : {
-      controls: [
-        'tc_post_list_thumb_height'
-      ],
-      callback: function (to) {
-        return to.indexOf('rectangular') > -1;
+        tc_post_list_thumb_alternate: { master: 'tc_post_list_thumb_position', callback: function (to) { return _.contains( [ 'left', 'right'], to ); } }
       }
     },
     'tc_breadcrumb' : {

--- a/inc/parts/class-content-post_list.php
+++ b/inc/parts/class-content-post_list.php
@@ -448,7 +448,9 @@ class TC_post_list {
   */
   function tc_set_post_list_layout( $_layout ) {
     $_position                  = esc_attr( TC_utils::$inst->tc_opt( 'tc_post_list_thumb_position' ) );
-    $_layout['alternate']        = ( 0 == esc_attr( TC_utils::$inst->tc_opt( 'tc_post_list_thumb_alternate' ) ) ) ? false : true;
+    //since 3.4.16 the alternate layout is not available when the position is top or bottom
+    $_layout['alternate']        = ( 0 == esc_attr( TC_utils::$inst->tc_opt( 'tc_post_list_thumb_alternate' ) ) 
+                                   || in_array( $_position, array( 'top', 'bottom') ) ) ? false : true;
     $_layout['show_thumb_first'] = ( 'left' == $_position || 'top' == $_position ) ? true : false;
     $_layout['content']          = ( 'left' == $_position || 'right' == $_position ) ? $_layout['content'] : 'span12';
     $_layout['thumb']            = ( 'top' == $_position || 'bottom' == $_position ) ? 'span12' : $_layout['thumb'];


### PR DESCRIPTION
Also fixes the alternate layout thumbnail's height control visibility,
see(fixes) #443

fixes #362