### PR TITLE
Imp: some slider loader improvements

### DIFF
--- a/inc/assets/js/parts/_main_jquery_plugins.part.js
+++ b/inc/assets/js/parts/_main_jquery_plugins.part.js
@@ -129,8 +129,13 @@ var czrapp = czrapp || {};
             defaultCSSVal : { width : '100%' , height : 'auto' },
             useImgAttr : true
           });
-          //fade out the loading icon per slider
-          $( this ).prevAll('.tc-slider-loader-wrapper').fadeOut();
+          //fade out the loading icon per slider with a little delay
+          //mostly for retina devices (the retina image will be downloaded afterwards
+          //and this may cause the re-centering of the image)
+          var self = this;
+          setTimeout( function() {
+              $( self ).prevAll('.tc-slider-loader-wrapper').fadeOut();
+          }, 500 );
         });  
       } , 50);
 

--- a/inc/assets/less/tc_custom.less
+++ b/inc/assets/less/tc_custom.less
@@ -1736,6 +1736,79 @@ footer#footer .colophon .credits a[class*=icon-] {
   display: inline-block;
   height: 100%;
 }
+/* Pure CSS loader */
+@-webkit-keyframes tc-mr-loader {
+  0% {
+    -webkit-transform: scale(0.1);
+            transform: scale(0.1);
+    opacity: 1; }
+
+  70% {
+    -webkit-transform: scale(1);
+            transform: scale(1);
+    opacity: 0.7; }
+
+  100% {
+    opacity: 0.0; } 
+}
+
+@keyframes tc-mr-loader {
+  0% {
+    -webkit-transform: scale(0.1);
+            transform: scale(0.1);
+    opacity: 1; }
+
+  70% {
+    -webkit-transform: scale(1);
+            transform: scale(1);
+    opacity: 0.7; }
+
+  100% {
+    opacity: 0.0; } 
+}
+.tc-css-loader { 
+  display: none; 
+}
+.csstransforms3d .tc-css-loader {
+  width: 50px;
+  height: 50px;
+  position: absolute;
+  -webkit-transform: translate3d(-50%, -50%, 0);
+      -ms-transform: translate3d(-50%, -50%, 0);
+          transform: translate3d(-50%, -50%, 0); 
+  top: 50%;
+  left: 50%;
+  display: block;
+}
+.tc-mr-loader > div:nth-child(0) {
+  -webkit-animation-delay: -0.8s;
+          animation-delay: -0.8s; 
+}
+.tc-mr-loader > div:nth-child(1) {
+  -webkit-animation-delay: -0.6s;
+          animation-delay: -0.6s; 
+}
+.tc-mr-loader > div:nth-child(2) {
+  -webkit-animation-delay: -0.4s;
+          animation-delay: -0.4s; 
+}
+.tc-mr-loader > div:nth-child(3) {
+  -webkit-animation-delay: -0.2s;
+          animation-delay: -0.2s; 
+}
+.tc-mr-loader > div {
+  -webkit-animation-fill-mode: both;
+          animation-fill-mode: both;
+  position: absolute;
+  top: -4%;
+  left: -4%;
+  width: 100%;
+  height: 100%;
+  border-radius: 100%;
+  border: 2px solid #777;
+  -webkit-animation: tc-mr-loader 1.25s 0s infinite cubic-bezier(.21, .53, .56, .8);
+          animation: tc-mr-loader 1.25s 0s infinite cubic-bezier(.21, .53, .56, .8); 
+}
 /* CUSTOM SLIDER HEIGHT */
 .custom-slider-height .carousel-inner .item {
   /*min-height:inherit;*/


### PR DESCRIPTION
1) replace gif loader with a pure CSS loader
still use the gif as fall-back for old browsers (those which don't have
csstransforms3d). Several php filter have been added so we can easily
revert the pure CSS loader to the standard gif if users do not want it
( it can be a pro feature, we might also consider to let user load their
own gif loader ). Minor side effect: as the fall-back is for those browsers
with no-csstransforms3d (class added to the html by modernizr), the gif
with a small delay as it depends on the modernizr processing. Not a big
deal anyway, I think we shouldn't care too much about that.

2) add a little small delay before fading out the loader (500ms),
because of the re-sizing which might occurr after it has been disposed
when dealing with retina imgs (retina.js)