### PR TITLE
Fix: remove useless _blank target for some customizer links

### DIFF
--- a/inc/class-fire-utils_settings_map.php
+++ b/inc/class-fire-utils_settings_map.php
@@ -732,7 +732,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
                                 'notice'        => sprintf( '%1$s<br/><br/>%2$s',
                                   __( 'When the menu style is set to "Side Menu", the menu position is the side on which the menu will be revealed.' , 'customizr' ),
                                   sprintf( __("To change the global header layout, %s" , "customizr"),
-                                    sprintf( '<a href="%1$s" target="_blank" title="%3$s">%2$s &raquo;</a>',
+                                    sprintf( '<a href="%1$s" title="%3$s">%2$s &raquo;</a>',
                                       "javascript:wp.customize.section('header_layout_sec').focus();",
                                       __("jump to the Design and Layout section" , "customizr"),
                                       __("Change the header layout", "customizr")
@@ -2252,7 +2252,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
         );
       } else {
         $nav_section_desc .= "<br/>" . sprintf( __("You can create new menu and edit your menu's content %s." , "customizr"),
-          sprintf( '<strong><a href="%1$s" target="_blank" title="%3$s">%2$s &raquo;</a><strong>',
+          sprintf( '<strong><a href="%1$s" title="%3$s">%2$s &raquo;</a><strong>',
             "javascript:wp.customize.section('nav').container.find('.customize-section-back').trigger('click'); wp.customize.panel('nav_menus').focus();",
             __("in the menu panel" , "customizr"),
             __("create/edit menus", "customizr")


### PR DESCRIPTION
There's no reason to have the _blank target for customizer links which
are handled via js (pointing to a customizer itself element).
Also the _blank target seems to cause an issue with some browsers:
- with chrome those links worked fine
- with firefox a new empty tab is opened and nothing changes in the main
  one