### PR TITLE
Fix: calendar widget style in footer with multiple widget instances

### DIFF
--- a/inc/assets/less/tc_custom.less
+++ b/inc/assets/less/tc_custom.less
@@ -2831,7 +2831,7 @@ img.aligncenter {
 }
 /* OTHER CUSTOMIZED WP CSS */
 
-#calendar_wrap table {
+.calendar_wrap table {
   width: 100%;
   border-color: #e1e1e1;
   padding: 0;
@@ -2843,10 +2843,10 @@ img.aligncenter {
   border-spacing: 0;
 }
 
-#footer #calendar_wrap table {
+#footer .calendar_wrap table {
   color:#5A5A5A
 }
-#footer #calendar_wrap table caption{
+#footer .calendar_wrap table caption{
 color: #EEE;
 }
 


### PR DESCRIPTION
What happens is that if you have more than one calendar widget in the
same page to all the inner div of those after the first widget will not
be assigned an id (which anyways would have been unique). Hence if you
have a calendar in the sidebar and another in the footer, the footer one
will not be styled correctly (invisible numbers as their color is pretty
the same of the footer widget area container background).
This PR makes the rule referring to the css class instead of the element id