### PR TITLE
Fix: apply border bottom only to theme sidebars widget list item

### DIFF
--- a/inc/assets/less/tc_custom.less
+++ b/inc/assets/less/tc_custom.less
@@ -1478,13 +1478,13 @@ font-size: 13px;
   }
 }
 
-#main-wrapper .widget li {
+.tc-sidebar .widget li {
   line-height:25px;
   border-bottom: 1px solid #EEE;
   position: relative;
 }
 
-#main-wrapper .widget li:after {
+.tc-sidebar .widget li:after {
   content: "";
   border-bottom: 1px solid #FFF;
   position: absolute;
@@ -1493,12 +1493,12 @@ font-size: 13px;
   bottom: -2px;
 }
 
-#main-wrapper .widget li:hover, .widget li:focus {
+.tc-sidebar .widget li:hover, .widget li:focus {
   text-decoration: none;
   background-color: #EEE;
 }
 
-#main-wrapper .widget li a {
+.tc-sidebar .widget li a {
   text-shadow: 0 1px 0 #FFF;
 }
 /* NO WIDGETS ICONS */


### PR DESCRIPTION
to avoid styling widgets in the #main-content which are not in
sidebars (for example those printed by some plugin in the content)

fixes #459