### PR TITLE
Fix: fix highlighted footer calendar day font color/size

### DIFF
--- a/inc/assets/less/tc_custom.less
+++ b/inc/assets/less/tc_custom.less
@@ -2846,8 +2846,11 @@ img.aligncenter {
 #footer .calendar_wrap table {
   color:#5A5A5A
 }
+footer#footer .calendar_wrap table a {
+  font-size: inherit
+}
 #footer .calendar_wrap table caption{
-color: #EEE;
+  color: #EEE;
 }
 
 

--- a/inc/assets/less/tc_skin_rules.less
+++ b/inc/assets/less/tc_skin_rules.less
@@ -391,7 +391,7 @@ h3.assistive-text {
 }
 
 /* OTHER CUSTOMIZED WP CSS */
-#footer #calendar_wrap table a{
+#footer .calendar_wrap table a{
   color:@lnkColWidgetlinkColor
 }
 


### PR DESCRIPTION
The font-size and color of the highlighted day (a link) should follow the global link rules, not the ones for the "footer" links