### PR TITLE
Fix: thumb-position-bottom placement in alternate layouts

### DIFF
--- a/inc/assets/less/tc_custom_responsive.less
+++ b/inc/assets/less/tc_custom_responsive.less
@@ -65,6 +65,7 @@
 
 @media (min-width: 980px) {
   /* ROUND DIV FOR 3 columns Top or bottom thumb position SINCE V3.2.0*/
+  .span6 .thumb-position-bottom .round-div,
   .span6 .thumb-position-top .round-div {
     width: 125px;
     height: 125px;
@@ -592,12 +593,14 @@
     text-align: center;
   }
   /* SINCE V3.2.0 */
+  .span6 .thumb-position-bottom .round-div,
   .span6 .thumb-position-top .round-div {
     width: 125px;
     height: 125px;
     top: -59px;
     left: -63px;
   }
+  .span6 .thumb-position-bottom .thumb-wrapper,
   .span6 .thumb-position-top .thumb-wrapper {
     max-width: none;
   }


### PR DESCRIPTION
css rule round div for 3 columns when thumb-position bottom should follow the same rule
applied when thumb-position top