### PR TITLE
Fix: customizer: don't remove wp background customization controls

### DIFF
--- a/inc/class-fire-utils_settings_map.php
+++ b/inc/class-fire-utils_settings_map.php
@@ -2183,9 +2183,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
     function tc_popul_remove_section_map( $_sections ) {
       //customizer option array
       $remove_section = array(
-        'background_image' ,
         'static_front_page' ,
-        'colors',
         'nav',
         'title_tagline',
         'tc_page_comments'


### PR DESCRIPTION
They will be shown only if users adds
add_theme_support('custom-background')
to the child-theme functions.php

fixes #479