### PR TITLE
Fix: fix post-metas hierarchical tax check when building button class

### DIFF
--- a/inc/parts/class-content-post_metas.php
+++ b/inc/parts/class-content-post_metas.php
@@ -356,11 +356,12 @@ if ( ! class_exists( 'TC_post_metas' ) ) :
         * @since Customizr 3.3.2
         */
         private function tc_meta_term_view( $term ) {
-          $_classes     =  array( 'btn' , 'btn-mini' );
-          if ( isset( $term -> category_parent ) ) //<= check if hierarchical (category) or not (tag)
+          $_classes         =  array( 'btn' , 'btn-mini' );
+          $_is_hierarchical  =  is_taxonomy_hierarchical( $term -> taxonomy );
+          if ( $_is_hierarchical ) //<= check if hierarchical (category) or not (tag)
             array_push( $_classes , 'btn-tag' );
 
-          $_classes      = implode( ' ', apply_filters( 'tc_meta_tax_class', $_classes , isset( $term -> category_parent ) ) );
+          $_classes      = implode( ' ', apply_filters( 'tc_meta_tax_class', $_classes , $_is_hierarchical, $term ) );
 
           // (Rocco's PR Comment) : following to this https://wordpress.org/support/topic/empty-articles-when-upgrading-to-customizr-version-332
           // I found that at least wp 3.6.1  get_term_link($term->term_id, $term->taxonomy) returns a WP_Error


### PR DESCRIPTION
It checked whether a term was a category or not accordingly to the
'category_parent' field, which isn't a Term object field.
That field, among others, was added in wp<4.2 to the category term
by `get_the_category()` in `get_post_class()` when filling the
article selectors.
In wp 4.2 and above `get_post_class()` treats categories as any other
taxonomy without calling `get_the_category()`.

Fixed using a more proper conditional tag extending the check also to
custom hierarchical taxonomies.

fixes #511