### PR TITLE
Imp:better rendering of the rating block in the customizer + small fixes

### DIFF
--- a/inc/admin/css/theme-customizer-control.css
+++ b/inc/admin/css/theme-customizer-control.css
@@ -20,6 +20,11 @@
 .accordion-sub-container.control-panel-content {
   left: 440px;
 }
+.in-sub-panel #tc-donate-customizer,
+.in-sub-panel .tc-cta-wrap {
+  left: -450px;
+  height: 0;
+}
 
 /* RTL*/
 .rtl.wp-customizer .wp-full-overlay.expanded {
@@ -43,6 +48,10 @@
 }
 .rtl .accordion-sub-container.control-panel-content {
   right: 440px;
+}
+.rtl .in-sub-panel #tc-donate-customizer,
+.rtl .in-sub-panel .tc-cta-wrap {
+  right: -450px;
 }
 
 
@@ -99,6 +108,34 @@
     right: -380px;
   }
 }
+/* Reponsive buttons + rating footer actions hack 
+* What we do is:
+* a) stretch heigh and width of the footer-actions
+* b) sett an higher bottom vallue for the wp-full-overlay-sidebar-content
+* according with the new footer-actions-height
+* ( the devices buttons are not visibile for window's width below 1025px
+*/
+@media screen and (min-width: 980px) {
+  .expanded #customize-footer-actions {
+    width: 380px;
+  }
+}
+@media screen and (min-width: 1025px) {
+  .expanded #customize-footer-actions {
+    height: 85px;
+    background: inherit;
+  }
+  #customize-controls .wp-full-overlay-sidebar-content {
+    bottom: 85px;
+  }
+}
+@media screen and (min-width: 1401px) {
+  .expanded #customize-footer-actions {
+    width: 440px;
+  }
+}
+/* end hack */
+
 @media screen and (max-width: 979px) {
   .wp-customizer .wp-full-overlay.expanded {
     margin-left: 300px;
@@ -153,7 +190,48 @@
     right: -300px;
   }
 }
+/* at max-width 640px the wp-full-overlay-sidebar becomes 100% */
+@media screen and (max-width: 640px) {
+  .wp-customizer .wp-full-overlay.expanded {
+    margin-left: 0;
+  }
 
+  .in-sub-panel #customize-info,
+  .in-sub-panel #customize-theme-controls > ul > .accordion-section {
+    left: -100%;
+    width: 100%;
+  }
+
+  .in-sub-panel .tc-cta-wrap,
+  .in-sub-panel #tc-donate-customizer,
+  #customize-theme-controls .control-section.current-panel > h3.accordion-section-title {
+    left: -100%;
+  }
+  .accordion-sub-container.control-panel-content {
+    left: 100%;
+  }
+
+  /* RTL */
+  .rtl.wp-customizer .wp-full-overlay.expanded {
+    margin-right: 0;
+  }
+  
+  .rtl .in-sub-panel #customize-info,
+  .rtl .in-sub-panel #customize-theme-controls > ul > .accordion-section {
+    right: -100%;
+    width: 100%;
+    left: auto;
+  }
+  .rtl .in-sub-panel #tc-donate-customizer,
+  .rtl .in-sub-panel .tc-cta-wrap,
+  .rtl #customize-theme-controls .control-section.current-panel > h3.accordion-section-title {
+    right: -100%;
+    left: auto;
+  }
+  .rtl .accordion-sub-container.control-panel-content {
+    right: 100%;
+  }
+}
 
 /* PANELS AND SECTIONS TITLES */
 .wp-customizer #customize-theme-controls .accordion-section-title {
@@ -1018,14 +1096,7 @@ body .select2-results {
   -webkit-box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.3);
   box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.3);
 }
-.in-sub-panel #tc-donate-customizer,
-.in-sub-panel .tc-cta-wrap {
-  left: -450px;
-}
-.rtl .in-sub-panel #tc-donate-customizer,
-.rtl .in-sub-panel .tc-cta-wrap {
-  right: -450px;
-}
+
 .tc-grid-control-section {
   width: 100%;
   float: left;
@@ -1118,12 +1189,19 @@ body .select2-results {
 .tc-rate-link {
   position: absolute;
   bottom: 0;
-  right: 0;
-  padding: 4px 12px;
+  left: 40px;
+  padding: 4px 12px 4px 0;
   font-size: 10px;
   line-height: 14px;
-  width: 90%;
   text-align: right;
+  right: 0;
+}
+
+.rtl .tc-rate-link {
+  text-align: left;
+  left: auto;
+  right: 40px;
+  padding: 4px 0 4px 12px;
 }
 .wp-full-overlay.collapsed .tc-rate-link {
   display: none;

--- a/inc/admin/css/theme-customizer-control.css
+++ b/inc/admin/css/theme-customizer-control.css
@@ -116,21 +116,21 @@
 * ( the devices buttons are not visibile for window's width below 1025px
 */
 @media screen and (min-width: 980px) {
-  .expanded #customize-footer-actions {
+  .wp-customizer .expanded #customize-footer-actions {
     width: 380px;
   }
 }
 @media screen and (min-width: 1025px) {
-  .expanded #customize-footer-actions {
+  .wp-customizer .expanded #customize-footer-actions {
     height: 85px;
     background: inherit;
   }
-  #customize-controls .wp-full-overlay-sidebar-content {
+  .wp-customizer #customize-controls .wp-full-overlay-sidebar-content {
     bottom: 85px;
   }
 }
 @media screen and (min-width: 1401px) {
-  .expanded #customize-footer-actions {
+  .wp-customizer .expanded #customize-footer-actions {
     width: 440px;
   }
 }

--- a/inc/admin/js/parts/_control.js
+++ b/inc/admin/js/parts/_control.js
@@ -33,31 +33,34 @@
       this.container.slideUp( args.duration, args.completeCallback );
     }
   };
+  
 
-  /* mokey patch for the content height set */
-  // backup the original function
-  var _original_section_initialize = api.Section.prototype.initialize;
-  api.Section.prototype.initialize = function( id, options ) {
-    //call the original constructor
-    _original_section_initialize.apply( this, [id, options] );
-    var section = this;
+  /* monkey patch for the content height set */
+  //wp.customize.Section is not available before wp 4.1
+  if ( 'function' == typeof api.Section ) {
+    // backup the original function
+    var _original_section_initialize = api.Section.prototype.initialize;
+    api.Section.prototype.initialize = function( id, options ) {
+      //call the original constructor
+      _original_section_initialize.apply( this, [id, options] );
+      var section = this;
     
-    this.expanded.callbacks.add( function( _expanded ) {
-      if ( ! _expanded )
-        return;
+      this.expanded.callbacks.add( function( _expanded ) {
+        if ( ! _expanded )
+          return;
 
- 	  var container = section.container.closest( '.wp-full-overlay-sidebar-content' ),
-          content = section.container.find( '.accordion-section-content' ); 
-      //content resizing to the container height
-      _resizeContentHeight = function() {
-        console.log('pippo');  
-        content.css( 'height', container.innerHeight() );
-	  };
-      _resizeContentHeight();
-      //this is set to off in the original expand callback if 'expanded' is false
-      $( window ).on( 'resize.customizer-section', _.debounce( _resizeContentHeight, 110 ) );
-    });
-  };
+ 	    var container = section.container.closest( '.wp-full-overlay-sidebar-content' ),
+            content = section.container.find( '.accordion-section-content' ); 
+        //content resizing to the container height
+        _resizeContentHeight = function() {
+          content.css( 'height', container.innerHeight() );
+	    };
+        _resizeContentHeight();
+        //this is set to off in the original expand callback if 'expanded' is false
+        $( window ).on( 'resize.customizer-section', _.debounce( _resizeContentHeight, 110 ) );
+      });
+    };
+  }
   /* end monkey patch */
 
 

--- a/inc/admin/js/parts/_control.js
+++ b/inc/admin/js/parts/_control.js
@@ -34,6 +34,33 @@
     }
   };
 
+  /* mokey patch for the content height set */
+  // backup the original function
+  var _original_section_initialize = api.Section.prototype.initialize;
+  api.Section.prototype.initialize = function( id, options ) {
+    //call the original constructor
+    _original_section_initialize.apply( this, [id, options] );
+    var section = this;
+    
+    this.expanded.callbacks.add( function( _expanded ) {
+      if ( ! _expanded )
+        return;
+
+ 	  var container = section.container.closest( '.wp-full-overlay-sidebar-content' ),
+          content = section.container.find( '.accordion-section-content' ); 
+      //content resizing to the container height
+      _resizeContentHeight = function() {
+        console.log('pippo');  
+        content.css( 'height', container.innerHeight() );
+	  };
+      _resizeContentHeight();
+      //this is set to off in the original expand callback if 'expanded' is false
+      $( window ).on( 'resize.customizer-section', _.debounce( _resizeContentHeight, 110 ) );
+    });
+  };
+  /* end monkey patch */
+
+
   /* Multiple Picker */
   /**
    * @constructor


### PR DESCRIPTION
- do not overflow the collapsing arrow
- for the upcoming wp 4.5 allow coexistence with the devices
  (responsiveness) buttons
  -- for this purpose an override of the api.Section has been needed in
  order to re-set the height of the section content dynamically
- fine tune of the customizer elements when in subpanel when the
customizer settings panel width becomes 100% (ww<641px )
- set the height of the donate block to 0 when in subpanels so it
  doesn't hurt the panel top offset (hence its opened section ) as the
  panel top offset isn't dynamically calculated when resizing the window