### PR TITLE
Fix: fix jetpack's photon - theme smartload compatibility issue

### DIFF
--- a/inc/assets/js/parts/jqueryimgSmartLoad.js
+++ b/inc/assets/js/parts/jqueryimgSmartLoad.js
@@ -138,6 +138,22 @@
       //prevent calling this twice on an already smartloaded img  
       if ( $_img.hasClass('tc-smart-loaded') ) return;
       $_img.fadeIn(self.options.fadeIn_options).addClass('tc-smart-loaded').trigger('smartload');
+      //jetpack's photon commpability
+      //Honestly to me this makes no really sense but photon does it.
+      //Basically photon recalculates the image dimension and sets its 
+      //width/height attribute once the image is smartloaded. Given the fact that those attributes are "needed" by the browser to assign the images a certain space so that when loaded the page doesn't "grow" it's height .. what's the point doing it so late?
+      if ( typeof $_img.attr('data-tcjp-recalc-dims') !== undefined ) {
+        var _width  = $_img.originalWidth();
+            _height = $_img.originalHeight();
+ 
+        //From photon.js: Modify given image's markup so that devicepx-jetpack.js will act on the image and it won't be reprocessed by this script.
+        $_img.removeAttr( ('data-tcjp-recalc-dims scale') );
+       
+        if ( 2 != _.size( _.filter( [ _width, _height ], function(num){ return _.isNumber( parseInt(num, 10) ) && 0 !== num; } ) ) )
+          return;    
+        $_img.attr( 'width', _width );
+        $_img.attr( 'height', _height );
+      }
     });//<= create a load() fn
     //http://stackoverflow.com/questions/1948672/how-to-tell-if-an-image-is-loaded-or-cached-in-jquery
     if ( $_img[0].complete )

--- a/inc/class-fire-plugins_compat.php
+++ b/inc/class-fire-plugins_compat.php
@@ -56,16 +56,16 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
 
 
     /**
-    * This function handles the following plugins compatibility : Jetpack (for the carousel addon), Bbpress, Qtranslate, Woocommerce
+    * This function handles the following plugins compatibility : Jetpack (for the carousel addon and photon), Bbpress, Qtranslate, Woocommerce
     *
     * @package Customizr
     * @since Customizr 3.0.15
     */
     function tc_plugins_compatibility() {
       /* JETPACK */
-      //adds compatibilty with the jetpack image carousel
+      //adds compatibilty with the jetpack image carousel and photon
       if ( current_theme_supports( 'jetpack' ) && $this -> tc_is_plugin_active('jetpack/jetpack.php') )
-        add_filter( 'tc_gallery_bool', '__return_false' );
+        $this -> tc_set_jetpack_compat();
 
       /* BBPRESS */
       //if bbpress is installed and activated, we can check the existence of the contextual boolean function is_bbpress() to execute some code
@@ -123,6 +123,40 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
         $this -> tc_set_disqus_compat();
 
     }//end of plugin compatibility function
+
+
+
+    /**
+    * Jetpack compat hooks
+    *
+    * @package Customizr
+    * @since Customizr 3.4+
+    */
+    private function tc_set_jetpack_compat() {
+      //jetpack image carousel 
+      //this filter doesn't exist anymore it has been replaced by
+      //tc_is_gallery_enabled
+      //I think we can remove the following compatibility as everything seems to work (considering that it doesn't do anything atm)
+      //and we haven't received any complain
+      //Also we now have a whole gallery section of settings and we coul redirect users there to fine tune it
+      add_filter( 'tc_gallery_bool', '__return_false' ); 
+
+      //Photon jetpack's module conflicts with our smartload feature:
+      //Photon removes the width,height attribute in php, then in js it compute them (when they have the special attribute 'data-recalc-dims') 
+      //based on the img src. When smartload is enabled the images parsed by its js which are not already smartloaded are dummy
+      //and their width=height is 1. The image is correctly loaded but the space
+      //assigned to it will be 1x1px. Photon js, is compatible with Auttomatic plugin lazy load and it sets the width/height
+      //attribute only when the img is smartloaded. This is pretty useless to me, as it doesn't solve the main issue:
+      //document's height change when the img are smartloaded.
+      //Anyway to avoid the 1x1 issue we alter the img attribute (data-recalc-dims) which photon adds to the img tag(php) so
+      //the width/height will not be erronously recalculated
+      if ( class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'photon' ) )
+        add_filter( 'tc_img_smartloaded', 'tc_jp_smartload_img');
+      function tc_jp_smartload_img( $img ) {
+        return str_replace( 'data-recalc-dims', 'data-tcjp-recalc-dims', $img );    
+      }    
+    }//end jetpack compat
+
 
 
 

--- a/inc/class-fire-utils.php
+++ b/inc/class-fire-utils.php
@@ -137,13 +137,15 @@ if ( ! class_exists( 'TC_utils' ) ) :
             preg_match('/ data-smartload *= *"false" */', $matches[0]) )
           return $matches[0];    
         else
-          return str_replace( 'srcset=', 'data-srcset=',
+          return apply_filters( 'tc_img_smartloaded',
+            str_replace( 'srcset=', 'data-srcset=',
                 sprintf('<img %1$s src="%2$s" data-src="%3$s" %4$s>',
                     $matches[1],
                     $_placeholder,
                     $matches[2],
                     $matches[3]
                 )
+            )
           );
       }
 


### PR DESCRIPTION
This issue is due to the fact that jetpack's photon, when parsing imgs
server side removes their width/height attributes. It recalculates/sets
them client side (js) when the actual image (due to smartload) is a dummy one
1x1px.

fixes #493