### PR TITLE
Theme prefixes

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -4,7 +4,7 @@
  *
  * The area of the page that contains both current comments
  * and the comment form. The actual display of comments is
- * handled by a callback to tc_comment_callback()
+ * handled by a callback to czr_comment_callback()
  *
  * @package Customizr
  * @since Customizr 1.0

--- a/comments.php
+++ b/comments.php
@@ -4,7 +4,7 @@
  *
  * The area of the page that contains both current comments
  * and the comment form. The actual display of comments is
- * handled by a callback to czr_comment_callback()
+ * handled by a callback to czr_fn_comment_callback()
  *
  * @package Customizr
  * @since Customizr 1.0

--- a/custom-page.php
+++ b/custom-page.php
@@ -13,7 +13,7 @@ Template Name: Custom Page Example
 
             <?php do_action( '__before_article_container' ); ##hook of left sidebar?>
 
-                <div id="content" class="<?php echo implode(' ', apply_filters( 'tc_article_container_class' , array( TC_utils::tc_get_layout(  TC_utils::tc_id() , 'class' ) , 'article-container' ) ) ) ?>">
+                <div id="content" class="<?php echo implode(' ', apply_filters( 'tc_article_container_class' , array( CZR_utils::tc_get_layout(  CZR_utils::tc_id() , 'class' ) , 'article-container' ) ) ) ?>">
 
                     <?php do_action( '__before_loop' );##hooks the header of the list of post : archive, search... ?>
 

--- a/custom-page.php
+++ b/custom-page.php
@@ -13,7 +13,7 @@ Template Name: Custom Page Example
 
             <?php do_action( '__before_article_container' ); ##hook of left sidebar?>
 
-                <div id="content" class="<?php echo implode(' ', apply_filters( 'tc_article_container_class' , array( CZR_utils::czr_get_layout(  CZR_utils::czr_id() , 'class' ) , 'article-container' ) ) ) ?>">
+                <div id="content" class="<?php echo implode(' ', apply_filters( 'tc_article_container_class' , array( CZR_utils::czr_fn_get_layout(  CZR_utils::czr_fn_id() , 'class' ) , 'article-container' ) ) ) ?>">
 
                     <?php do_action( '__before_loop' );##hooks the header of the list of post : archive, search... ?>
 
@@ -24,7 +24,7 @@ Template Name: Custom Page Example
                                 <?php the_post(); ?>
 
                                 <?php do_action( '__before_article' ) ?>
-                                    <article <?php czr__f( '__article_selectors' ) ?>>
+                                    <article <?php czr_fn__f( '__article_selectors' ) ?>>
                                         <?php do_action( '__loop' ); ?>
                                     </article>
                                 <?php do_action( '__after_article' ) ?>

--- a/custom-page.php
+++ b/custom-page.php
@@ -13,7 +13,7 @@ Template Name: Custom Page Example
 
             <?php do_action( '__before_article_container' ); ##hook of left sidebar?>
 
-                <div id="content" class="<?php echo implode(' ', apply_filters( 'tc_article_container_class' , array( CZR_utils::tc_get_layout(  CZR_utils::tc_id() , 'class' ) , 'article-container' ) ) ) ?>">
+                <div id="content" class="<?php echo implode(' ', apply_filters( 'tc_article_container_class' , array( CZR_utils::czr_get_layout(  CZR_utils::czr_id() , 'class' ) , 'article-container' ) ) ) ?>">
 
                     <?php do_action( '__before_loop' );##hooks the header of the list of post : archive, search... ?>
 
@@ -24,7 +24,7 @@ Template Name: Custom Page Example
                                 <?php the_post(); ?>
 
                                 <?php do_action( '__before_article' ) ?>
-                                    <article <?php tc__f( '__article_selectors' ) ?>>
+                                    <article <?php czr__f( '__article_selectors' ) ?>>
                                         <?php do_action( '__loop' ); ?>
                                     </article>
                                 <?php do_action( '__after_article' ) ?>

--- a/footer.php
+++ b/footer.php
@@ -8,7 +8,7 @@
  */
   	do_action( '__before_footer' ); ?>
   		<!-- FOOTER -->
-  		<footer id="footer" class="<?php echo czr__f('tc_footer_classes', '') ?>">
+  		<footer id="footer" class="<?php echo czr_fn__f('tc_footer_classes', '') ?>">
   		 	<?php do_action( '__footer' ); // hook of footer widget and colophon?>
   		</footer>
     </div><!-- //#tc-page-wrapper -->

--- a/footer.php
+++ b/footer.php
@@ -8,7 +8,7 @@
  */
   	do_action( '__before_footer' ); ?>
   		<!-- FOOTER -->
-  		<footer id="footer" class="<?php echo tc__f('tc_footer_classes', '') ?>">
+  		<footer id="footer" class="<?php echo czr__f('tc_footer_classes', '') ?>">
   		 	<?php do_action( '__footer' ); // hook of footer widget and colophon?>
   		</footer>
     </div><!-- //#tc-page-wrapper -->

--- a/functions.php
+++ b/functions.php
@@ -31,7 +31,7 @@
 * => Default filtered options for the customizer
 * => Customizr theme's hooks API : front end components are rendered with action and filter hooks
 *
-* The method CZR__::czr__() loads the php files and instantiates all theme's classes.
+* The method CZR__::czr_fn__() loads the php files and instantiates all theme's classes.
 * All classes files (except the class__.php file which loads the other) are named with the following convention : class-[group]-[class_name].php
 *
 * The theme is entirely built on an extensible filter and action hooks API, which makes customizations easy and safe, without ever needing to modify the core structure.

--- a/functions.php
+++ b/functions.php
@@ -23,7 +23,7 @@
 
 /**
 * This is where Customizr starts. This file defines and loads the theme's components :
-* => Constants : CUSTOMIZR_VER, TC_BASE, TC_BASE_CHILD, TC_BASE_URL, TC_BASE_URL_CHILD, THEMENAME, TC_WEBSITE
+* => Constants : CUSTOMIZR_VER, TC_BASE, TC_BASE_CHILD, TC_BASE_URL, TC_BASE_URL_CHILD, THEMENAME, CZR_WEBSITE
 * => Default filtered values : images sizes, skins, featured pages, social networks, widgets, post list layout
 * => Text Domain
 * => Theme supports : editor style, automatic-feed-links, post formats, navigation menu, post-thumbnails, retina support
@@ -31,7 +31,7 @@
 * => Default filtered options for the customizer
 * => Customizr theme's hooks API : front end components are rendered with action and filter hooks
 *
-* The method TC__::tc__() loads the php files and instantiates all theme's classes.
+* The method CZR__::tc__() loads the php files and instantiates all theme's classes.
 * All classes files (except the class__.php file which loads the other) are named with the following convention : class-[group]-[class_name].php
 *
 * The theme is entirely built on an extensible filter and action hooks API, which makes customizations easy and safe, without ever needing to modify the core structure.

--- a/functions.php
+++ b/functions.php
@@ -31,7 +31,7 @@
 * => Default filtered options for the customizer
 * => Customizr theme's hooks API : front end components are rendered with action and filter hooks
 *
-* The method CZR__::tc__() loads the php files and instantiates all theme's classes.
+* The method CZR__::czr__() loads the php files and instantiates all theme's classes.
 * All classes files (except the class__.php file which loads the other) are named with the following convention : class-[group]-[class_name].php
 *
 * The theme is entirely built on an extensible filter and action hooks API, which makes customizations easy and safe, without ever needing to modify the core structure.

--- a/header.php
+++ b/header.php
@@ -19,7 +19,7 @@
 <html <?php language_attributes(); ?>>
 <!--<![endif]-->
 	<?php
-		//the '__before_body' hook is used by CZR_header_main::$instance->czr_head_display()
+		//the '__before_body' hook is used by CZR_header_main::$instance->czr_fn_head_display()
 		do_action( '__before_body' );
 	?>
 
@@ -34,11 +34,11 @@
   	   	<header class="<?php echo implode( " ", apply_filters('tc_header_classes', array('tc-header' ,'clearfix', 'row-fluid') ) ) ?>" role="banner">
   			<?php
   				// The '__header' hook is used with the following callback functions (ordered by priorities) :
-  				//CZR_header_main::$instance->tc_logo_title_display(), CZR_header_main::$instance->czr_tagline_display(), CZR_header_main::$instance->czr_navbar_display()
+  				//CZR_header_main::$instance->tc_logo_title_display(), CZR_header_main::$instance->czr_fn_tagline_display(), CZR_header_main::$instance->czr_fn_navbar_display()
   				do_action( '__header' );
   			?>
   		</header>
   		<?php
-  		 	//This hook is used for the slider : CZR_slider::$instance->czr_slider_display()
+  		 	//This hook is used for the slider : CZR_slider::$instance->czr_fn_slider_display()
   			do_action ( '__after_header' )
   		?>

--- a/header.php
+++ b/header.php
@@ -19,7 +19,7 @@
 <html <?php language_attributes(); ?>>
 <!--<![endif]-->
 	<?php
-		//the '__before_body' hook is used by TC_header_main::$instance->tc_head_display()
+		//the '__before_body' hook is used by CZR_header_main::$instance->tc_head_display()
 		do_action( '__before_body' );
 	?>
 
@@ -34,11 +34,11 @@
   	   	<header class="<?php echo implode( " ", apply_filters('tc_header_classes', array('tc-header' ,'clearfix', 'row-fluid') ) ) ?>" role="banner">
   			<?php
   				// The '__header' hook is used with the following callback functions (ordered by priorities) :
-  				//TC_header_main::$instance->tc_logo_title_display(), TC_header_main::$instance->tc_tagline_display(), TC_header_main::$instance->tc_navbar_display()
+  				//CZR_header_main::$instance->tc_logo_title_display(), CZR_header_main::$instance->tc_tagline_display(), CZR_header_main::$instance->tc_navbar_display()
   				do_action( '__header' );
   			?>
   		</header>
   		<?php
-  		 	//This hook is used for the slider : TC_slider::$instance->tc_slider_display()
+  		 	//This hook is used for the slider : CZR_slider::$instance->tc_slider_display()
   			do_action ( '__after_header' )
   		?>

--- a/header.php
+++ b/header.php
@@ -19,7 +19,7 @@
 <html <?php language_attributes(); ?>>
 <!--<![endif]-->
 	<?php
-		//the '__before_body' hook is used by CZR_header_main::$instance->tc_head_display()
+		//the '__before_body' hook is used by CZR_header_main::$instance->czr_head_display()
 		do_action( '__before_body' );
 	?>
 
@@ -34,11 +34,11 @@
   	   	<header class="<?php echo implode( " ", apply_filters('tc_header_classes', array('tc-header' ,'clearfix', 'row-fluid') ) ) ?>" role="banner">
   			<?php
   				// The '__header' hook is used with the following callback functions (ordered by priorities) :
-  				//CZR_header_main::$instance->tc_logo_title_display(), CZR_header_main::$instance->tc_tagline_display(), CZR_header_main::$instance->tc_navbar_display()
+  				//CZR_header_main::$instance->tc_logo_title_display(), CZR_header_main::$instance->czr_tagline_display(), CZR_header_main::$instance->czr_navbar_display()
   				do_action( '__header' );
   			?>
   		</header>
   		<?php
-  		 	//This hook is used for the slider : CZR_slider::$instance->tc_slider_display()
+  		 	//This hook is used for the slider : CZR_slider::$instance->czr_slider_display()
   			do_action ( '__after_header' )
   		?>

--- a/inc/admin/class-admin-customize.php
+++ b/inc/admin/class-admin-customize.php
@@ -179,10 +179,10 @@ if ( ! class_exists( 'CZR_customize' ) ) :
 		* @since Customizr 3.0
 		*/
 		function czr_customize_register( $wp_customize) {
-			return $this -> tc_customize_factory (
+			return $this -> czr_customize_factory (
         $wp_customize,
-        $this -> tc_customize_arguments(),
-        CZR_utils_settings_map::$instance -> tc_get_customizer_map()
+        $this -> czr_customize_arguments(),
+        CZR_utils_settings_map::$instance -> czr_get_customizer_map()
       );
 		}
 
@@ -314,7 +314,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
           //=> grid customizer addon starts by gc_
           //When do we add a prefix ?
           $add_prefix = false;
-          if ( CZR_utils::$inst -> tc_is_customizr_option( $key ) )
+          if ( CZR_utils::$inst -> czr_is_customizr_option( $key ) )
             $add_prefix = true;
           $_opt_name = $add_prefix ? "{$tc_option_group}[{$key}]" : $key;
 
@@ -391,7 +391,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
                 //can be hacked to override the preview params when a custom skin is used
                 //array( 'skinName' => 'custom-skin-#40542.css', 'fullPath' => 'http://....' )
                 'customSkin'      => apply_filters( 'tc_custom_skin_preview_params' , array( 'skinName' => '', 'fullPath' => '' ) ),
-                'fontPairs'       => CZR_utils::$inst -> tc_get_font( 'list' ),
+                'fontPairs'       => CZR_utils::$inst -> czr_get_font( 'list' ),
                 'fontSelectors'   => CZR_init::$instance -> font_selectors,
                 //patch for old wp versions which don't trigger preview-ready signal => since WP 4.1
                 'preview_ready_event_exists'   => version_compare( $wp_version, '4.1' , '>=' )
@@ -464,8 +464,8 @@ if ( ! class_exists( 'CZR_customize' ) ) :
 	        	'AjaxUrl'       => admin_url( 'admin-ajax.php' ),
 	        	'TCNonce' 			=> wp_create_nonce( 'tc-customizer-nonce' ),
             'themeName'     => CZR___::$theme_name,
-            'HideDonate'    => $this -> tc_get_hide_donate_status(),
-            'ShowCTA'       => ( true == CZR_utils::$inst->tc_opt('tc_hide_donate') && ! get_transient ('tc_cta') ) ? true : false,
+            'HideDonate'    => $this -> czr_get_hide_donate_status(),
+            'ShowCTA'       => ( true == CZR_utils::$inst->czr_opt('tc_hide_donate') && ! get_transient ('tc_cta') ) ? true : false,
             'defaultSliderHeight' => 500,//500px, @todo make sure we can hard code it here
             'translatedStrings'    => array(
               'postSliderNote' => __( "This option generates a home page slider based on your last posts, starting from the most recent or the featured (sticky) post(s) if any.", "customizr" ),
@@ -492,7 +492,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
       $_user_started_customize = false !== $_options || ! empty( $_options );
 
       //shall we hide donate ?
-      return ! $_user_started_customize || ! $_is_customizr_active || CZR_utils::$inst->tc_opt('tc_hide_donate');
+      return ! $_user_started_customize || ! $_is_customizr_active || CZR_utils::$inst->czr_opt('tc_hide_donate');
     }
 
 

--- a/inc/admin/class-admin-customize.php
+++ b/inc/admin/class-admin-customize.php
@@ -58,7 +58,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
     * hook : tc_customize_register:30
     * @return void()
     */
-    function tc_alter_wp_customizer_settings( $wp_customize ) {
+    function czr_alter_wp_customizer_settings( $wp_customize ) {
       //CHANGE BLOGNAME AND BLOGDESCRIPTION TRANSPORT
       $wp_customize -> get_setting( 'blogname' )->transport = 'postMessage';
       $wp_customize -> get_setting( 'blogdescription' )->transport = 'postMessage';
@@ -145,7 +145,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
     * hook : '__after_setting_control' (declared in class-tc-controls-settings.php)
     * Display a title for the favicon control, after the logo
     */
-    function tc_add_favicon_title($set_id) {
+    function czr_add_favicon_title($set_id) {
       if ( false !== strpos( $set_id, 'tc_sticky_logo_upload' ) )
         printf( '<h3 class="tc-customizr-title">%s</h3>', __( 'SITE ICON' , 'customizr') );
     }
@@ -155,7 +155,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
 		* @package Customizr
 		* @since Customizr 1.0
 		*/
-		function tc_augment_customizer( $manager ) {
+		function czr_augment_customizer( $manager ) {
       //loads custom settings and controls classes for the Customizr theme
       //- CZR_Customize_Setting extends WP_Customize_Setting => to override the value() method
       //- CZR_controls extends WP_Customize_Control => overrides the render() method
@@ -178,7 +178,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
 		* @package Customizr
 		* @since Customizr 3.0
 		*/
-		function tc_customize_register( $wp_customize) {
+		function czr_customize_register( $wp_customize) {
 			return $this -> tc_customize_factory (
         $wp_customize,
         $this -> tc_customize_arguments(),
@@ -194,7 +194,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
 		 * @package Customizr
 		 * @since Customizr 3.0
 		 */
-		function tc_customize_arguments() {
+		function czr_customize_arguments() {
 			$args = array(
 					'panels' => array(
 								'title' ,
@@ -261,7 +261,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
 		 * @package Customizr
 		 * @since Customizr 3.0
 		 */
-		function tc_customize_factory ( $wp_customize , $args, $setup ) {
+		function czr_customize_factory ( $wp_customize , $args, $setup ) {
 			global $wp_version;
 			//add panels if current WP version >= 4.0
 			if ( isset( $setup['add_panel']) && version_compare( $wp_version, '4.0', '>=' ) ) {
@@ -358,7 +358,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
     * hook __before_setting_control (declared in class-tc-controls-settings.php)
     * @echo clickable text
     */
-    function tc_render_grid_control_link( $set_id ) {
+    function czr_render_grid_control_link( $set_id ) {
       if ( false !== strpos( $set_id, 'tc_post_list_show_thumb' ) )
         printf('<span class="tc-grid-toggle-controls" title="%1$s">%1$s</span>' , __('More grid design options' , 'customizr'));
     }
@@ -370,7 +370,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
 		 * @since Customizr 1.0
 		 */
 
-		function tc_customize_preview_js() {
+		function czr_customize_preview_js() {
 			global $wp_version;
 
 			wp_enqueue_script(
@@ -409,7 +409,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
 		 * @package Customizr
 		 * @since Customizr 3.1.0
 		 */
-		function tc_customize_controls_js_css() {
+		function czr_customize_controls_js_css() {
 
 			wp_enqueue_style(
 				'tc-customizer-controls-style',
@@ -484,7 +484,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
     * @package Customizr
     * @since Customizr 3.1.14
     */
-    function tc_get_hide_donate_status() {
+    function czr_get_hide_donate_status() {
       //is customizr the current active theme?
       //=> check the existence of is_theme_active for backward compatibility (may be useless because introduced in 3.4... )
       $_is_customizr_active = method_exists( $GLOBALS['wp_customize'], 'is_theme_active' ) && $GLOBALS['wp_customize'] -> is_theme_active();
@@ -503,7 +503,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
 		* @package Customizr
 		* @since Customizr 3.1.14
 		*/
-    function tc_hide_donate() {
+    function czr_hide_donate() {
     	check_ajax_referer( 'tc-customizer-nonce', 'TCnonce' );
     	$options = get_option('tc_theme_options');
     	$options['tc_hide_donate'] = true;
@@ -521,7 +521,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
     * callback of 'customize_controls_print_footer_scripts'
     *@since v3.2.9
     */
-    function tc_print_js_templates() {
+    function czr_print_js_templates() {
       ?>
       <script type="text/template" id="donate_template">
         <div id="tc-donate-customizer">
@@ -644,7 +644,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
     * @package Customizr
     * @since Customizr 1.1
     */
-    function tc_add_fallback_page() {
+    function czr_add_fallback_page() {
         $theme_page = add_theme_page(
             __( 'Upgrade WP' , 'customizr' ),   // Name of page
             __( 'Upgrade WP' , 'customizr' ),   // Label in menu
@@ -662,7 +662,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
     * @package Customizr
     * @since Customizr 1.1
     */
-    function tc_fallback_admin_page() {
+    function czr_fallback_admin_page() {
       ?>
         <div class="wrap upgrade_wordpress">
           <div id="icon-options-general" class="icon32"><br></div>

--- a/inc/admin/class-admin-customize.php
+++ b/inc/admin/class-admin-customize.php
@@ -21,32 +21,32 @@ if ( ! class_exists( 'CZR_customize' ) ) :
       //check if WP version >= 3.4 to include customizer functions
       //Shall we really keep this ?
       if ( ! version_compare( $wp_version, '3.4' , '>=' ) ) {
-        add_action( 'admin_menu'                    , array( $this , 'czr_add_fallback_page' ));
+        add_action( 'admin_menu'                    , array( $this , 'czr_fn_add_fallback_page' ));
         return;
       }
 
       self::$instance =& $this;
   		//add control class
-  		add_action ( 'customize_register'				                , array( $this , 'czr_augment_customizer' ),10,1);
+  		add_action ( 'customize_register'				                , array( $this , 'czr_fn_augment_customizer' ),10,1);
 
   		//add grid/post list buttons in the control views
-  		add_action( '__before_setting_control'                  , array( $this , 'czr_render_grid_control_link') );
+  		add_action( '__before_setting_control'                  , array( $this , 'czr_fn_render_grid_control_link') );
 
   		//control scripts and style
-  		add_action ( 'customize_controls_enqueue_scripts'	      , array( $this , 'czr_customize_controls_js_css' ));
+  		add_action ( 'customize_controls_enqueue_scripts'	      , array( $this , 'czr_fn_customize_controls_js_css' ));
   		//add the customizer built with the builder below
-  		add_action ( 'customize_register'				                , array( $this , 'czr_customize_register' ), 20, 1 );
+  		add_action ( 'customize_register'				                , array( $this , 'czr_fn_customize_register' ), 20, 1 );
 
       //modify some WP built-in settings / controls / sections
-      add_action ( 'customize_register'                       , array( $this , 'czr_alter_wp_customizer_settings' ), 30, 1 );
+      add_action ( 'customize_register'                       , array( $this , 'czr_fn_alter_wp_customizer_settings' ), 30, 1 );
 
       //preview scripts
       //set with priority 20 to be fired after tc_customize_store_db_opt in CZR_utils
-  		add_action ( 'customize_preview_init'			              , array( $this , 'czr_customize_preview_js' ), 20 );
+  		add_action ( 'customize_preview_init'			              , array( $this , 'czr_fn_customize_preview_js' ), 20 );
   		//Hide donate button
-  		add_action ( 'wp_ajax_hide_donate'				              , array( $this , 'czr_hide_donate' ) );
+  		add_action ( 'wp_ajax_hide_donate'				              , array( $this , 'czr_fn_hide_donate' ) );
 
-      add_action ( 'customize_controls_print_footer_scripts'  , array( $this, 'czr_print_js_templates' ) );
+      add_action ( 'customize_controls_print_footer_scripts'  , array( $this, 'czr_fn_print_js_templates' ) );
     }
 
 
@@ -58,7 +58,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
     * hook : tc_customize_register:30
     * @return void()
     */
-    function czr_alter_wp_customizer_settings( $wp_customize ) {
+    function czr_fn_alter_wp_customizer_settings( $wp_customize ) {
       //CHANGE BLOGNAME AND BLOGDESCRIPTION TRANSPORT
       $wp_customize -> get_setting( 'blogname' )->transport = 'postMessage';
       $wp_customize -> get_setting( 'blogdescription' )->transport = 'postMessage';
@@ -75,7 +75,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
         $wp_customize -> get_control( 'site_icon' )->section = 'logo_sec';
 
         //add a favicon title after the logo upload
-        add_action( '__after_setting_control' , array( $this , 'czr_add_favicon_title') );
+        add_action( '__after_setting_control' , array( $this , 'czr_fn_add_favicon_title') );
       }//end ALTER SITE ICON
 
 
@@ -145,7 +145,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
     * hook : '__after_setting_control' (declared in class-tc-controls-settings.php)
     * Display a title for the favicon control, after the logo
     */
-    function czr_add_favicon_title($set_id) {
+    function czr_fn_add_favicon_title($set_id) {
       if ( false !== strpos( $set_id, 'tc_sticky_logo_upload' ) )
         printf( '<h3 class="tc-customizr-title">%s</h3>', __( 'SITE ICON' , 'customizr') );
     }
@@ -155,7 +155,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
 		* @package Customizr
 		* @since Customizr 1.0
 		*/
-		function czr_augment_customizer( $manager ) {
+		function czr_fn_augment_customizer( $manager ) {
       //loads custom settings and controls classes for the Customizr theme
       //- CZR_Customize_Setting extends WP_Customize_Setting => to override the value() method
       //- CZR_controls extends WP_Customize_Control => overrides the render() method
@@ -178,11 +178,11 @@ if ( ! class_exists( 'CZR_customize' ) ) :
 		* @package Customizr
 		* @since Customizr 3.0
 		*/
-		function czr_customize_register( $wp_customize) {
-			return $this -> czr_customize_factory (
+		function czr_fn_customize_register( $wp_customize) {
+			return $this -> czr_fn_customize_factory (
         $wp_customize,
-        $this -> czr_customize_arguments(),
-        CZR_utils_settings_map::$instance -> czr_get_customizer_map()
+        $this -> czr_fn_customize_arguments(),
+        CZR_utils_settings_map::$instance -> czr_fn_get_customizer_map()
       );
 		}
 
@@ -194,7 +194,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
 		 * @package Customizr
 		 * @since Customizr 3.0
 		 */
-		function czr_customize_arguments() {
+		function czr_fn_customize_arguments() {
 			$args = array(
 					'panels' => array(
 								'title' ,
@@ -261,7 +261,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
 		 * @package Customizr
 		 * @since Customizr 3.0
 		 */
-		function czr_customize_factory ( $wp_customize , $args, $setup ) {
+		function czr_fn_customize_factory ( $wp_customize , $args, $setup ) {
 			global $wp_version;
 			//add panels if current WP version >= 4.0
 			if ( isset( $setup['add_panel']) && version_compare( $wp_version, '4.0', '>=' ) ) {
@@ -314,7 +314,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
           //=> grid customizer addon starts by gc_
           //When do we add a prefix ?
           $add_prefix = false;
-          if ( CZR_utils::$inst -> czr_is_customizr_option( $key ) )
+          if ( CZR_utils::$inst -> czr_fn_is_customizr_option( $key ) )
             $add_prefix = true;
           $_opt_name = $add_prefix ? "{$tc_option_group}[{$key}]" : $key;
 
@@ -358,7 +358,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
     * hook __before_setting_control (declared in class-tc-controls-settings.php)
     * @echo clickable text
     */
-    function czr_render_grid_control_link( $set_id ) {
+    function czr_fn_render_grid_control_link( $set_id ) {
       if ( false !== strpos( $set_id, 'tc_post_list_show_thumb' ) )
         printf('<span class="tc-grid-toggle-controls" title="%1$s">%1$s</span>' , __('More grid design options' , 'customizr'));
     }
@@ -370,7 +370,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
 		 * @since Customizr 1.0
 		 */
 
-		function czr_customize_preview_js() {
+		function czr_fn_customize_preview_js() {
 			global $wp_version;
 
 			wp_enqueue_script(
@@ -391,7 +391,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
                 //can be hacked to override the preview params when a custom skin is used
                 //array( 'skinName' => 'custom-skin-#40542.css', 'fullPath' => 'http://....' )
                 'customSkin'      => apply_filters( 'tc_custom_skin_preview_params' , array( 'skinName' => '', 'fullPath' => '' ) ),
-                'fontPairs'       => CZR_utils::$inst -> czr_get_font( 'list' ),
+                'fontPairs'       => CZR_utils::$inst -> czr_fn_get_font( 'list' ),
                 'fontSelectors'   => CZR_init::$instance -> font_selectors,
                 //patch for old wp versions which don't trigger preview-ready signal => since WP 4.1
                 'preview_ready_event_exists'   => version_compare( $wp_version, '4.1' , '>=' )
@@ -409,7 +409,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
 		 * @package Customizr
 		 * @since Customizr 3.1.0
 		 */
-		function czr_customize_controls_js_css() {
+		function czr_fn_customize_controls_js_css() {
 
 			wp_enqueue_style(
 				'tc-customizer-controls-style',
@@ -464,8 +464,8 @@ if ( ! class_exists( 'CZR_customize' ) ) :
 	        	'AjaxUrl'       => admin_url( 'admin-ajax.php' ),
 	        	'TCNonce' 			=> wp_create_nonce( 'tc-customizer-nonce' ),
             'themeName'     => CZR___::$theme_name,
-            'HideDonate'    => $this -> czr_get_hide_donate_status(),
-            'ShowCTA'       => ( true == CZR_utils::$inst->czr_opt('tc_hide_donate') && ! get_transient ('tc_cta') ) ? true : false,
+            'HideDonate'    => $this -> czr_fn_get_hide_donate_status(),
+            'ShowCTA'       => ( true == CZR_utils::$inst->czr_fn_opt('tc_hide_donate') && ! get_transient ('tc_cta') ) ? true : false,
             'defaultSliderHeight' => 500,//500px, @todo make sure we can hard code it here
             'translatedStrings'    => array(
               'postSliderNote' => __( "This option generates a home page slider based on your last posts, starting from the most recent or the featured (sticky) post(s) if any.", "customizr" ),
@@ -484,7 +484,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
     * @package Customizr
     * @since Customizr 3.1.14
     */
-    function czr_get_hide_donate_status() {
+    function czr_fn_get_hide_donate_status() {
       //is customizr the current active theme?
       //=> check the existence of is_theme_active for backward compatibility (may be useless because introduced in 3.4... )
       $_is_customizr_active = method_exists( $GLOBALS['wp_customize'], 'is_theme_active' ) && $GLOBALS['wp_customize'] -> is_theme_active();
@@ -492,7 +492,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
       $_user_started_customize = false !== $_options || ! empty( $_options );
 
       //shall we hide donate ?
-      return ! $_user_started_customize || ! $_is_customizr_active || CZR_utils::$inst->czr_opt('tc_hide_donate');
+      return ! $_user_started_customize || ! $_is_customizr_active || CZR_utils::$inst->czr_fn_opt('tc_hide_donate');
     }
 
 
@@ -503,7 +503,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
 		* @package Customizr
 		* @since Customizr 3.1.14
 		*/
-    function czr_hide_donate() {
+    function czr_fn_hide_donate() {
     	check_ajax_referer( 'tc-customizer-nonce', 'TCnonce' );
     	$options = get_option('tc_theme_options');
     	$options['tc_hide_donate'] = true;
@@ -521,7 +521,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
     * callback of 'customize_controls_print_footer_scripts'
     *@since v3.2.9
     */
-    function czr_print_js_templates() {
+    function czr_fn_print_js_templates() {
       ?>
       <script type="text/template" id="donate_template">
         <div id="tc-donate-customizer">
@@ -644,13 +644,13 @@ if ( ! class_exists( 'CZR_customize' ) ) :
     * @package Customizr
     * @since Customizr 1.1
     */
-    function czr_add_fallback_page() {
+    function czr_fn_add_fallback_page() {
         $theme_page = add_theme_page(
             __( 'Upgrade WP' , 'customizr' ),   // Name of page
             __( 'Upgrade WP' , 'customizr' ),   // Label in menu
             'edit_theme_options' ,          // Capability required
             'upgrade_wp.php' ,             // Menu slug, used to uniquely identify the page
-            array( $this , 'czr_fallback_admin_page' )         //function to be called to output the content of this page
+            array( $this , 'czr_fn_fallback_admin_page' )         //function to be called to output the content of this page
         );
     }
 
@@ -662,7 +662,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
     * @package Customizr
     * @since Customizr 1.1
     */
-    function czr_fallback_admin_page() {
+    function czr_fn_fallback_admin_page() {
       ?>
         <div class="wrap upgrade_wordpress">
           <div id="icon-options-general" class="icon32"><br></div>

--- a/inc/admin/class-admin-customize.php
+++ b/inc/admin/class-admin-customize.php
@@ -21,32 +21,32 @@ if ( ! class_exists( 'CZR_customize' ) ) :
       //check if WP version >= 3.4 to include customizer functions
       //Shall we really keep this ?
       if ( ! version_compare( $wp_version, '3.4' , '>=' ) ) {
-        add_action( 'admin_menu'                    , array( $this , 'tc_add_fallback_page' ));
+        add_action( 'admin_menu'                    , array( $this , 'czr_add_fallback_page' ));
         return;
       }
 
       self::$instance =& $this;
   		//add control class
-  		add_action ( 'customize_register'				                , array( $this , 'tc_augment_customizer' ),10,1);
+  		add_action ( 'customize_register'				                , array( $this , 'czr_augment_customizer' ),10,1);
 
   		//add grid/post list buttons in the control views
-  		add_action( '__before_setting_control'                  , array( $this , 'tc_render_grid_control_link') );
+  		add_action( '__before_setting_control'                  , array( $this , 'czr_render_grid_control_link') );
 
   		//control scripts and style
-  		add_action ( 'customize_controls_enqueue_scripts'	      , array( $this , 'tc_customize_controls_js_css' ));
+  		add_action ( 'customize_controls_enqueue_scripts'	      , array( $this , 'czr_customize_controls_js_css' ));
   		//add the customizer built with the builder below
-  		add_action ( 'customize_register'				                , array( $this , 'tc_customize_register' ), 20, 1 );
+  		add_action ( 'customize_register'				                , array( $this , 'czr_customize_register' ), 20, 1 );
 
       //modify some WP built-in settings / controls / sections
-      add_action ( 'customize_register'                       , array( $this , 'tc_alter_wp_customizer_settings' ), 30, 1 );
+      add_action ( 'customize_register'                       , array( $this , 'czr_alter_wp_customizer_settings' ), 30, 1 );
 
       //preview scripts
       //set with priority 20 to be fired after tc_customize_store_db_opt in CZR_utils
-  		add_action ( 'customize_preview_init'			              , array( $this , 'tc_customize_preview_js' ), 20 );
+  		add_action ( 'customize_preview_init'			              , array( $this , 'czr_customize_preview_js' ), 20 );
   		//Hide donate button
-  		add_action ( 'wp_ajax_hide_donate'				              , array( $this , 'tc_hide_donate' ) );
+  		add_action ( 'wp_ajax_hide_donate'				              , array( $this , 'czr_hide_donate' ) );
 
-      add_action ( 'customize_controls_print_footer_scripts'  , array( $this, 'tc_print_js_templates' ) );
+      add_action ( 'customize_controls_print_footer_scripts'  , array( $this, 'czr_print_js_templates' ) );
     }
 
 
@@ -75,7 +75,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
         $wp_customize -> get_control( 'site_icon' )->section = 'logo_sec';
 
         //add a favicon title after the logo upload
-        add_action( '__after_setting_control' , array( $this , 'tc_add_favicon_title') );
+        add_action( '__after_setting_control' , array( $this , 'czr_add_favicon_title') );
       }//end ALTER SITE ICON
 
 
@@ -650,7 +650,7 @@ if ( ! class_exists( 'CZR_customize' ) ) :
             __( 'Upgrade WP' , 'customizr' ),   // Label in menu
             'edit_theme_options' ,          // Capability required
             'upgrade_wp.php' ,             // Menu slug, used to uniquely identify the page
-            array( $this , 'tc_fallback_admin_page' )         //function to be called to output the content of this page
+            array( $this , 'czr_fallback_admin_page' )         //function to be called to output the content of this page
         );
     }
 

--- a/inc/admin/class-admin-customize.php
+++ b/inc/admin/class-admin-customize.php
@@ -11,8 +11,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_customize' ) ) :
-	class TC_customize {
+if ( ! class_exists( 'CZR_customize' ) ) :
+	class CZR_customize {
     static $instance;
     public $control_translations;
 
@@ -41,7 +41,7 @@ if ( ! class_exists( 'TC_customize' ) ) :
       add_action ( 'customize_register'                       , array( $this , 'tc_alter_wp_customizer_settings' ), 30, 1 );
 
       //preview scripts
-      //set with priority 20 to be fired after tc_customize_store_db_opt in TC_utils
+      //set with priority 20 to be fired after tc_customize_store_db_opt in CZR_utils
   		add_action ( 'customize_preview_init'			              , array( $this , 'tc_customize_preview_js' ), 20 );
   		//Hide donate button
   		add_action ( 'wp_ajax_hide_donate'				              , array( $this , 'tc_hide_donate' ) );
@@ -69,7 +69,7 @@ if ( ! class_exists( 'TC_customize' ) ) :
       //=> CHANGE SITE ICON DEFAULT WP SECTION TO CUSTOMIZR LOGO SECTION
       global $wp_version;
       if ( version_compare( $wp_version, '4.3', '>=' ) && is_object( $wp_customize -> get_control( 'site_icon' ) ) ) {
-        $tc_option_group = TC___::$tc_option_group;
+        $tc_option_group = CZR___::$tc_option_group;
         $wp_customize -> remove_control( "{$tc_option_group}[tc_fav_upload]" );
         //note : the setting is kept because used in the customizer js api to handle the transition between Customizr favicon to WP site icon.
         $wp_customize -> get_control( 'site_icon' )->section = 'logo_sec';
@@ -134,7 +134,7 @@ if ( ! class_exists( 'TC_customize' ) ) :
           );
         }
 
-        $wp_customize -> add_control( new TC_controls( $wp_customize, $menu_setting_id, $_control_properties ) );
+        $wp_customize -> add_control( new CZR_controls( $wp_customize, $menu_setting_id, $_control_properties ) );
 
         $_priority = $_priority + 10;
       }//foreach
@@ -157,18 +157,18 @@ if ( ! class_exists( 'TC_customize' ) ) :
 		*/
 		function tc_augment_customizer( $manager ) {
       //loads custom settings and controls classes for the Customizr theme
-      //- TC_Customize_Setting extends WP_Customize_Setting => to override the value() method
-      //- TC_controls extends WP_Customize_Control => overrides the render() method
-      //- TC_Customize_Cropped_Image_Control extends WP_Customize_Cropped_Image_Control => introduced in v3.4.19, uses a js template to render the control
-      //- TC_Customize_Upload_Control extends WP_Customize_Control => old upload control used until v3.4.18, still used if current version of WP is < 4.3
-      //- TC_Customize_Multipicker_Control extends TC_controls => used for multiple cat picker for example
-      //- TC_Customize_Multipicker_Categories_Control extends TC_Customize_Multipicker_Control => extends the multipicker
-      //- TC_Walker_CategoryDropdown_Multipicker extends Walker_CategoryDropdown => needed for the multipicker to allow more than one "selected" attribute
+      //- CZR_Customize_Setting extends WP_Customize_Setting => to override the value() method
+      //- CZR_controls extends WP_Customize_Control => overrides the render() method
+      //- CZR_Customize_Cropped_Image_Control extends WP_Customize_Cropped_Image_Control => introduced in v3.4.19, uses a js template to render the control
+      //- CZR_Customize_Upload_Control extends WP_Customize_Control => old upload control used until v3.4.18, still used if current version of WP is < 4.3
+      //- CZR_Customize_Multipicker_Control extends CZR_controls => used for multiple cat picker for example
+      //- CZR_Customize_Multipicker_Categories_Control extends CZR_Customize_Multipicker_Control => extends the multipicker
+      //- CZR_Walker_CategoryDropdown_Multipicker extends Walker_CategoryDropdown => needed for the multipicker to allow more than one "selected" attribute
       locate_template( 'inc/admin/class-tc-controls-settings.php' , $load = true, $require_once = true );
 
       //Registered types are eligible to be rendered via JS and created dynamically.
-      if ( class_exists('TC_Customize_Cropped_Image_Control') )
-        $manager -> register_control_type( 'TC_Customize_Cropped_Image_Control' );
+      if ( class_exists('CZR_Customize_Cropped_Image_Control') )
+        $manager -> register_control_type( 'CZR_Customize_Cropped_Image_Control' );
 		}
 
 
@@ -182,7 +182,7 @@ if ( ! class_exists( 'TC_customize' ) ) :
 			return $this -> tc_customize_factory (
         $wp_customize,
         $this -> tc_customize_arguments(),
-        TC_utils_settings_map::$instance -> tc_get_customizer_map()
+        CZR_utils_settings_map::$instance -> tc_get_customizer_map()
       );
 		}
 
@@ -306,7 +306,7 @@ if ( ! class_exists( 'TC_customize' ) ) :
 					$f_option = preg_match_all( '/\[(.*?)\]/' , $key , $match );
 		      $f_option_name = isset( $match[1][0] )  ? $match[1][0] : 'setting';
 
-          $tc_option_group = TC___::$tc_option_group;
+          $tc_option_group = CZR___::$tc_option_group;
           //build option name
           //When do we add a prefix ?
           //all customizr theme options start by "tc_" by convention
@@ -314,7 +314,7 @@ if ( ! class_exists( 'TC_customize' ) ) :
           //=> grid customizer addon starts by gc_
           //When do we add a prefix ?
           $add_prefix = false;
-          if ( TC_utils::$inst -> tc_is_customizr_option( $key ) )
+          if ( CZR_utils::$inst -> tc_is_customizr_option( $key ) )
             $add_prefix = true;
           $_opt_name = $add_prefix ? "{$tc_option_group}[{$key}]" : $key;
 
@@ -332,8 +332,8 @@ if ( ! class_exists( 'TC_customize' ) ) :
 					}
 
           //add setting
-          if ( class_exists('TC_Customize_Setting') )
-            $wp_customize -> add_setting( new TC_Customize_Setting ( $wp_customize, $_opt_name, $option_settings ) );
+          if ( class_exists('CZR_Customize_Setting') )
+            $wp_customize -> add_setting( new CZR_Customize_Setting ( $wp_customize, $_opt_name, $option_settings ) );
           else
             $wp_customize -> add_setting( $_opt_name, $option_settings );
 
@@ -391,8 +391,8 @@ if ( ! class_exists( 'TC_customize' ) ) :
                 //can be hacked to override the preview params when a custom skin is used
                 //array( 'skinName' => 'custom-skin-#40542.css', 'fullPath' => 'http://....' )
                 'customSkin'      => apply_filters( 'tc_custom_skin_preview_params' , array( 'skinName' => '', 'fullPath' => '' ) ),
-                'fontPairs'       => TC_utils::$inst -> tc_get_font( 'list' ),
-                'fontSelectors'   => TC_init::$instance -> font_selectors,
+                'fontPairs'       => CZR_utils::$inst -> tc_get_font( 'list' ),
+                'fontSelectors'   => CZR_init::$instance -> font_selectors,
                 //patch for old wp versions which don't trigger preview-ready signal => since WP 4.1
                 'preview_ready_event_exists'   => version_compare( $wp_version, '4.1' , '>=' )
 			        )
@@ -438,7 +438,7 @@ if ( ! class_exists( 'TC_customize' ) ) :
 
 
 			//gets the featured pages id from init
-			$fp_ids				= apply_filters( 'tc_featured_pages_ids' , TC_init::$instance -> fp_ids);
+			$fp_ids				= apply_filters( 'tc_featured_pages_ids' , CZR_init::$instance -> fp_ids);
 
 			//declares the common fp control fields and the dynamic arrays
 			$fp_controls 			= array(
@@ -463,9 +463,9 @@ if ( ! class_exists( 'TC_customize' ) ) :
 	        	'FPControls' => array_merge( $fp_controls , $page_dropdowns , $text_fields ),
 	        	'AjaxUrl'       => admin_url( 'admin-ajax.php' ),
 	        	'TCNonce' 			=> wp_create_nonce( 'tc-customizer-nonce' ),
-            'themeName'     => TC___::$theme_name,
+            'themeName'     => CZR___::$theme_name,
             'HideDonate'    => $this -> tc_get_hide_donate_status(),
-            'ShowCTA'       => ( true == TC_utils::$inst->tc_opt('tc_hide_donate') && ! get_transient ('tc_cta') ) ? true : false,
+            'ShowCTA'       => ( true == CZR_utils::$inst->tc_opt('tc_hide_donate') && ! get_transient ('tc_cta') ) ? true : false,
             'defaultSliderHeight' => 500,//500px, @todo make sure we can hard code it here
             'translatedStrings'    => array(
               'postSliderNote' => __( "This option generates a home page slider based on your last posts, starting from the most recent or the featured (sticky) post(s) if any.", "customizr" ),
@@ -492,7 +492,7 @@ if ( ! class_exists( 'TC_customize' ) ) :
       $_user_started_customize = false !== $_options || ! empty( $_options );
 
       //shall we hide donate ?
-      return ! $_user_started_customize || ! $_is_customizr_active || TC_utils::$inst->tc_opt('tc_hide_donate');
+      return ! $_user_started_customize || ! $_is_customizr_active || CZR_utils::$inst->tc_opt('tc_hide_donate');
     }
 
 
@@ -552,7 +552,7 @@ if ( ! class_exists( 'TC_customize' ) ) :
         <div class="tc-cta tc-cta-wrap">
           <?php
             printf('<a class="tc-cta-btn" href="%1$s" title="%2$s" target="_blank">%2$s &raquo;</a>',
-              sprintf('%scustomizr-pro/', TC_WEBSITE ),
+              sprintf('%scustomizr-pro/', CZR_WEBSITE ),
               __( "Upgrade to Customizr Pro" , 'customizr' )
             );
           ?>
@@ -563,7 +563,7 @@ if ( ! class_exists( 'TC_customize' ) ) :
           <?php
             printf('<span class="tc-notice">%1$s</span><a class="tc-cta-btn" href="%2$s" title="%3$s" target="_blank">%3$s &raquo;</a>',
               __( "Need more control on your fonts ? Style any text in live preview ( size, color, font family, effect, ...) with Customizr Pro." , 'customizr' ),
-              sprintf('%scustomizr-pro/', TC_WEBSITE ),
+              sprintf('%scustomizr-pro/', CZR_WEBSITE ),
               __( "Upgrade to Customizr Pro" , 'customizr' )
             );
           ?>
@@ -574,7 +574,7 @@ if ( ! class_exists( 'TC_customize' ) ) :
           <?php
             printf('<span class="tc-notice">%1$s</span><a class="tc-cta-btn" href="%2$s" title="%3$s" target="_blank">%3$s &raquo;</a>',
               __( "Add unlimited featured pages with Customizr Pro." , 'customizr' ),
-              sprintf('%scustomizr-pro/', TC_WEBSITE ),
+              sprintf('%scustomizr-pro/', CZR_WEBSITE ),
               __( "Upgrade to Customizr Pro" , 'customizr' )
             );
           ?>
@@ -588,7 +588,7 @@ if ( ! class_exists( 'TC_customize' ) ) :
               __( "Rediscover the beauty of your blog posts and increase your visitors engagement with the Grid Customizer." , 'customizr' ),
                sprintf('<a href="%1$s" class="tc-notice-inline-link" title="%2$s" target="_blank">%2$s<span class="tc-notice-ext-icon dashicons dashicons-external"></span></a>' , esc_url('demo.presscustomizr.com/?design=demo_grid_customizer'), __("Try it in the demo" , "customizr" )
               ),
-              sprintf('%scustomizr-pro/', TC_WEBSITE ),
+              sprintf('%scustomizr-pro/', CZR_WEBSITE ),
               __( "Upgrade to Customizr Pro" , 'customizr' )
             );
           ?>
@@ -602,7 +602,7 @@ if ( ! class_exists( 'TC_customize' ) ) :
               __( "Add creative and engaging reveal animations to your side menu." , 'customizr' ),
               sprintf('<a href="%1$s" class="tc-notice-inline-link" title="%2$s" target="_blank">%2$s<span class="tc-notice-ext-icon dashicons dashicons-external"></span></a>' , esc_url('demo.presscustomizr.com/?design=nav'), __("Side menu animation demo" , "customizr" )
               ),
-              sprintf('%scustomizr-pro/', TC_WEBSITE ),
+              sprintf('%scustomizr-pro/', CZR_WEBSITE ),
               __( "Upgrade to Customizr Pro" , 'customizr' )
             );
           ?>
@@ -614,7 +614,7 @@ if ( ! class_exists( 'TC_customize' ) ) :
           <?php
             printf('<span class="tc-notice">%1$s</span><a class="tc-cta-btn" href="%2$s" title="%3$s" target="_blank">%3$s &raquo;</a>',
               __( "Customize your footer credits with Customizr Pro." , 'customizr' ),
-              sprintf('%scustomizr-pro/', TC_WEBSITE ),
+              sprintf('%scustomizr-pro/', CZR_WEBSITE ),
               __( "Upgrade to Customizr Pro" , 'customizr' )
             );
           ?>
@@ -622,12 +622,12 @@ if ( ! class_exists( 'TC_customize' ) ) :
       </script>
       <script type="text/template" id="rate-czr">
         <?php
-        $_is_pro = 'customizr-pro' == TC___::$theme_name;
+        $_is_pro = 'customizr-pro' == CZR___::$theme_name;
           printf( '<span class="tc-rate-link">%1$s %2$s, <br/>%3$s <a href="%4$s" title="%5$s" class="tc-stars" target="_blank">%6$s</a> %7$s</span>',
             __( 'If you like' , 'customizr' ),
             ! $_is_pro ? __( 'the Customizr theme' , 'customizr') : __( 'the Customizr pro theme' , 'customizr'),
             __( 'we would love to receive a' , 'customizr' ),
-            ! $_is_pro ? 'https://' . 'wordpress.org/support/view/theme-reviews/customizr?filter=5' : sprintf('%scustomizr-pro/#comments', TC_WEBSITE ),
+            ! $_is_pro ? 'https://' . 'wordpress.org/support/view/theme-reviews/customizr?filter=5' : sprintf('%scustomizr-pro/#comments', CZR_WEBSITE ),
             __( 'Review the Customizr theme' , 'customizr' ),
             '&#9733;&#9733;&#9733;&#9733;&#9733;',
             __( 'rating. Thanks :) !' , 'customizr')

--- a/inc/admin/class-admin-meta_boxes.php
+++ b/inc/admin/class-admin-meta_boxes.php
@@ -79,9 +79,10 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
 
           //3- Adding the meta-boxes to those screens
           foreach ( $screens as $key => $screen) {
-              //skip if acf
-              if ('acf' == $screen )
+              //skip if acf or ris_gallery (ultimate responsive image slider)
+              if ( in_array( $screen, array( 'acf', 'ris_gallery' ) ) )
                 continue;
+
               add_meta_box(
                   'layout_sectionid' ,
                   __( 'Layout Options' , 'customizr' ),

--- a/inc/admin/class-admin-meta_boxes.php
+++ b/inc/admin/class-admin-meta_boxes.php
@@ -59,7 +59,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
      * @package Customizr
      * @since Customizr 1.0
      */
-      function tc_post_meta_boxes() {//id, title, callback, post_type, context, priority, callback_args
+      function czr_post_meta_boxes() {//id, title, callback, post_type, context, priority, callback_args
            /***
             Determines which screens we display the box
           **/
@@ -112,7 +112,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
        * @package Customizr
        * @since Customizr 1.0
        */
-      function tc_post_layout_box( $post ) {
+      function czr_post_layout_box( $post ) {
             // Use nonce for verification
             wp_nonce_field( plugin_basename( __FILE__ ), 'post_layout_noncename' );
 
@@ -211,7 +211,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
        * @package Customizr
        * @since Customizr 2.0
        */
-        function tc_post_slider_box( $post ) {
+        function czr_post_slider_box( $post ) {
             // Use nonce for verification
             wp_nonce_field( plugin_basename( __FILE__ ), 'post_slider_noncename' );
 
@@ -252,7 +252,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
      * @package Customizr
      * @since Customizr 2.0
      */
-      function tc_get_post_slider_infos( $postid ) {
+      function czr_get_post_slider_infos( $postid ) {
           //check value is ajax saved ?
           $post_slider_check_value   = esc_attr(get_post_meta( $postid, $key = 'post_slider_check_key' , $single = true ));
 
@@ -389,7 +389,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
        * @package Customizr
        * @since Customizr 1.0
        */
-      function tc_post_fields_save( $post_id ) {
+      function czr_post_fields_save( $post_id ) {
         // verify if this is an auto save routine.
         // If it is our form has not been submitted, so we dont want to do anything
         if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE )
@@ -483,7 +483,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
        * @package Customizr
        * @since Customizr 2.0
        */
-        function tc_attachment_meta_box() {//id, title, callback, post_type, context, priority, callback_args
+        function czr_attachment_meta_box() {//id, title, callback, post_type, context, priority, callback_args
           $screens = array( 'attachment' );
           foreach ( $screens as $screen) {
               add_meta_box(
@@ -507,7 +507,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
        * @package Customizr
        * @since Customizr 2.0
        */
-        function tc_attachment_slider_box( $post ) {
+        function czr_attachment_slider_box( $post ) {
             // Use nonce for verification
             //wp_nonce_field( plugin_basename( __FILE__ ), 'slider_noncename' );
             // The actual fields for data entry
@@ -550,7 +550,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
        * @package Customizr
        * @since Customizr 2.0
        */
-        function tc_get_attachment_slider_infos( $postid ) {
+        function czr_get_attachment_slider_infos( $postid ) {
           //check value is ajax saved ?
           $slider_check_value     = esc_attr(get_post_meta( $postid, $key = 'slider_check_key' , $single = true ));
 
@@ -803,7 +803,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
        * @package Customizr
        * @since Customizr 2.0
        */
-        function tc_slide_save( $post_id ) {
+        function czr_slide_save( $post_id ) {
           // verify if this is an auto save routine.
           // If it is our form has not been submitted, so we dont want to do anything
 
@@ -899,7 +899,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
        * @package Customizr
        * @since Customizr 2.0
        */
-      function tc_show_slides ( $current_post_slides,$current_attachement_id) {
+      function czr_show_slides ( $current_post_slides,$current_attachement_id) {
           //check if we have slides to show
           ?>
           <?php if(empty( $current_post_slides)) : ?>
@@ -1027,7 +1027,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
        * @package Customizr
        * @since Customizr 2.0
        */
-      function tc_slider_ajax_save( $post_id ) {
+      function czr_slider_ajax_save( $post_id ) {
 
             //We check the ajax nonce (common for post and attachment)
             if ( isset( $_POST['SliderCheckNonce']) && !wp_verify_nonce( $_POST['SliderCheckNonce'], 'tc-slider-check-nonce' ) )
@@ -1323,7 +1323,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
    * @package Customizr
    * @since Customizr 2.0
    */
-     function tc_slider_cb() {
+     function czr_slider_cb() {
 
       $nonce = $_POST['SliderCheckNonce'];
       // check if the submitted nonce matches with the generated nonce we created earlier
@@ -1365,7 +1365,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
        * @package Customizr
        * @since Customizr 1.0
        */
-        function tc_slider_admin_scripts( $hook) {
+        function czr_slider_admin_scripts( $hook) {
         global $post;
 
         $_min_version = ( defined('WP_DEBUG') && true === WP_DEBUG ) ? '' : '.min';
@@ -1453,13 +1453,13 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
   ------------- ATTACHMENT FIELDS FILTER IF WP < 3.5 -------------
   ----------------------------------------------------------------
   */
-      function tc_attachment_filter( $form_fields, $post = null) {
+      function czr_attachment_filter( $form_fields, $post = null) {
           $this -> tc_attachment_slider_box ( $post);
            return $form_fields;
       }
 
 
-      function tc_attachment_save_filter( $post, $attachment ) {
+      function czr_attachment_save_filter( $post, $attachment ) {
           if ( isset( $_POST['tc_post_id']))
            $postid = $_POST['tc_post_id'];
 

--- a/inc/admin/class-admin-meta_boxes.php
+++ b/inc/admin/class-admin-meta_boxes.php
@@ -16,19 +16,19 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
       static $instance;
       function __construct () {
           self::$instance =& $this;
-          add_action( 'add_meta_boxes'                       , array( $this , 'czr_post_meta_boxes' ));
-          add_action( '__post_slider_infos'                  , array( $this , 'czr_get_post_slider_infos' ));
-          add_action( 'save_post'                            , array( $this , 'czr_post_fields_save' ));
+          add_action( 'add_meta_boxes'                       , array( $this , 'czr_fn_post_meta_boxes' ));
+          add_action( '__post_slider_infos'                  , array( $this , 'czr_fn_get_post_slider_infos' ));
+          add_action( 'save_post'                            , array( $this , 'czr_fn_post_fields_save' ));
 
-          add_action( 'add_meta_boxes'                       , array( $this , 'czr_attachment_meta_box' ));
-          add_action( '__attachment_slider_infos'            , array( $this , 'czr_get_attachment_slider_infos' ));
-          add_action( 'edit_attachment'                      , array( $this , 'czr_slide_save' ));
+          add_action( 'add_meta_boxes'                       , array( $this , 'czr_fn_attachment_meta_box' ));
+          add_action( '__attachment_slider_infos'            , array( $this , 'czr_fn_get_attachment_slider_infos' ));
+          add_action( 'edit_attachment'                      , array( $this , 'czr_fn_slide_save' ));
 
-          add_action( '__show_slides'                        , array( $this , 'czr_show_slides' ), 10, 2);
+          add_action( '__show_slides'                        , array( $this , 'czr_fn_show_slides' ), 10, 2);
 
-          add_action( 'wp_ajax_slider_action'                , array( $this , 'czr_slider_cb' ));
+          add_action( 'wp_ajax_slider_action'                , array( $this , 'czr_fn_slider_cb' ));
 
-          add_action( 'admin_enqueue_scripts'                , array( $this , 'czr_slider_admin_scripts' ));
+          add_action( 'admin_enqueue_scripts'                , array( $this , 'czr_fn_slider_admin_scripts' ));
 
 
 
@@ -40,8 +40,8 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
          */
         global $wp_version;
         if (version_compare( $wp_version, '3.5' , '<' ) ) {
-            add_filter( 'attachment_fields_to_edit'           , array( $this , 'czr_attachment_filter' ), 11, 2 );
-            add_filter( 'attachment_fields_to_save'           , array( $this , 'czr_attachment_save_filter' ), 11, 2 );
+            add_filter( 'attachment_fields_to_edit'           , array( $this , 'czr_fn_attachment_filter' ), 11, 2 );
+            add_filter( 'attachment_fields_to_save'           , array( $this , 'czr_fn_attachment_save_filter' ), 11, 2 );
           }
 
       }//end of __construct
@@ -59,7 +59,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
      * @package Customizr
      * @since Customizr 1.0
      */
-      function czr_post_meta_boxes() {//id, title, callback, post_type, context, priority, callback_args
+      function czr_fn_post_meta_boxes() {//id, title, callback, post_type, context, priority, callback_args
            /***
             Determines which screens we display the box
           **/
@@ -85,7 +85,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
               add_meta_box(
                   'layout_sectionid' ,
                   __( 'Layout Options' , 'customizr' ),
-                  array( $this , 'czr_post_layout_box' ),
+                  array( $this , 'czr_fn_post_layout_box' ),
                   $screen,
                   ( 'page' == $screen | 'post' == $screen ) ? 'side' : 'normal',//displays meta box below editor for custom post types
                   apply_filters('tc_post_meta_boxes_priority' , 'high', $screen )
@@ -93,7 +93,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
               add_meta_box(
                   'slider_sectionid' ,
                   __( 'Slider Options' , 'customizr' ),
-                  array( $this , 'czr_post_slider_box' ),
+                  array( $this , 'czr_fn_post_slider_box' ),
                   $screen,
                   'normal' ,
                   apply_filters('tc_post_meta_boxes_priority' , 'high', $screen)
@@ -112,7 +112,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
        * @package Customizr
        * @since Customizr 1.0
        */
-      function czr_post_layout_box( $post ) {
+      function czr_fn_post_layout_box( $post ) {
             // Use nonce for verification
             wp_nonce_field( plugin_basename( __FILE__ ), 'post_layout_noncename' );
 
@@ -131,7 +131,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
             }
 
             //by default we apply the global default layout
-            $tc_sidebar_default_layout  = esc_attr( CZR_utils::$inst->czr_opt('tc_sidebar_global_layout') );
+            $tc_sidebar_default_layout  = esc_attr( CZR_utils::$inst->czr_fn_opt('tc_sidebar_global_layout') );
 
             //get the lists of eligible post types + normal posts (not pages!)
             $args                 = array(
@@ -146,16 +146,16 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
 
             //eligible posts (and custom posts types) default layout
             if ( in_array($post->post_type , $eligible_posts ) ) {
-              $tc_sidebar_default_layout  = esc_attr( CZR_utils::$inst->czr_opt('tc_sidebar_post_layout') );
+              $tc_sidebar_default_layout  = esc_attr( CZR_utils::$inst->czr_fn_opt('tc_sidebar_post_layout') );
             }
 
             //page default layout
             if ( $post->post_type == 'page' ) {
-              $tc_sidebar_default_layout  = esc_attr( CZR_utils::$inst->czr_opt('tc_sidebar_page_layout') );
+              $tc_sidebar_default_layout  = esc_attr( CZR_utils::$inst->czr_fn_opt('tc_sidebar_page_layout') );
             }
 
             //check if the 'force default layout' option is checked
-            $force_layout                 = esc_attr( CZR_utils::$inst->czr_opt('tc_sidebar_force_layout') );
+            $force_layout                 = esc_attr( CZR_utils::$inst->czr_fn_opt('tc_sidebar_force_layout') );
 
 
             ?>
@@ -211,7 +211,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
        * @package Customizr
        * @since Customizr 2.0
        */
-        function czr_post_slider_box( $post ) {
+        function czr_fn_post_slider_box( $post ) {
             // Use nonce for verification
             wp_nonce_field( plugin_basename( __FILE__ ), 'post_slider_noncename' );
 
@@ -252,7 +252,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
      * @package Customizr
      * @since Customizr 2.0
      */
-      function czr_get_post_slider_infos( $postid ) {
+      function czr_fn_get_post_slider_infos( $postid ) {
           //check value is ajax saved ?
           $post_slider_check_value   = esc_attr(get_post_meta( $postid, $key = 'post_slider_check_key' , $single = true ));
 
@@ -389,7 +389,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
        * @package Customizr
        * @since Customizr 1.0
        */
-      function czr_post_fields_save( $post_id ) {
+      function czr_fn_post_fields_save( $post_id ) {
         // verify if this is an auto save routine.
         // If it is our form has not been submitted, so we dont want to do anything
         if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE )
@@ -483,13 +483,13 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
        * @package Customizr
        * @since Customizr 2.0
        */
-        function czr_attachment_meta_box() {//id, title, callback, post_type, context, priority, callback_args
+        function czr_fn_attachment_meta_box() {//id, title, callback, post_type, context, priority, callback_args
           $screens = array( 'attachment' );
           foreach ( $screens as $screen) {
               add_meta_box(
                   'slider_sectionid' ,
                   __( 'Slider Options' , 'customizr' ),
-                  array( $this , 'czr_attachment_slider_box' ),
+                  array( $this , 'czr_fn_attachment_slider_box' ),
                   $screen/*,
                   'side' ,
                   'high'*/
@@ -507,7 +507,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
        * @package Customizr
        * @since Customizr 2.0
        */
-        function czr_attachment_slider_box( $post ) {
+        function czr_fn_attachment_slider_box( $post ) {
             // Use nonce for verification
             //wp_nonce_field( plugin_basename( __FILE__ ), 'slider_noncename' );
             // The actual fields for data entry
@@ -550,7 +550,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
        * @package Customizr
        * @since Customizr 2.0
        */
-        function czr_get_attachment_slider_infos( $postid ) {
+        function czr_fn_get_attachment_slider_infos( $postid ) {
           //check value is ajax saved ?
           $slider_check_value     = esc_attr(get_post_meta( $postid, $key = 'slider_check_key' , $single = true ));
 
@@ -803,7 +803,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
        * @package Customizr
        * @since Customizr 2.0
        */
-        function czr_slide_save( $post_id ) {
+        function czr_fn_slide_save( $post_id ) {
           // verify if this is an auto save routine.
           // If it is our form has not been submitted, so we dont want to do anything
 
@@ -899,7 +899,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
        * @package Customizr
        * @since Customizr 2.0
        */
-      function czr_show_slides ( $current_post_slides,$current_attachement_id) {
+      function czr_fn_show_slides ( $current_post_slides,$current_attachement_id) {
           //check if we have slides to show
           ?>
           <?php if(empty( $current_post_slides)) : ?>
@@ -1027,7 +1027,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
        * @package Customizr
        * @since Customizr 2.0
        */
-      function czr_slider_ajax_save( $post_id ) {
+      function czr_fn_slider_ajax_save( $post_id ) {
 
             //We check the ajax nonce (common for post and attachment)
             if ( isset( $_POST['SliderCheckNonce']) && !wp_verify_nonce( $_POST['SliderCheckNonce'], 'tc-slider-check-nonce' ) )
@@ -1300,7 +1300,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
                 }//end foreach
                 //attachments
                 if( $tc_post_type == 'attachment' )
-                  $this -> czr_slide_save( $post_ID );
+                  $this -> czr_fn_slide_save( $post_ID );
 
                 do_action( "__after_ajax_save_slider_{$tc_post_type}", $_POST, $tc_slider_fields );
             }//function
@@ -1323,7 +1323,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
    * @package Customizr
    * @since Customizr 2.0
    */
-     function czr_slider_cb() {
+     function czr_fn_slider_cb() {
 
       $nonce = $_POST['SliderCheckNonce'];
       // check if the submitted nonce matches with the generated nonce we created earlier
@@ -1336,16 +1336,16 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
         $tc_post_id         = $_POST['tc_post_id'];
 
         //save $_POST var in DB
-        $this -> czr_slider_ajax_save( $tc_post_id);
+        $this -> czr_fn_slider_ajax_save( $tc_post_id);
 
         //check if we are in the post or attachment screen and select the appropriate rendering
         //we use the post_slider var defined in tc_ajax_slider.js
         if ( isset( $_POST['tc_post_type'])) {
           if( $_POST['tc_post_type'] == 'post' ) {
-            $this -> czr_get_post_slider_infos( $tc_post_id );
+            $this -> czr_fn_get_post_slider_infos( $tc_post_id );
           }
           else {
-            $this -> czr_get_attachment_slider_infos( $tc_post_id );
+            $this -> czr_fn_get_attachment_slider_infos( $tc_post_id );
           }
         }
         //echo $_POST['slider_id'];
@@ -1365,7 +1365,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
        * @package Customizr
        * @since Customizr 1.0
        */
-        function czr_slider_admin_scripts( $hook) {
+        function czr_fn_slider_admin_scripts( $hook) {
         global $post;
 
         $_min_version = ( defined('WP_DEBUG') && true === WP_DEBUG ) ? '' : '.min';
@@ -1453,17 +1453,17 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
   ------------- ATTACHMENT FIELDS FILTER IF WP < 3.5 -------------
   ----------------------------------------------------------------
   */
-      function czr_attachment_filter( $form_fields, $post = null) {
-          $this -> czr_attachment_slider_box ( $post);
+      function czr_fn_attachment_filter( $form_fields, $post = null) {
+          $this -> czr_fn_attachment_slider_box ( $post);
            return $form_fields;
       }
 
 
-      function czr_attachment_save_filter( $post, $attachment ) {
+      function czr_fn_attachment_save_filter( $post, $attachment ) {
           if ( isset( $_POST['tc_post_id']))
            $postid = $_POST['tc_post_id'];
 
-          $this -> czr_slide_save( $postid );
+          $this -> czr_fn_slide_save( $postid );
 
           return $post;
       }

--- a/inc/admin/class-admin-meta_boxes.php
+++ b/inc/admin/class-admin-meta_boxes.php
@@ -11,8 +11,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_meta_boxes' ) ) :
-  class TC_meta_boxes {
+if ( ! class_exists( 'CZR_meta_boxes' ) ) :
+  class CZR_meta_boxes {
       static $instance;
       function __construct () {
           self::$instance =& $this;
@@ -125,13 +125,13 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
 
             //Generates layouts select list array
             $layouts              = array();
-            $global_layout        = apply_filters( 'tc_global_layout' , TC_init::$instance -> global_layout );
+            $global_layout        = apply_filters( 'tc_global_layout' , CZR_init::$instance -> global_layout );
             foreach ( $global_layout as $key => $value ) {
               $layouts[$key]      = call_user_func( '__' , $value['metabox'] , 'customizr' );
             }
 
             //by default we apply the global default layout
-            $tc_sidebar_default_layout  = esc_attr( TC_utils::$inst->tc_opt('tc_sidebar_global_layout') );
+            $tc_sidebar_default_layout  = esc_attr( CZR_utils::$inst->tc_opt('tc_sidebar_global_layout') );
 
             //get the lists of eligible post types + normal posts (not pages!)
             $args                 = array(
@@ -146,16 +146,16 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
 
             //eligible posts (and custom posts types) default layout
             if ( in_array($post->post_type , $eligible_posts ) ) {
-              $tc_sidebar_default_layout  = esc_attr( TC_utils::$inst->tc_opt('tc_sidebar_post_layout') );
+              $tc_sidebar_default_layout  = esc_attr( CZR_utils::$inst->tc_opt('tc_sidebar_post_layout') );
             }
 
             //page default layout
             if ( $post->post_type == 'page' ) {
-              $tc_sidebar_default_layout  = esc_attr( TC_utils::$inst->tc_opt('tc_sidebar_page_layout') );
+              $tc_sidebar_default_layout  = esc_attr( CZR_utils::$inst->tc_opt('tc_sidebar_page_layout') );
             }
 
             //check if the 'force default layout' option is checked
-            $force_layout                 = esc_attr( TC_utils::$inst->tc_opt('tc_sidebar_force_layout') );
+            $force_layout                 = esc_attr( CZR_utils::$inst->tc_opt('tc_sidebar_force_layout') );
 
 
             ?>
@@ -261,7 +261,7 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
           if ( isset($options['tc_sliders']) ) {
             $sliders                   = $options['tc_sliders'];
           }else
-            $sliders                   = array();  
+            $sliders                   = array();
 
           //post slider fields setup
           $post_slider_id            = 'post_slider_field';
@@ -283,9 +283,9 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
           //sliders field
           $slider_id                 = 'slider_field';
 
-          if( $post_slider_check_value == true ): 
+          if( $post_slider_check_value == true ):
               $selectable_sliders    = apply_filters( 'tc_post_selectable_sliders', $sliders );
-              if ( isset( $selectable_sliders ) && ! empty( $selectable_sliders ) ): 
+              if ( isset( $selectable_sliders ) && ! empty( $selectable_sliders ) ):
 
           ?>
               <div class="meta-box-item-title">
@@ -313,7 +313,7 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
                       printf( '<option value="%1$s" %2$s> %3$s</option>',
                           esc_attr( $id ),
                           selected( $current_post_slider, esc_attr( $id ), $echo = false ),
-                          $label  
+                          $label
                       );
                     }
                   ?>
@@ -358,10 +358,10 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
                         </div>
                       </div>
                     <?php  do_action( '__show_slides' , $current_post_slides, $current_attachement_id = null); ?>
-                <?php else: //there are no slides 
+                <?php else: //there are no slides
                   do_action( '__no_slides', $postid, $current_post_slider );
                 ?>
-              <?php endif; //slides? ?>      
+              <?php endif; //slides? ?>
             <?php else://if no slider created yet and no slider of posts addon?>
 
                  <div class="meta-box-item-content">

--- a/inc/admin/class-admin-meta_boxes.php
+++ b/inc/admin/class-admin-meta_boxes.php
@@ -16,19 +16,19 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
       static $instance;
       function __construct () {
           self::$instance =& $this;
-          add_action( 'add_meta_boxes'                       , array( $this , 'tc_post_meta_boxes' ));
-          add_action( '__post_slider_infos'                  , array( $this , 'tc_get_post_slider_infos' ));
-          add_action( 'save_post'                            , array( $this , 'tc_post_fields_save' ));
+          add_action( 'add_meta_boxes'                       , array( $this , 'czr_post_meta_boxes' ));
+          add_action( '__post_slider_infos'                  , array( $this , 'czr_get_post_slider_infos' ));
+          add_action( 'save_post'                            , array( $this , 'czr_post_fields_save' ));
 
-          add_action( 'add_meta_boxes'                       , array( $this , 'tc_attachment_meta_box' ));
-          add_action( '__attachment_slider_infos'            , array( $this , 'tc_get_attachment_slider_infos' ));
-          add_action( 'edit_attachment'                      , array( $this , 'tc_slide_save' ));
+          add_action( 'add_meta_boxes'                       , array( $this , 'czr_attachment_meta_box' ));
+          add_action( '__attachment_slider_infos'            , array( $this , 'czr_get_attachment_slider_infos' ));
+          add_action( 'edit_attachment'                      , array( $this , 'czr_slide_save' ));
 
-          add_action( '__show_slides'                        , array( $this , 'tc_show_slides' ), 10, 2);
+          add_action( '__show_slides'                        , array( $this , 'czr_show_slides' ), 10, 2);
 
-          add_action( 'wp_ajax_slider_action'                , array( $this , 'tc_slider_cb' ));
+          add_action( 'wp_ajax_slider_action'                , array( $this , 'czr_slider_cb' ));
 
-          add_action( 'admin_enqueue_scripts'                , array( $this , 'tc_slider_admin_scripts' ));
+          add_action( 'admin_enqueue_scripts'                , array( $this , 'czr_slider_admin_scripts' ));
 
 
 
@@ -40,8 +40,8 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
          */
         global $wp_version;
         if (version_compare( $wp_version, '3.5' , '<' ) ) {
-            add_filter( 'attachment_fields_to_edit'           , array( $this , 'tc_attachment_filter' ), 11, 2 );
-            add_filter( 'attachment_fields_to_save'           , array( $this , 'tc_attachment_save_filter' ), 11, 2 );
+            add_filter( 'attachment_fields_to_edit'           , array( $this , 'czr_attachment_filter' ), 11, 2 );
+            add_filter( 'attachment_fields_to_save'           , array( $this , 'czr_attachment_save_filter' ), 11, 2 );
           }
 
       }//end of __construct
@@ -85,7 +85,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
               add_meta_box(
                   'layout_sectionid' ,
                   __( 'Layout Options' , 'customizr' ),
-                  array( $this , 'tc_post_layout_box' ),
+                  array( $this , 'czr_post_layout_box' ),
                   $screen,
                   ( 'page' == $screen | 'post' == $screen ) ? 'side' : 'normal',//displays meta box below editor for custom post types
                   apply_filters('tc_post_meta_boxes_priority' , 'high', $screen )
@@ -93,7 +93,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
               add_meta_box(
                   'slider_sectionid' ,
                   __( 'Slider Options' , 'customizr' ),
-                  array( $this , 'tc_post_slider_box' ),
+                  array( $this , 'czr_post_slider_box' ),
                   $screen,
                   'normal' ,
                   apply_filters('tc_post_meta_boxes_priority' , 'high', $screen)
@@ -489,7 +489,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
               add_meta_box(
                   'slider_sectionid' ,
                   __( 'Slider Options' , 'customizr' ),
-                  array( $this , 'tc_attachment_slider_box' ),
+                  array( $this , 'czr_attachment_slider_box' ),
                   $screen/*,
                   'side' ,
                   'high'*/

--- a/inc/admin/class-admin-meta_boxes.php
+++ b/inc/admin/class-admin-meta_boxes.php
@@ -131,7 +131,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
             }
 
             //by default we apply the global default layout
-            $tc_sidebar_default_layout  = esc_attr( CZR_utils::$inst->tc_opt('tc_sidebar_global_layout') );
+            $tc_sidebar_default_layout  = esc_attr( CZR_utils::$inst->czr_opt('tc_sidebar_global_layout') );
 
             //get the lists of eligible post types + normal posts (not pages!)
             $args                 = array(
@@ -146,16 +146,16 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
 
             //eligible posts (and custom posts types) default layout
             if ( in_array($post->post_type , $eligible_posts ) ) {
-              $tc_sidebar_default_layout  = esc_attr( CZR_utils::$inst->tc_opt('tc_sidebar_post_layout') );
+              $tc_sidebar_default_layout  = esc_attr( CZR_utils::$inst->czr_opt('tc_sidebar_post_layout') );
             }
 
             //page default layout
             if ( $post->post_type == 'page' ) {
-              $tc_sidebar_default_layout  = esc_attr( CZR_utils::$inst->tc_opt('tc_sidebar_page_layout') );
+              $tc_sidebar_default_layout  = esc_attr( CZR_utils::$inst->czr_opt('tc_sidebar_page_layout') );
             }
 
             //check if the 'force default layout' option is checked
-            $force_layout                 = esc_attr( CZR_utils::$inst->tc_opt('tc_sidebar_force_layout') );
+            $force_layout                 = esc_attr( CZR_utils::$inst->czr_opt('tc_sidebar_force_layout') );
 
 
             ?>
@@ -1300,7 +1300,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
                 }//end foreach
                 //attachments
                 if( $tc_post_type == 'attachment' )
-                  $this -> tc_slide_save( $post_ID );
+                  $this -> czr_slide_save( $post_ID );
 
                 do_action( "__after_ajax_save_slider_{$tc_post_type}", $_POST, $tc_slider_fields );
             }//function
@@ -1336,16 +1336,16 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
         $tc_post_id         = $_POST['tc_post_id'];
 
         //save $_POST var in DB
-        $this -> tc_slider_ajax_save( $tc_post_id);
+        $this -> czr_slider_ajax_save( $tc_post_id);
 
         //check if we are in the post or attachment screen and select the appropriate rendering
         //we use the post_slider var defined in tc_ajax_slider.js
         if ( isset( $_POST['tc_post_type'])) {
           if( $_POST['tc_post_type'] == 'post' ) {
-            $this -> tc_get_post_slider_infos( $tc_post_id );
+            $this -> czr_get_post_slider_infos( $tc_post_id );
           }
           else {
-            $this -> tc_get_attachment_slider_infos( $tc_post_id );
+            $this -> czr_get_attachment_slider_infos( $tc_post_id );
           }
         }
         //echo $_POST['slider_id'];
@@ -1454,7 +1454,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
   ----------------------------------------------------------------
   */
       function czr_attachment_filter( $form_fields, $post = null) {
-          $this -> tc_attachment_slider_box ( $post);
+          $this -> czr_attachment_slider_box ( $post);
            return $form_fields;
       }
 
@@ -1463,7 +1463,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
           if ( isset( $_POST['tc_post_id']))
            $postid = $_POST['tc_post_id'];
 
-          $this -> tc_slide_save( $postid );
+          $this -> czr_slide_save( $postid );
 
           return $post;
       }

--- a/inc/admin/class-fire-admin_init.php
+++ b/inc/admin/class-fire-admin_init.php
@@ -11,8 +11,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_admin_init' ) ) :
-  class TC_admin_init {
+if ( ! class_exists( 'CZR_admin_init' ) ) :
+  class CZR_admin_init {
     static $instance;
     function __construct () {
       self::$instance =& $this;
@@ -58,10 +58,10 @@ if ( ! class_exists( 'TC_admin_init' ) ) :
       if ( wp_is_post_revision( $post_id ) || ( ! empty($post) && 'auto-draft' == $post->post_status ) )
         return;
 
-      if ( ! class_exists( 'TC_post_thumbnails' ) )
-        TC___::$instance -> tc__( array('content' => array( array('inc/parts', 'post_thumbnails') ) ), true );
+      if ( ! class_exists( 'CZR_post_thumbnails' ) )
+        CZR___::$instance -> tc__( array('content' => array( array('inc/parts', 'post_thumbnails') ) ), true );
 
-      TC_post_thumbnails::$instance -> tc_set_thumb_info( $post_id );
+      CZR_post_thumbnails::$instance -> tc_set_thumb_info( $post_id );
     }
 
     /*
@@ -73,18 +73,18 @@ if ( ! class_exists( 'TC_admin_init' ) ) :
     function tc_refresh_posts_slider( $post_id, $post = array() ) {
       // no need to build up/refresh the transient it we don't use the posts slider
       // since we always delete the transient when entering the preview.
-      if ( 'tc_posts_slider' != TC_utils::$inst->tc_opt( 'tc_front_slider' ) || ! apply_filters('tc_posts_slider_use_transient' , true ) )
+      if ( 'tc_posts_slider' != CZR_utils::$inst->tc_opt( 'tc_front_slider' ) || ! apply_filters('tc_posts_slider_use_transient' , true ) )
         return;
 
       if ( wp_is_post_revision( $post_id ) || ( ! empty($post) && 'auto-draft' == $post->post_status ) )
         return;
 
-      if ( ! class_exists( 'TC_post_thumbnails' ) )
-        TC___::$instance -> tc__( array('content' => array( array('inc/parts', 'post_thumbnails') ) ), true );
-      if ( ! class_exists( 'TC_slider' ) )
-        TC___::$instance -> tc__( array('content' => array( array('inc/parts', 'slider') ) ), true );
+      if ( ! class_exists( 'CZR_post_thumbnails' ) )
+        CZR___::$instance -> tc__( array('content' => array( array('inc/parts', 'post_thumbnails') ) ), true );
+      if ( ! class_exists( 'CZR_slider' ) )
+        CZR___::$instance -> tc__( array('content' => array( array('inc/parts', 'slider') ) ), true );
 
-      TC_slider::$instance -> tc_cache_posts_slider();
+      CZR_slider::$instance -> tc_cache_posts_slider();
     }
 
 
@@ -107,15 +107,15 @@ if ( ! class_exists( 'TC_admin_init' ) ) :
 
     function tc_refresh_term_picker_options( $term, $option_name, $option_group = null ) {
        //home/blog posts category picker
-       $_option = TC_utils::$inst -> tc_opt( $option_name, $option_group, $use_default = false );
+       $_option = CZR_utils::$inst -> tc_opt( $option_name, $option_group, $use_default = false );
        if ( is_array( $_option ) && ! empty( $_option ) && in_array( $term, $_option ) )
          //update the option
-         TC_utils::$inst -> tc_set_option( $option_name, array_diff( $_option, (array)$term ) );
+         CZR_utils::$inst -> tc_set_option( $option_name, array_diff( $_option, (array)$term ) );
 
        //alternative, cycle throughout the cats and keep just the existent ones
        /*if ( is_array( $blog_cats ) && ! empty( $blog_cats ) ) {
          //update the option
-         TC_utils::$inst -> tc_set_option( 'tc_blog_restrict_by_cat', array_filter( $blog_cats, array(TC_utils::$inst, 'tc_category_id_exists' ) ) );
+         CZR_utils::$inst -> tc_set_option( 'tc_blog_restrict_by_cat', array_filter( $blog_cats, array(CZR_utils::$inst, 'tc_category_id_exists' ) ) );
        }*/
     }
 
@@ -127,8 +127,8 @@ if ( ! class_exists( 'TC_admin_init' ) ) :
     * @since Customizr 3.2.10
     */
     function tc_maybe_add_gfonts_to_editor() {
-      $_font_pair         = esc_attr( TC_utils::$inst->tc_opt('tc_fonts') );
-      $_all_font_pairs    = TC_init::$instance -> font_pairs;
+      $_font_pair         = esc_attr( CZR_utils::$inst->tc_opt('tc_fonts') );
+      $_all_font_pairs    = CZR_init::$instance -> font_pairs;
       if ( false === strpos($_font_pair,'_g_') )
         return;
       //Commas in a URL need to be encoded before the string can be passed to add_editor_style.
@@ -136,7 +136,7 @@ if ( ! class_exists( 'TC_admin_init' ) ) :
         str_replace(
           ',',
           '%2C',
-          sprintf( '//fonts.googleapis.com/css?family=%s', TC_utils::$inst -> tc_get_font( 'single' , $_font_pair ) )
+          sprintf( '//fonts.googleapis.com/css?family=%s', CZR_utils::$inst -> tc_get_font( 'single' , $_font_pair ) )
         )
       );
     }
@@ -214,7 +214,7 @@ if ( ! class_exists( 'TC_admin_init' ) ) :
     function tc_add_editor_style() {
       $_stylesheets = array(
           TC_BASE_URL.'inc/admin/css/editor-style.css',
-          TC_init::$instance -> tc_get_style_src() , get_stylesheet_uri()
+          CZR_init::$instance -> tc_get_style_src() , get_stylesheet_uri()
       );
 
       if ( apply_filters( 'tc_add_custom_fonts_to_editor' , false != $this -> tc_maybe_add_gfonts_to_editor() ) )
@@ -242,14 +242,14 @@ if ( ! class_exists( 'TC_admin_init' ) ) :
         return $init;
 
       //some plugins fire tiny mce editor in the customizer
-      //in this case, the TC_resource class has to be loaded
-      if ( ! class_exists('TC_resources') )
-        TC___::$instance -> tc__( array('fire' => array( array('inc' , 'resources') ) ), true );
+      //in this case, the CZR_resource class has to be loaded
+      if ( ! class_exists('CZR_resources') )
+        CZR___::$instance -> tc__( array('fire' => array( array('inc' , 'resources') ) ), true );
 
       //fonts
-      $_css = TC_resources::$instance -> tc_write_fonts_inline_css( '', 'mce-content-body');
+      $_css = CZR_resources::$instance -> tc_write_fonts_inline_css( '', 'mce-content-body');
       //icons
-      $_css .= TC_resources::$instance -> tc_get_inline_font_icons_css();
+      $_css .= CZR_resources::$instance -> tc_get_inline_font_icons_css();
       $init['content_style'] =  trim(preg_replace('/\s+/', ' ', $_css ) );
 
       return $init;
@@ -269,8 +269,8 @@ if ( ! class_exists( 'TC_admin_init' ) ) :
     * hook : admin_notices
     */
     function tc_may_be_display_update_notice() {
-      $opt_name                   = "customizr-pro" == TC___::$theme_name ? 'last_update_notice_pro' : 'last_update_notice';
-      $last_update_notice_values  = TC_utils::$inst -> tc_opt($opt_name);
+      $opt_name                   = "customizr-pro" == CZR___::$theme_name ? 'last_update_notice_pro' : 'last_update_notice';
+      $last_update_notice_values  = CZR_utils::$inst -> tc_opt($opt_name);
       $show_new_notice = false;
 
       if ( ! $last_update_notice_values || ! is_array($last_update_notice_values) ) {
@@ -278,9 +278,9 @@ if ( ! class_exists( 'TC_admin_init' ) ) :
         // 1) initialize it => set it to the current Customizr version, displayed 0 times.
         // 2) update in db
         $last_update_notice_values = array( "version" => CUSTOMIZR_VER, "display_count" => 0 );
-        TC_utils::$inst->tc_set_option( $opt_name, $last_update_notice_values );
+        CZR_utils::$inst->tc_set_option( $opt_name, $last_update_notice_values );
         //already user of the theme ?
-        if ( TC_utils::$inst->tc_user_started_before_version( CUSTOMIZR_VER, CUSTOMIZR_VER ) )
+        if ( CZR_utils::$inst->tc_user_started_before_version( CUSTOMIZR_VER, CUSTOMIZR_VER ) )
           $show_new_notice = true;
       }
 
@@ -297,13 +297,13 @@ if ( ! class_exists( 'TC_admin_init' ) ) :
           (int) $_db_displayed_count++;
           $last_update_notice_values["display_count"] = $_db_displayed_count;
           //updates the option val with the new count
-          TC_utils::$inst->tc_set_option( $opt_name, $last_update_notice_values );
+          CZR_utils::$inst->tc_set_option( $opt_name, $last_update_notice_values );
         }
         //CASE 2 : displayed 5 times => automatic dismiss
         else {
           //reset option value with new version and counter to 0
           $new_val  = array( "version" => CUSTOMIZR_VER, "display_count" => 0 );
-          TC_utils::$inst->tc_set_option( $opt_name, $new_val );
+          CZR_utils::$inst->tc_set_option( $opt_name, $new_val );
         }//end else
       }//end if
 
@@ -318,7 +318,7 @@ if ( ! class_exists( 'TC_admin_init' ) ) :
               'tc_update_notice',
               sprintf('<h3>%1$s %2$s %3$s %4$s :D</h3>',
                 __( "Good, you've just upgraded to", "customizr"),
-                "customizr-pro" == TC___::$theme_name ? 'Customizr Pro' : 'Customizr',
+                "customizr-pro" == CZR___::$theme_name ? 'Customizr Pro' : 'Customizr',
                 __( "version", "customizr"),
                 CUSTOMIZR_VER
               )
@@ -329,7 +329,7 @@ if ( ! class_exists( 'TC_admin_init' ) ) :
               'tc_update_notice',
               sprintf( '<h4>%1$s</h4><strong><a class="button button-primary" href="%2$s" title="%3$s" target="_blank">%3$s &raquo;</a> <a class="button button-primary" href="%4$s" title="%5$s" target="_blank">%5$s &raquo;</a></strong>',
                 __( "We'd like to introduce the new features we've been working on.", "customizr"),
-                TC_WEBSITE . "category/customizr-releases/",
+                CZR_WEBSITE . "category/customizr-releases/",
                 __( "Read the latest release notes" , "customizr" ),
                 esc_url('demo.presscustomizr.com'),
                 __( "Visit the demo", "customizr" )
@@ -357,10 +357,10 @@ if ( ! class_exists( 'TC_admin_init' ) ) :
     */
     function tc_dismiss_update_notice_action() {
       check_ajax_referer( 'dismiss-update-notice-nonce', 'dismissUpdateNoticeNonce' );
-      $opt_name = "customizr-pro" == TC___::$theme_name ? 'last_update_notice_pro' : 'last_update_notice';
+      $opt_name = "customizr-pro" == CZR___::$theme_name ? 'last_update_notice_pro' : 'last_update_notice';
       //reset option value with new version and counter to 0
       $new_val  = array( "version" => CUSTOMIZR_VER, "display_count" => 0 );
-      TC_utils::$inst->tc_set_option( $opt_name, $new_val );
+      CZR_utils::$inst->tc_set_option( $opt_name, $new_val );
       wp_die();
     }
 

--- a/inc/admin/class-fire-admin_init.php
+++ b/inc/admin/class-fire-admin_init.php
@@ -59,9 +59,9 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
         return;
 
       if ( ! class_exists( 'CZR_post_thumbnails' ) )
-        CZR___::$instance -> tc__( array('content' => array( array('inc/parts', 'post_thumbnails') ) ), true );
+        CZR___::$instance -> czr__( array('content' => array( array('inc/parts', 'post_thumbnails') ) ), true );
 
-      CZR_post_thumbnails::$instance -> tc_set_thumb_info( $post_id );
+      CZR_post_thumbnails::$instance -> czr_set_thumb_info( $post_id );
     }
 
     /*
@@ -73,18 +73,18 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
     function czr_refresh_posts_slider( $post_id, $post = array() ) {
       // no need to build up/refresh the transient it we don't use the posts slider
       // since we always delete the transient when entering the preview.
-      if ( 'tc_posts_slider' != CZR_utils::$inst->tc_opt( 'tc_front_slider' ) || ! apply_filters('tc_posts_slider_use_transient' , true ) )
+      if ( 'tc_posts_slider' != CZR_utils::$inst->czr_opt( 'tc_front_slider' ) || ! apply_filters('tc_posts_slider_use_transient' , true ) )
         return;
 
       if ( wp_is_post_revision( $post_id ) || ( ! empty($post) && 'auto-draft' == $post->post_status ) )
         return;
 
       if ( ! class_exists( 'CZR_post_thumbnails' ) )
-        CZR___::$instance -> tc__( array('content' => array( array('inc/parts', 'post_thumbnails') ) ), true );
+        CZR___::$instance -> czr__( array('content' => array( array('inc/parts', 'post_thumbnails') ) ), true );
       if ( ! class_exists( 'CZR_slider' ) )
-        CZR___::$instance -> tc__( array('content' => array( array('inc/parts', 'slider') ) ), true );
+        CZR___::$instance -> czr__( array('content' => array( array('inc/parts', 'slider') ) ), true );
 
-      CZR_slider::$instance -> tc_cache_posts_slider();
+      CZR_slider::$instance -> czr_cache_posts_slider();
     }
 
 
@@ -99,7 +99,7 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
 
         //delete categories based options
         case 'category':
-          $this -> tc_refresh_term_picker_options( $term, $option_name = 'tc_blog_restrict_by_cat' );
+          $this -> czr_refresh_term_picker_options( $term, $option_name = 'tc_blog_restrict_by_cat' );
           break;
       }
     }
@@ -107,15 +107,15 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
 
     function czr_refresh_term_picker_options( $term, $option_name, $option_group = null ) {
        //home/blog posts category picker
-       $_option = CZR_utils::$inst -> tc_opt( $option_name, $option_group, $use_default = false );
+       $_option = CZR_utils::$inst -> czr_opt( $option_name, $option_group, $use_default = false );
        if ( is_array( $_option ) && ! empty( $_option ) && in_array( $term, $_option ) )
          //update the option
-         CZR_utils::$inst -> tc_set_option( $option_name, array_diff( $_option, (array)$term ) );
+         CZR_utils::$inst -> czr_set_option( $option_name, array_diff( $_option, (array)$term ) );
 
        //alternative, cycle throughout the cats and keep just the existent ones
        /*if ( is_array( $blog_cats ) && ! empty( $blog_cats ) ) {
          //update the option
-         CZR_utils::$inst -> tc_set_option( 'tc_blog_restrict_by_cat', array_filter( $blog_cats, array(CZR_utils::$inst, 'tc_category_id_exists' ) ) );
+         CZR_utils::$inst -> czr_set_option( 'tc_blog_restrict_by_cat', array_filter( $blog_cats, array(CZR_utils::$inst, 'tc_category_id_exists' ) ) );
        }*/
     }
 
@@ -127,7 +127,7 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
     * @since Customizr 3.2.10
     */
     function czr_maybe_add_gfonts_to_editor() {
-      $_font_pair         = esc_attr( CZR_utils::$inst->tc_opt('tc_fonts') );
+      $_font_pair         = esc_attr( CZR_utils::$inst->czr_opt('tc_fonts') );
       $_all_font_pairs    = CZR_init::$instance -> font_pairs;
       if ( false === strpos($_font_pair,'_g_') )
         return;
@@ -136,7 +136,7 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
         str_replace(
           ',',
           '%2C',
-          sprintf( '//fonts.googleapis.com/css?family=%s', CZR_utils::$inst -> tc_get_font( 'single' , $_font_pair ) )
+          sprintf( '//fonts.googleapis.com/css?family=%s', CZR_utils::$inst -> czr_get_font( 'single' , $_font_pair ) )
         )
       );
     }
@@ -214,11 +214,11 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
     function czr_add_editor_style() {
       $_stylesheets = array(
           TC_BASE_URL.'inc/admin/css/editor-style.css',
-          CZR_init::$instance -> tc_get_style_src() , get_stylesheet_uri()
+          CZR_init::$instance -> czr_get_style_src() , get_stylesheet_uri()
       );
 
-      if ( apply_filters( 'tc_add_custom_fonts_to_editor' , false != $this -> tc_maybe_add_gfonts_to_editor() ) )
-        $_stylesheets = array_merge( $_stylesheets , $this -> tc_maybe_add_gfonts_to_editor() );
+      if ( apply_filters( 'tc_add_custom_fonts_to_editor' , false != $this -> czr_maybe_add_gfonts_to_editor() ) )
+        $_stylesheets = array_merge( $_stylesheets , $this -> czr_maybe_add_gfonts_to_editor() );
 
       add_editor_style( $_stylesheets );
     }
@@ -244,12 +244,12 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
       //some plugins fire tiny mce editor in the customizer
       //in this case, the CZR_resource class has to be loaded
       if ( ! class_exists('CZR_resources') )
-        CZR___::$instance -> tc__( array('fire' => array( array('inc' , 'resources') ) ), true );
+        CZR___::$instance -> czr__( array('fire' => array( array('inc' , 'resources') ) ), true );
 
       //fonts
-      $_css = CZR_resources::$instance -> tc_write_fonts_inline_css( '', 'mce-content-body');
+      $_css = CZR_resources::$instance -> czr_write_fonts_inline_css( '', 'mce-content-body');
       //icons
-      $_css .= CZR_resources::$instance -> tc_get_inline_font_icons_css();
+      $_css .= CZR_resources::$instance -> czr_get_inline_font_icons_css();
       $init['content_style'] =  trim(preg_replace('/\s+/', ' ', $_css ) );
 
       return $init;
@@ -270,7 +270,7 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
     */
     function czr_may_be_display_update_notice() {
       $opt_name                   = "customizr-pro" == CZR___::$theme_name ? 'last_update_notice_pro' : 'last_update_notice';
-      $last_update_notice_values  = CZR_utils::$inst -> tc_opt($opt_name);
+      $last_update_notice_values  = CZR_utils::$inst -> czr_opt($opt_name);
       $show_new_notice = false;
 
       if ( ! $last_update_notice_values || ! is_array($last_update_notice_values) ) {
@@ -278,9 +278,9 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
         // 1) initialize it => set it to the current Customizr version, displayed 0 times.
         // 2) update in db
         $last_update_notice_values = array( "version" => CUSTOMIZR_VER, "display_count" => 0 );
-        CZR_utils::$inst->tc_set_option( $opt_name, $last_update_notice_values );
+        CZR_utils::$inst->czr_set_option( $opt_name, $last_update_notice_values );
         //already user of the theme ?
-        if ( CZR_utils::$inst->tc_user_started_before_version( CUSTOMIZR_VER, CUSTOMIZR_VER ) )
+        if ( CZR_utils::$inst->czr_user_started_before_version( CUSTOMIZR_VER, CUSTOMIZR_VER ) )
           $show_new_notice = true;
       }
 
@@ -297,13 +297,13 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
           (int) $_db_displayed_count++;
           $last_update_notice_values["display_count"] = $_db_displayed_count;
           //updates the option val with the new count
-          CZR_utils::$inst->tc_set_option( $opt_name, $last_update_notice_values );
+          CZR_utils::$inst->czr_set_option( $opt_name, $last_update_notice_values );
         }
         //CASE 2 : displayed 5 times => automatic dismiss
         else {
           //reset option value with new version and counter to 0
           $new_val  = array( "version" => CUSTOMIZR_VER, "display_count" => 0 );
-          CZR_utils::$inst->tc_set_option( $opt_name, $new_val );
+          CZR_utils::$inst->czr_set_option( $opt_name, $new_val );
         }//end else
       }//end if
 
@@ -360,7 +360,7 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
       $opt_name = "customizr-pro" == CZR___::$theme_name ? 'last_update_notice_pro' : 'last_update_notice';
       //reset option value with new version and counter to 0
       $new_val  = array( "version" => CUSTOMIZR_VER, "display_count" => 0 );
-      CZR_utils::$inst->tc_set_option( $opt_name, $new_val );
+      CZR_utils::$inst->czr_set_option( $opt_name, $new_val );
       wp_die();
     }
 

--- a/inc/admin/class-fire-admin_init.php
+++ b/inc/admin/class-fire-admin_init.php
@@ -17,29 +17,29 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
     function __construct () {
       self::$instance =& $this;
       //enqueue additional styling for admin screens
-      add_action( 'admin_init'            , array( $this , 'czr_admin_style' ) );
+      add_action( 'admin_init'            , array( $this , 'czr_fn_admin_style' ) );
 
       //Load the editor-style specific (post formats and RTL), the active skin, the user style.css
       //add user defined fonts in the editor style (@see the query args add_editor_style below)
-      add_action( 'after_setup_theme'     , array( $this, 'czr_add_editor_style') );
+      add_action( 'after_setup_theme'     , array( $this, 'czr_fn_add_editor_style') );
 
-      add_filter( 'tiny_mce_before_init'  , array( $this, 'czr_user_defined_tinymce_css') );
+      add_filter( 'tiny_mce_before_init'  , array( $this, 'czr_fn_user_defined_tinymce_css') );
       //refresh the post / CPT / page thumbnail on save. Since v3.3.2.
-      add_action ( 'save_post'            , array( $this , 'czr_refresh_thumbnail') , 10, 2);
+      add_action ( 'save_post'            , array( $this , 'czr_fn_refresh_thumbnail') , 10, 2);
 
       //refresh the posts slider transient on save_post. Since v3.4.9.
-      add_action ( 'save_post'            , array( $this , 'czr_refresh_posts_slider'), 20, 2 );
+      add_action ( 'save_post'            , array( $this , 'czr_fn_refresh_posts_slider'), 20, 2 );
       //refresh the posts slider transient on permanent post/attachment deletion. Since v3.4.9.
-      add_action ( 'deleted_post'         , array( $this , 'czr_refresh_posts_slider') );
+      add_action ( 'deleted_post'         , array( $this , 'czr_fn_refresh_posts_slider') );
 
       //refresh the terms array (categories/tags pickers options) on term deletion
-      add_action ( 'delete_term'          , array( $this, 'czr_refresh_terms_pickers_options_cb'), 10, 3 );
+      add_action ( 'delete_term'          , array( $this, 'czr_fn_refresh_terms_pickers_options_cb'), 10, 3 );
 
       //UPDATE NOTICE
-      add_action( 'admin_notices'         , array( $this, 'czr_may_be_display_update_notice') );
+      add_action( 'admin_notices'         , array( $this, 'czr_fn_may_be_display_update_notice') );
       //always add the ajax action
-      add_action( 'wp_ajax_dismiss_customizr_update_notice'    , array( $this , 'czr_dismiss_update_notice_action' ) );
-      add_action( 'admin_footer'                  , array( $this , 'czr_write_ajax_dismis_script' ) );
+      add_action( 'wp_ajax_dismiss_customizr_update_notice'    , array( $this , 'czr_fn_dismiss_update_notice_action' ) );
+      add_action( 'admin_footer'                  , array( $this , 'czr_fn_write_ajax_dismis_script' ) );
       /* beautify admin notice text using some defaults the_content filter callbacks */
       foreach ( array( 'wptexturize', 'convert_smilies', 'wpautop') as $callback )
         add_filter( 'tc_update_notice', $callback );
@@ -53,15 +53,15 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
     * @package Customizr
     * @since Customizr 3.3.2
     */
-    function czr_refresh_thumbnail( $post_id, $post ) {
+    function czr_fn_refresh_thumbnail( $post_id, $post ) {
       // If this is just a revision, don't send the email.
       if ( wp_is_post_revision( $post_id ) || ( ! empty($post) && 'auto-draft' == $post->post_status ) )
         return;
 
       if ( ! class_exists( 'CZR_post_thumbnails' ) )
-        CZR___::$instance -> czr__( array('content' => array( array('inc/parts', 'post_thumbnails') ) ), true );
+        CZR___::$instance -> czr_fn__( array('content' => array( array('inc/parts', 'post_thumbnails') ) ), true );
 
-      CZR_post_thumbnails::$instance -> czr_set_thumb_info( $post_id );
+      CZR_post_thumbnails::$instance -> czr_fn_set_thumb_info( $post_id );
     }
 
     /*
@@ -70,21 +70,21 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
     * @package Customizr
     * @since Customizr 3.4.9
     */
-    function czr_refresh_posts_slider( $post_id, $post = array() ) {
+    function czr_fn_refresh_posts_slider( $post_id, $post = array() ) {
       // no need to build up/refresh the transient it we don't use the posts slider
       // since we always delete the transient when entering the preview.
-      if ( 'tc_posts_slider' != CZR_utils::$inst->czr_opt( 'tc_front_slider' ) || ! apply_filters('tc_posts_slider_use_transient' , true ) )
+      if ( 'tc_posts_slider' != CZR_utils::$inst->czr_fn_opt( 'tc_front_slider' ) || ! apply_filters('tc_posts_slider_use_transient' , true ) )
         return;
 
       if ( wp_is_post_revision( $post_id ) || ( ! empty($post) && 'auto-draft' == $post->post_status ) )
         return;
 
       if ( ! class_exists( 'CZR_post_thumbnails' ) )
-        CZR___::$instance -> czr__( array('content' => array( array('inc/parts', 'post_thumbnails') ) ), true );
+        CZR___::$instance -> czr_fn__( array('content' => array( array('inc/parts', 'post_thumbnails') ) ), true );
       if ( ! class_exists( 'CZR_slider' ) )
-        CZR___::$instance -> czr__( array('content' => array( array('inc/parts', 'slider') ) ), true );
+        CZR___::$instance -> czr_fn__( array('content' => array( array('inc/parts', 'slider') ) ), true );
 
-      CZR_slider::$instance -> czr_cache_posts_slider();
+      CZR_slider::$instance -> czr_fn_cache_posts_slider();
     }
 
 
@@ -94,28 +94,28 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
     * @package Customizr
     * @since Customizr 3.4.10
     */
-    function czr_refresh_terms_pickers_options_cb( $term, $tt_id, $taxonomy ) {
+    function czr_fn_refresh_terms_pickers_options_cb( $term, $tt_id, $taxonomy ) {
       switch ( $taxonomy ) {
 
         //delete categories based options
         case 'category':
-          $this -> czr_refresh_term_picker_options( $term, $option_name = 'tc_blog_restrict_by_cat' );
+          $this -> czr_fn_refresh_term_picker_options( $term, $option_name = 'tc_blog_restrict_by_cat' );
           break;
       }
     }
 
 
-    function czr_refresh_term_picker_options( $term, $option_name, $option_group = null ) {
+    function czr_fn_refresh_term_picker_options( $term, $option_name, $option_group = null ) {
        //home/blog posts category picker
-       $_option = CZR_utils::$inst -> czr_opt( $option_name, $option_group, $use_default = false );
+       $_option = CZR_utils::$inst -> czr_fn_opt( $option_name, $option_group, $use_default = false );
        if ( is_array( $_option ) && ! empty( $_option ) && in_array( $term, $_option ) )
          //update the option
-         CZR_utils::$inst -> czr_set_option( $option_name, array_diff( $_option, (array)$term ) );
+         CZR_utils::$inst -> czr_fn_set_option( $option_name, array_diff( $_option, (array)$term ) );
 
        //alternative, cycle throughout the cats and keep just the existent ones
        /*if ( is_array( $blog_cats ) && ! empty( $blog_cats ) ) {
          //update the option
-         CZR_utils::$inst -> czr_set_option( 'tc_blog_restrict_by_cat', array_filter( $blog_cats, array(CZR_utils::$inst, 'czr_category_id_exists' ) ) );
+         CZR_utils::$inst -> czr_fn_set_option( 'tc_blog_restrict_by_cat', array_filter( $blog_cats, array(CZR_utils::$inst, 'czr_fn_category_id_exists' ) ) );
        }*/
     }
 
@@ -126,8 +126,8 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
     * @package Customizr
     * @since Customizr 3.2.10
     */
-    function czr_maybe_add_gfonts_to_editor() {
-      $_font_pair         = esc_attr( CZR_utils::$inst->czr_opt('tc_fonts') );
+    function czr_fn_maybe_add_gfonts_to_editor() {
+      $_font_pair         = esc_attr( CZR_utils::$inst->czr_fn_opt('tc_fonts') );
       $_all_font_pairs    = CZR_init::$instance -> font_pairs;
       if ( false === strpos($_font_pair,'_g_') )
         return;
@@ -136,7 +136,7 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
         str_replace(
           ',',
           '%2C',
-          sprintf( '//fonts.googleapis.com/css?family=%s', CZR_utils::$inst -> czr_get_font( 'single' , $_font_pair ) )
+          sprintf( '//fonts.googleapis.com/css?family=%s', CZR_utils::$inst -> czr_fn_get_font( 'single' , $_font_pair ) )
         )
       );
     }
@@ -148,7 +148,7 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
    * @package Customizr
    * @since Customizr 3.0.4
    */
-    function czr_admin_style() {
+    function czr_fn_admin_style() {
       wp_enqueue_style(
         'tc-admincss',
         sprintf('%1$sinc/admin/css/tc_admin%2$s.css' , TC_BASE_URL, ( defined('WP_DEBUG') && true === WP_DEBUG ) ? '' : '.min' ),
@@ -164,7 +164,7 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
    * @package Customizr
    * @since Customizr 3.0.5
    */
-    function czr_extract_changelog() {
+    function czr_fn_extract_changelog() {
 
       if( ! file_exists(TC_BASE."readme.txt") ) {
         return;
@@ -211,14 +211,14 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
     * @since Customizr 3.2.11
     *
     */
-    function czr_add_editor_style() {
+    function czr_fn_add_editor_style() {
       $_stylesheets = array(
           TC_BASE_URL.'inc/admin/css/editor-style.css',
-          CZR_init::$instance -> czr_get_style_src() , get_stylesheet_uri()
+          CZR_init::$instance -> czr_fn_get_style_src() , get_stylesheet_uri()
       );
 
-      if ( apply_filters( 'tc_add_custom_fonts_to_editor' , false != $this -> czr_maybe_add_gfonts_to_editor() ) )
-        $_stylesheets = array_merge( $_stylesheets , $this -> czr_maybe_add_gfonts_to_editor() );
+      if ( apply_filters( 'tc_add_custom_fonts_to_editor' , false != $this -> czr_fn_maybe_add_gfonts_to_editor() ) )
+        $_stylesheets = array_merge( $_stylesheets , $this -> czr_fn_maybe_add_gfonts_to_editor() );
 
       add_editor_style( $_stylesheets );
     }
@@ -234,7 +234,7 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
     * @since Customizr 3.2.11
     *
     */
-    function czr_user_defined_tinymce_css( $init ) {
+    function czr_fn_user_defined_tinymce_css( $init ) {
       if ( ! apply_filters( 'tc_add_custom_fonts_to_editor' , true ) )
         return $init;
 
@@ -244,12 +244,12 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
       //some plugins fire tiny mce editor in the customizer
       //in this case, the CZR_resource class has to be loaded
       if ( ! class_exists('CZR_resources') )
-        CZR___::$instance -> czr__( array('fire' => array( array('inc' , 'resources') ) ), true );
+        CZR___::$instance -> czr_fn__( array('fire' => array( array('inc' , 'resources') ) ), true );
 
       //fonts
-      $_css = CZR_resources::$instance -> czr_write_fonts_inline_css( '', 'mce-content-body');
+      $_css = CZR_resources::$instance -> czr_fn_write_fonts_inline_css( '', 'mce-content-body');
       //icons
-      $_css .= CZR_resources::$instance -> czr_get_inline_font_icons_css();
+      $_css .= CZR_resources::$instance -> czr_fn_get_inline_font_icons_css();
       $init['content_style'] =  trim(preg_replace('/\s+/', ' ', $_css ) );
 
       return $init;
@@ -268,9 +268,9 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
     /**
     * hook : admin_notices
     */
-    function czr_may_be_display_update_notice() {
+    function czr_fn_may_be_display_update_notice() {
       $opt_name                   = "customizr-pro" == CZR___::$theme_name ? 'last_update_notice_pro' : 'last_update_notice';
-      $last_update_notice_values  = CZR_utils::$inst -> czr_opt($opt_name);
+      $last_update_notice_values  = CZR_utils::$inst -> czr_fn_opt($opt_name);
       $show_new_notice = false;
 
       if ( ! $last_update_notice_values || ! is_array($last_update_notice_values) ) {
@@ -278,9 +278,9 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
         // 1) initialize it => set it to the current Customizr version, displayed 0 times.
         // 2) update in db
         $last_update_notice_values = array( "version" => CUSTOMIZR_VER, "display_count" => 0 );
-        CZR_utils::$inst->czr_set_option( $opt_name, $last_update_notice_values );
+        CZR_utils::$inst->czr_fn_set_option( $opt_name, $last_update_notice_values );
         //already user of the theme ?
-        if ( CZR_utils::$inst->czr_user_started_before_version( CUSTOMIZR_VER, CUSTOMIZR_VER ) )
+        if ( CZR_utils::$inst->czr_fn_user_started_before_version( CUSTOMIZR_VER, CUSTOMIZR_VER ) )
           $show_new_notice = true;
       }
 
@@ -297,13 +297,13 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
           (int) $_db_displayed_count++;
           $last_update_notice_values["display_count"] = $_db_displayed_count;
           //updates the option val with the new count
-          CZR_utils::$inst->czr_set_option( $opt_name, $last_update_notice_values );
+          CZR_utils::$inst->czr_fn_set_option( $opt_name, $last_update_notice_values );
         }
         //CASE 2 : displayed 5 times => automatic dismiss
         else {
           //reset option value with new version and counter to 0
           $new_val  = array( "version" => CUSTOMIZR_VER, "display_count" => 0 );
-          CZR_utils::$inst->czr_set_option( $opt_name, $new_val );
+          CZR_utils::$inst->czr_fn_set_option( $opt_name, $new_val );
         }//end else
       }//end if
 
@@ -355,12 +355,12 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
     * hook : wp_ajax_dismiss_customizr_update_notice
     * => sets the last_update_notice to the current Customizr version when user click on dismiss notice link
     */
-    function czr_dismiss_update_notice_action() {
+    function czr_fn_dismiss_update_notice_action() {
       check_ajax_referer( 'dismiss-update-notice-nonce', 'dismissUpdateNoticeNonce' );
       $opt_name = "customizr-pro" == CZR___::$theme_name ? 'last_update_notice_pro' : 'last_update_notice';
       //reset option value with new version and counter to 0
       $new_val  = array( "version" => CUSTOMIZR_VER, "display_count" => 0 );
-      CZR_utils::$inst->czr_set_option( $opt_name, $new_val );
+      CZR_utils::$inst->czr_fn_set_option( $opt_name, $new_val );
       wp_die();
     }
 
@@ -369,7 +369,7 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
     /**
     * hook : admin_footer
     */
-    function czr_write_ajax_dismis_script() {
+    function czr_fn_write_ajax_dismis_script() {
       ?>
       <script type="text/javascript" id="tc-dismiss-update-notice">
         ( function($){

--- a/inc/admin/class-fire-admin_init.php
+++ b/inc/admin/class-fire-admin_init.php
@@ -17,29 +17,29 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
     function __construct () {
       self::$instance =& $this;
       //enqueue additional styling for admin screens
-      add_action( 'admin_init'            , array( $this , 'tc_admin_style' ) );
+      add_action( 'admin_init'            , array( $this , 'czr_admin_style' ) );
 
       //Load the editor-style specific (post formats and RTL), the active skin, the user style.css
       //add user defined fonts in the editor style (@see the query args add_editor_style below)
-      add_action( 'after_setup_theme'     , array( $this, 'tc_add_editor_style') );
+      add_action( 'after_setup_theme'     , array( $this, 'czr_add_editor_style') );
 
-      add_filter( 'tiny_mce_before_init'  , array( $this, 'tc_user_defined_tinymce_css') );
+      add_filter( 'tiny_mce_before_init'  , array( $this, 'czr_user_defined_tinymce_css') );
       //refresh the post / CPT / page thumbnail on save. Since v3.3.2.
-      add_action ( 'save_post'            , array( $this , 'tc_refresh_thumbnail') , 10, 2);
+      add_action ( 'save_post'            , array( $this , 'czr_refresh_thumbnail') , 10, 2);
 
       //refresh the posts slider transient on save_post. Since v3.4.9.
-      add_action ( 'save_post'            , array( $this , 'tc_refresh_posts_slider'), 20, 2 );
+      add_action ( 'save_post'            , array( $this , 'czr_refresh_posts_slider'), 20, 2 );
       //refresh the posts slider transient on permanent post/attachment deletion. Since v3.4.9.
-      add_action ( 'deleted_post'         , array( $this , 'tc_refresh_posts_slider') );
+      add_action ( 'deleted_post'         , array( $this , 'czr_refresh_posts_slider') );
 
       //refresh the terms array (categories/tags pickers options) on term deletion
-      add_action ( 'delete_term'          , array( $this, 'tc_refresh_terms_pickers_options_cb'), 10, 3 );
+      add_action ( 'delete_term'          , array( $this, 'czr_refresh_terms_pickers_options_cb'), 10, 3 );
 
       //UPDATE NOTICE
-      add_action( 'admin_notices'         , array( $this, 'tc_may_be_display_update_notice') );
+      add_action( 'admin_notices'         , array( $this, 'czr_may_be_display_update_notice') );
       //always add the ajax action
-      add_action( 'wp_ajax_dismiss_customizr_update_notice'    , array( $this , 'tc_dismiss_update_notice_action' ) );
-      add_action( 'admin_footer'                  , array( $this , 'tc_write_ajax_dismis_script' ) );
+      add_action( 'wp_ajax_dismiss_customizr_update_notice'    , array( $this , 'czr_dismiss_update_notice_action' ) );
+      add_action( 'admin_footer'                  , array( $this , 'czr_write_ajax_dismis_script' ) );
       /* beautify admin notice text using some defaults the_content filter callbacks */
       foreach ( array( 'wptexturize', 'convert_smilies', 'wpautop') as $callback )
         add_filter( 'tc_update_notice', $callback );
@@ -115,7 +115,7 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
        //alternative, cycle throughout the cats and keep just the existent ones
        /*if ( is_array( $blog_cats ) && ! empty( $blog_cats ) ) {
          //update the option
-         CZR_utils::$inst -> czr_set_option( 'tc_blog_restrict_by_cat', array_filter( $blog_cats, array(CZR_utils::$inst, 'tc_category_id_exists' ) ) );
+         CZR_utils::$inst -> czr_set_option( 'tc_blog_restrict_by_cat', array_filter( $blog_cats, array(CZR_utils::$inst, 'czr_category_id_exists' ) ) );
        }*/
     }
 

--- a/inc/admin/class-fire-admin_init.php
+++ b/inc/admin/class-fire-admin_init.php
@@ -53,7 +53,7 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
     * @package Customizr
     * @since Customizr 3.3.2
     */
-    function tc_refresh_thumbnail( $post_id, $post ) {
+    function czr_refresh_thumbnail( $post_id, $post ) {
       // If this is just a revision, don't send the email.
       if ( wp_is_post_revision( $post_id ) || ( ! empty($post) && 'auto-draft' == $post->post_status ) )
         return;
@@ -70,7 +70,7 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
     * @package Customizr
     * @since Customizr 3.4.9
     */
-    function tc_refresh_posts_slider( $post_id, $post = array() ) {
+    function czr_refresh_posts_slider( $post_id, $post = array() ) {
       // no need to build up/refresh the transient it we don't use the posts slider
       // since we always delete the transient when entering the preview.
       if ( 'tc_posts_slider' != CZR_utils::$inst->tc_opt( 'tc_front_slider' ) || ! apply_filters('tc_posts_slider_use_transient' , true ) )
@@ -94,7 +94,7 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
     * @package Customizr
     * @since Customizr 3.4.10
     */
-    function tc_refresh_terms_pickers_options_cb( $term, $tt_id, $taxonomy ) {
+    function czr_refresh_terms_pickers_options_cb( $term, $tt_id, $taxonomy ) {
       switch ( $taxonomy ) {
 
         //delete categories based options
@@ -105,7 +105,7 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
     }
 
 
-    function tc_refresh_term_picker_options( $term, $option_name, $option_group = null ) {
+    function czr_refresh_term_picker_options( $term, $option_name, $option_group = null ) {
        //home/blog posts category picker
        $_option = CZR_utils::$inst -> tc_opt( $option_name, $option_group, $use_default = false );
        if ( is_array( $_option ) && ! empty( $_option ) && in_array( $term, $_option ) )
@@ -126,7 +126,7 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
     * @package Customizr
     * @since Customizr 3.2.10
     */
-    function tc_maybe_add_gfonts_to_editor() {
+    function czr_maybe_add_gfonts_to_editor() {
       $_font_pair         = esc_attr( CZR_utils::$inst->tc_opt('tc_fonts') );
       $_all_font_pairs    = CZR_init::$instance -> font_pairs;
       if ( false === strpos($_font_pair,'_g_') )
@@ -148,7 +148,7 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
    * @package Customizr
    * @since Customizr 3.0.4
    */
-    function tc_admin_style() {
+    function czr_admin_style() {
       wp_enqueue_style(
         'tc-admincss',
         sprintf('%1$sinc/admin/css/tc_admin%2$s.css' , TC_BASE_URL, ( defined('WP_DEBUG') && true === WP_DEBUG ) ? '' : '.min' ),
@@ -164,7 +164,7 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
    * @package Customizr
    * @since Customizr 3.0.5
    */
-    function tc_extract_changelog() {
+    function czr_extract_changelog() {
 
       if( ! file_exists(TC_BASE."readme.txt") ) {
         return;
@@ -211,7 +211,7 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
     * @since Customizr 3.2.11
     *
     */
-    function tc_add_editor_style() {
+    function czr_add_editor_style() {
       $_stylesheets = array(
           TC_BASE_URL.'inc/admin/css/editor-style.css',
           CZR_init::$instance -> tc_get_style_src() , get_stylesheet_uri()
@@ -234,7 +234,7 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
     * @since Customizr 3.2.11
     *
     */
-    function tc_user_defined_tinymce_css( $init ) {
+    function czr_user_defined_tinymce_css( $init ) {
       if ( ! apply_filters( 'tc_add_custom_fonts_to_editor' , true ) )
         return $init;
 
@@ -268,7 +268,7 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
     /**
     * hook : admin_notices
     */
-    function tc_may_be_display_update_notice() {
+    function czr_may_be_display_update_notice() {
       $opt_name                   = "customizr-pro" == CZR___::$theme_name ? 'last_update_notice_pro' : 'last_update_notice';
       $last_update_notice_values  = CZR_utils::$inst -> tc_opt($opt_name);
       $show_new_notice = false;
@@ -355,7 +355,7 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
     * hook : wp_ajax_dismiss_customizr_update_notice
     * => sets the last_update_notice to the current Customizr version when user click on dismiss notice link
     */
-    function tc_dismiss_update_notice_action() {
+    function czr_dismiss_update_notice_action() {
       check_ajax_referer( 'dismiss-update-notice-nonce', 'dismissUpdateNoticeNonce' );
       $opt_name = "customizr-pro" == CZR___::$theme_name ? 'last_update_notice_pro' : 'last_update_notice';
       //reset option value with new version and counter to 0
@@ -369,7 +369,7 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
     /**
     * hook : admin_footer
     */
-    function tc_write_ajax_dismis_script() {
+    function czr_write_ajax_dismis_script() {
       ?>
       <script type="text/javascript" id="tc-dismiss-update-notice">
         ( function($){

--- a/inc/admin/class-fire-admin_page.php
+++ b/inc/admin/class-fire-admin_page.php
@@ -19,15 +19,15 @@ if ( ! class_exists( 'CZR_admin_page' ) ) :
     function __construct () {
       self::$instance =& $this;
       //add welcome page in menu
-      add_action( 'admin_menu'             , array( $this , 'czr_add_welcome_page' ));
+      add_action( 'admin_menu'             , array( $this , 'czr_fn_add_welcome_page' ));
       //changelog
-      add_action( '__after_welcome_panel'  , array( $this , 'czr_extract_changelog' ));
+      add_action( '__after_welcome_panel'  , array( $this , 'czr_fn_extract_changelog' ));
       //config infos
-      add_action( '__after_welcome_panel'  , array( $this , 'czr_config_infos' ), 20 );
+      add_action( '__after_welcome_panel'  , array( $this , 'czr_fn_config_infos' ), 20 );
       //build the support url
-      $this -> support_url = CZR___::czr_is_pro() ? esc_url( sprintf('%ssupport' , CZR_WEBSITE ) ) : esc_url('wordpress.org/support/theme/customizr');
+      $this -> support_url = CZR___::czr_fn_is_pro() ? esc_url( sprintf('%ssupport' , CZR_WEBSITE ) ) : esc_url('wordpress.org/support/theme/customizr');
       //fix #wpfooter absolute positioning in the welcome and about pages
-      add_action( 'admin_print_styles'      , array( $this, 'czr_fix_wp_footer_link_style') );
+      add_action( 'admin_print_styles'      , array( $this, 'czr_fn_fix_wp_footer_link_style') );
     }
 
 
@@ -37,16 +37,16 @@ if ( ! class_exists( 'CZR_admin_page' ) ) :
    * @package Customizr
    * @since Customizr 1.1
    */
-    function czr_add_welcome_page() {
+    function czr_fn_add_welcome_page() {
         $_name = __( 'About Customizr' , 'customizr' );
-        $_name = CZR___::czr_is_pro() ? sprintf( '%s Pro', $_name ) : $_name;
+        $_name = CZR___::czr_fn_is_pro() ? sprintf( '%s Pro', $_name ) : $_name;
 
         $theme_page = add_theme_page(
             $_name,   // Name of page
             $_name,   // Label in menu
             'edit_theme_options' ,          // Capability required
             'welcome.php' ,             // Menu slug, used to uniquely identify the page
-            array( $this , 'czr_welcome_panel' )         //function to be called to output the content of this page
+            array( $this , 'czr_fn_welcome_panel' )         //function to be called to output the content of this page
         );
     }
 
@@ -57,12 +57,12 @@ if ( ! class_exists( 'CZR_admin_page' ) ) :
      * @package Customizr
      * @since Customizr 3.0.4
      */
-      function czr_welcome_panel() {
+      function czr_fn_welcome_panel() {
 
         $is_help        = isset($_GET['help'])  ?  true : false;
         $_faq_url       = esc_url('http://docs.presscustomizr.com/category/90-faq-and-common-issues');
         $_support_url   = $this -> support_url;
-        $_theme_name    = CZR___::czr_is_pro() ? 'Customizr Pro' : 'Customizr';
+        $_theme_name    = CZR___::czr_fn_is_pro() ? 'Customizr Pro' : 'Customizr';
 
         do_action('__before_welcome_panel');
 
@@ -95,7 +95,7 @@ if ( ! class_exists( 'CZR_admin_page' ) ) :
                 );
                 printf( '<p>%1$s</p><p><strong>%2$s</strong></p>',
                   __( "If you don't find an answer to your issue in the documentation, don't panic! The Customizr theme is used by a growing community of webmasters reporting bugs and making continuous improvements. If you have a problem with the theme, chances are that it's already been reported and fixed in the support forums.", "customizr" ),
-                  CZR___::czr_is_pro() ? '' : sprintf( __( "The easiest way to search in the support forums is to use our Google powered search engine on our %s.", "customizr" ),
+                  CZR___::czr_fn_is_pro() ? '' : sprintf( __( "The easiest way to search in the support forums is to use our Google powered search engine on our %s.", "customizr" ),
                     sprintf('<a href="%1$s" title="%2$s" target="_blank">%2$s</a>', esc_url('presscustomizr.com'), __("home page" , "customizr") )
                   )
                 );
@@ -117,7 +117,7 @@ if ( ! class_exists( 'CZR_admin_page' ) ) :
                 </div>
                  <div class="last-feature col">
                     <a class="button-secondary customizr-help" title="help" href="<?php echo $_support_url; ?>" target="_blank">
-                      <?php CZR___::czr_is_pro() ? _e( 'Get support','customizr' ) : _e( 'Get help in the free support forum','customizr' ); ?>
+                      <?php CZR___::czr_fn_is_pro() ? _e( 'Get support','customizr' ) : _e( 'Get help in the free support forum','customizr' ); ?>
                     </a>
                  </div>
               </div><!-- .two-col -->
@@ -145,7 +145,7 @@ if ( ! class_exists( 'CZR_admin_page' ) ) :
 
           <?php endif; ?>
 
-          <?php if ( CZR___::$instance -> czr_is_child() ) : ?>
+          <?php if ( CZR___::$instance -> czr_fn_is_child() ) : ?>
             <div class="changelog point-releases"></div>
 
             <div class="tc-upgrade-notice">
@@ -162,7 +162,7 @@ if ( ! class_exists( 'CZR_admin_page' ) ) :
 
           <div class="changelog point-releases"></div>
 
-          <?php if ( ! CZR___::czr_is_pro() ) : ?>
+          <?php if ( ! CZR___::czr_fn_is_pro() ) : ?>
             <div class="changelog">
 
                 <div class="feature-section col three-col">
@@ -243,7 +243,7 @@ if ( ! class_exists( 'CZR_admin_page' ) ) :
    * @package Customizr
    * @since Customizr 3.0.5
    */
-    function czr_extract_changelog() {
+    function czr_fn_extract_changelog() {
       if( ! file_exists(TC_BASE."readme.txt") ) {
         return;
       }
@@ -297,7 +297,7 @@ if ( ! class_exists( 'CZR_admin_page' ) ) :
     * Inspired by Easy Digital Download plugin by Pippin Williamson
     * @since 3.2.1
     */
-    function czr_config_infos() {
+    function czr_fn_config_infos() {
       global $wpdb;
 
       ?>
@@ -355,7 +355,7 @@ PHP Version:              <?php echo PHP_VERSION . "\n"; ?>
 MySQL Version:            <?php echo $mysql_ver . "\n"; ?>
 Web Server Info:          <?php echo $_SERVER['SERVER_SOFTWARE'] . "\n"; ?>
 
-WordPress Memory Limit:   <?php echo ( $this -> czr_let_to_num( WP_MEMORY_LIMIT )/( 1024 ) )."MB"; ?><?php echo "\n"; ?>
+WordPress Memory Limit:   <?php echo ( $this -> czr_fn_let_to_num( WP_MEMORY_LIMIT )/( 1024 ) )."MB"; ?><?php echo "\n"; ?>
 PHP Safe Mode:            <?php echo ini_get( 'safe_mode' ) ? "Yes" : "No\n"; ?>
 PHP Memory Limit:         <?php echo ini_get( 'memory_limit' ) . "\n"; ?>
 PHP Upload Max Size:      <?php echo ini_get( 'upload_max_filesize' ) . "\n"; ?>
@@ -387,7 +387,7 @@ Page For Posts:           <?php $id = get_option( 'page_for_posts' ); echo get_t
        *
        * @since 3.2.2
        */
-      function czr_let_to_num( $v ) {
+      function czr_fn_let_to_num( $v ) {
         $l   = substr( $v, -1 );
         $ret = substr( $v, 0, -1 );
 
@@ -411,7 +411,7 @@ Page For Posts:           <?php $id = get_option( 'page_for_posts' ); echo get_t
     * fix the absolute positioning of the wp footer admin link in the welcome pages
     * @return void
     */
-    function czr_fix_wp_footer_link_style() {
+    function czr_fn_fix_wp_footer_link_style() {
       /* if ( is_array(get_current_screen()) )
         array_walk_recursive(get_current_screen(), function(&$v) { $v = htmlspecialchars($v); }); */
       $screen = get_current_screen();

--- a/inc/admin/class-fire-admin_page.php
+++ b/inc/admin/class-fire-admin_page.php
@@ -11,8 +11,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_admin_page' ) ) :
-  class TC_admin_page {
+if ( ! class_exists( 'CZR_admin_page' ) ) :
+  class CZR_admin_page {
     static $instance;
     public $support_url;
 
@@ -25,7 +25,7 @@ if ( ! class_exists( 'TC_admin_page' ) ) :
       //config infos
       add_action( '__after_welcome_panel'  , array( $this , 'tc_config_infos' ), 20 );
       //build the support url
-      $this -> support_url = TC___::tc_is_pro() ? esc_url( sprintf('%ssupport' , TC_WEBSITE ) ) : esc_url('wordpress.org/support/theme/customizr');
+      $this -> support_url = CZR___::tc_is_pro() ? esc_url( sprintf('%ssupport' , CZR_WEBSITE ) ) : esc_url('wordpress.org/support/theme/customizr');
       //fix #wpfooter absolute positioning in the welcome and about pages
       add_action( 'admin_print_styles'      , array( $this, 'tc_fix_wp_footer_link_style') );
     }
@@ -39,7 +39,7 @@ if ( ! class_exists( 'TC_admin_page' ) ) :
    */
     function tc_add_welcome_page() {
         $_name = __( 'About Customizr' , 'customizr' );
-        $_name = TC___::tc_is_pro() ? sprintf( '%s Pro', $_name ) : $_name;
+        $_name = CZR___::tc_is_pro() ? sprintf( '%s Pro', $_name ) : $_name;
 
         $theme_page = add_theme_page(
             $_name,   // Name of page
@@ -62,7 +62,7 @@ if ( ! class_exists( 'TC_admin_page' ) ) :
         $is_help        = isset($_GET['help'])  ?  true : false;
         $_faq_url       = esc_url('http://docs.presscustomizr.com/category/90-faq-and-common-issues');
         $_support_url   = $this -> support_url;
-        $_theme_name    = TC___::tc_is_pro() ? 'Customizr Pro' : 'Customizr';
+        $_theme_name    = CZR___::tc_is_pro() ? 'Customizr Pro' : 'Customizr';
 
         do_action('__before_welcome_panel');
 
@@ -95,7 +95,7 @@ if ( ! class_exists( 'TC_admin_page' ) ) :
                 );
                 printf( '<p>%1$s</p><p><strong>%2$s</strong></p>',
                   __( "If you don't find an answer to your issue in the documentation, don't panic! The Customizr theme is used by a growing community of webmasters reporting bugs and making continuous improvements. If you have a problem with the theme, chances are that it's already been reported and fixed in the support forums.", "customizr" ),
-                  TC___::tc_is_pro() ? '' : sprintf( __( "The easiest way to search in the support forums is to use our Google powered search engine on our %s.", "customizr" ),
+                  CZR___::tc_is_pro() ? '' : sprintf( __( "The easiest way to search in the support forums is to use our Google powered search engine on our %s.", "customizr" ),
                     sprintf('<a href="%1$s" title="%2$s" target="_blank">%2$s</a>', esc_url('presscustomizr.com'), __("home page" , "customizr") )
                   )
                 );
@@ -113,11 +113,11 @@ if ( ! class_exists( 'TC_admin_page' ) ) :
               </div><!-- .two-col -->
               <div class="feature-section col two-col">
                  <div class="col">
-                    <a class="button-secondary customizr-help" title="code snippets" href="<?php echo TC_WEBSITE ?>code-snippets/" target="_blank"><?php _e( 'Code snippets for developers','customizr' ); ?></a>
+                    <a class="button-secondary customizr-help" title="code snippets" href="<?php echo CZR_WEBSITE ?>code-snippets/" target="_blank"><?php _e( 'Code snippets for developers','customizr' ); ?></a>
                 </div>
                  <div class="last-feature col">
                     <a class="button-secondary customizr-help" title="help" href="<?php echo $_support_url; ?>" target="_blank">
-                      <?php TC___::tc_is_pro() ? _e( 'Get support','customizr' ) : _e( 'Get help in the free support forum','customizr' ); ?>
+                      <?php CZR___::tc_is_pro() ? _e( 'Get support','customizr' ) : _e( 'Get help in the free support forum','customizr' ); ?>
                     </a>
                  </div>
               </div><!-- .two-col -->
@@ -145,7 +145,7 @@ if ( ! class_exists( 'TC_admin_page' ) ) :
 
           <?php endif; ?>
 
-          <?php if ( TC___::$instance -> tc_is_child() ) : ?>
+          <?php if ( CZR___::$instance -> tc_is_child() ) : ?>
             <div class="changelog point-releases"></div>
 
             <div class="tc-upgrade-notice">
@@ -162,7 +162,7 @@ if ( ! class_exists( 'TC_admin_page' ) ) :
 
           <div class="changelog point-releases"></div>
 
-          <?php if ( ! TC___::tc_is_pro() ) : ?>
+          <?php if ( ! CZR___::tc_is_pro() ) : ?>
             <div class="changelog">
 
                 <div class="feature-section col three-col">
@@ -183,7 +183,7 @@ if ( ! class_exists( 'TC_admin_page' ) ) :
 
                   <div class="last-feature col">
                     <h3><?php _e( 'Follow us','customizr' ); ?></h3>
-                    <p class="tc-follow"><a href="<?php echo TC_WEBSITE.'blog' ?>" target="_blank"><img src="<?php echo TC_BASE_URL.'inc/admin/img/pc.png' ?>" alt="Press Customizr" /></a></p>
+                    <p class="tc-follow"><a href="<?php echo CZR_WEBSITE.'blog' ?>" target="_blank"><img src="<?php echo TC_BASE_URL.'inc/admin/img/pc.png' ?>" alt="Press Customizr" /></a></p>
                     <!-- Place this tag where you want the widget to render. -->
 
                   </div><!-- .feature-section -->
@@ -195,13 +195,13 @@ if ( ! class_exists( 'TC_admin_page' ) ) :
               <h3 style="text-align:left"><?php _e("Go Customizr Pro" ,'customizr') ?></h3>
 
               <div class="feature-section images-stagger-right">
-                <a class="" title="<?php _e("Visit the extension's page",'customizr') ?>" href="<?php echo TC_WEBSITE ?>customizr-pro/" target="_blank"><img alt="Customizr'extensions" src="<?php echo TC_BASE_URL.'inc/admin/img/customizr-pro.png' ?>" class=""></a>
+                <a class="" title="<?php _e("Visit the extension's page",'customizr') ?>" href="<?php echo CZR_WEBSITE ?>customizr-pro/" target="_blank"><img alt="Customizr'extensions" src="<?php echo TC_BASE_URL.'inc/admin/img/customizr-pro.png' ?>" class=""></a>
                 <h4 style="text-align: left"><?php _e('Easily take your web design one step further' ,'customizr') ?></h4></br>
 
                 <p style="text-align: left"><?php _e("The Customizr Pro WordPress theme allows anyone to create a beautiful, professional and fully responsive website in a few seconds. In the Pro version, you'll get all the features of the free version plus some really cool and even revolutionary ones." , 'customizr') ?>
                 </p>
                 <p style="text-align:left">
-                    <a class="button-primary review-customizr" title="<?php _e("Discover Customizr Pro",'customizr') ?>" href="<?php echo TC_WEBSITE ?>customizr-pro/" target="_blank"><?php _e("Discover Customizr Pro",'customizr') ?> &raquo;</a>
+                    <a class="button-primary review-customizr" title="<?php _e("Discover Customizr Pro",'customizr') ?>" href="<?php echo CZR_WEBSITE ?>customizr-pro/" target="_blank"><?php _e("Discover Customizr Pro",'customizr') ?> &raquo;</a>
                 </p>
               </div>
             </div>
@@ -211,14 +211,14 @@ if ( ! class_exists( 'TC_admin_page' ) ) :
           <h3 style="text-align:right"><?php _e('Customizr Showcase' ,'customizr') ?></h3>
 
           <div class="feature-section images-stagger-left">
-             <a class="" title="<?php _e('Visit the showcase','customizr') ?>" href="<?php echo TC_WEBSITE ?>customizr/showcase/" target="_blank"><img alt="Customizr Showcase" src="<?php echo TC_BASE_URL.'inc/admin/img/mu2.png' ?>" class=""></a>
+             <a class="" title="<?php _e('Visit the showcase','customizr') ?>" href="<?php echo CZR_WEBSITE ?>customizr/showcase/" target="_blank"><img alt="Customizr Showcase" src="<?php echo TC_BASE_URL.'inc/admin/img/mu2.png' ?>" class=""></a>
             <h4 style="text-align: right"><?php _e('Find inspiration for your next Customizr based website!' ,'customizr') ?></h4>
             <p style="text-align: right"><?php _e('This showcase aims to show what can be done with Customizr and helping other users to find inspiration for their web design.' , 'customizr') ?>
             </p>
             <p style="text-align: right"><?php _e('Do you think you made an awesome website that can inspire people? Submitting a site for review is quick and easy to do.' , 'customizr') ?></br>
             </p>
             <p style="text-align:right">
-                <a class="button-primary review-customizr" title="<?php _e('Visit the showcase','customizr') ?>" href="<?php echo TC_WEBSITE ?>customizr/showcase/" target="_blank"><?php _e('Visit the showcase','customizr') ?> &raquo;</a>
+                <a class="button-primary review-customizr" title="<?php _e('Visit the showcase','customizr') ?>" href="<?php echo CZR_WEBSITE ?>customizr/showcase/" target="_blank"><?php _e('Visit the showcase','customizr') ?> &raquo;</a>
             </p>
           </div>
         </div>
@@ -310,7 +310,7 @@ if ( ! class_exists( 'TC_admin_page' ) ) :
 # HOME_URL:                 <?php echo home_url() . "\n"; ?>
 # IS MULTISITE :            <?php echo is_multisite() ? 'Yes' . "\n" : 'No' . "\n" ?>
 
-# THEME | VERSION :         <?php printf( '%1$s | v%2$s', TC___::$theme_name , CUSTOMIZR_VER ) . "\n"; ?>
+# THEME | VERSION :         <?php printf( '%1$s | v%2$s', CZR___::$theme_name , CUSTOMIZR_VER ) . "\n"; ?>
 # WP VERSION :              <?php echo get_bloginfo( 'version' ) . "\n"; ?>
 # PERMALINK STRUCTURE :     <?php echo get_option( 'permalink_structure' ) . "\n"; ?>
 

--- a/inc/admin/class-fire-admin_page.php
+++ b/inc/admin/class-fire-admin_page.php
@@ -25,7 +25,7 @@ if ( ! class_exists( 'CZR_admin_page' ) ) :
       //config infos
       add_action( '__after_welcome_panel'  , array( $this , 'tc_config_infos' ), 20 );
       //build the support url
-      $this -> support_url = CZR___::tc_is_pro() ? esc_url( sprintf('%ssupport' , CZR_WEBSITE ) ) : esc_url('wordpress.org/support/theme/customizr');
+      $this -> support_url = CZR___::czr_is_pro() ? esc_url( sprintf('%ssupport' , CZR_WEBSITE ) ) : esc_url('wordpress.org/support/theme/customizr');
       //fix #wpfooter absolute positioning in the welcome and about pages
       add_action( 'admin_print_styles'      , array( $this, 'tc_fix_wp_footer_link_style') );
     }
@@ -39,7 +39,7 @@ if ( ! class_exists( 'CZR_admin_page' ) ) :
    */
     function czr_add_welcome_page() {
         $_name = __( 'About Customizr' , 'customizr' );
-        $_name = CZR___::tc_is_pro() ? sprintf( '%s Pro', $_name ) : $_name;
+        $_name = CZR___::czr_is_pro() ? sprintf( '%s Pro', $_name ) : $_name;
 
         $theme_page = add_theme_page(
             $_name,   // Name of page
@@ -62,7 +62,7 @@ if ( ! class_exists( 'CZR_admin_page' ) ) :
         $is_help        = isset($_GET['help'])  ?  true : false;
         $_faq_url       = esc_url('http://docs.presscustomizr.com/category/90-faq-and-common-issues');
         $_support_url   = $this -> support_url;
-        $_theme_name    = CZR___::tc_is_pro() ? 'Customizr Pro' : 'Customizr';
+        $_theme_name    = CZR___::czr_is_pro() ? 'Customizr Pro' : 'Customizr';
 
         do_action('__before_welcome_panel');
 
@@ -95,7 +95,7 @@ if ( ! class_exists( 'CZR_admin_page' ) ) :
                 );
                 printf( '<p>%1$s</p><p><strong>%2$s</strong></p>',
                   __( "If you don't find an answer to your issue in the documentation, don't panic! The Customizr theme is used by a growing community of webmasters reporting bugs and making continuous improvements. If you have a problem with the theme, chances are that it's already been reported and fixed in the support forums.", "customizr" ),
-                  CZR___::tc_is_pro() ? '' : sprintf( __( "The easiest way to search in the support forums is to use our Google powered search engine on our %s.", "customizr" ),
+                  CZR___::czr_is_pro() ? '' : sprintf( __( "The easiest way to search in the support forums is to use our Google powered search engine on our %s.", "customizr" ),
                     sprintf('<a href="%1$s" title="%2$s" target="_blank">%2$s</a>', esc_url('presscustomizr.com'), __("home page" , "customizr") )
                   )
                 );
@@ -117,7 +117,7 @@ if ( ! class_exists( 'CZR_admin_page' ) ) :
                 </div>
                  <div class="last-feature col">
                     <a class="button-secondary customizr-help" title="help" href="<?php echo $_support_url; ?>" target="_blank">
-                      <?php CZR___::tc_is_pro() ? _e( 'Get support','customizr' ) : _e( 'Get help in the free support forum','customizr' ); ?>
+                      <?php CZR___::czr_is_pro() ? _e( 'Get support','customizr' ) : _e( 'Get help in the free support forum','customizr' ); ?>
                     </a>
                  </div>
               </div><!-- .two-col -->
@@ -145,7 +145,7 @@ if ( ! class_exists( 'CZR_admin_page' ) ) :
 
           <?php endif; ?>
 
-          <?php if ( CZR___::$instance -> tc_is_child() ) : ?>
+          <?php if ( CZR___::$instance -> czr_is_child() ) : ?>
             <div class="changelog point-releases"></div>
 
             <div class="tc-upgrade-notice">
@@ -162,7 +162,7 @@ if ( ! class_exists( 'CZR_admin_page' ) ) :
 
           <div class="changelog point-releases"></div>
 
-          <?php if ( ! CZR___::tc_is_pro() ) : ?>
+          <?php if ( ! CZR___::czr_is_pro() ) : ?>
             <div class="changelog">
 
                 <div class="feature-section col three-col">
@@ -355,7 +355,7 @@ PHP Version:              <?php echo PHP_VERSION . "\n"; ?>
 MySQL Version:            <?php echo $mysql_ver . "\n"; ?>
 Web Server Info:          <?php echo $_SERVER['SERVER_SOFTWARE'] . "\n"; ?>
 
-WordPress Memory Limit:   <?php echo ( $this -> tc_let_to_num( WP_MEMORY_LIMIT )/( 1024 ) )."MB"; ?><?php echo "\n"; ?>
+WordPress Memory Limit:   <?php echo ( $this -> czr_let_to_num( WP_MEMORY_LIMIT )/( 1024 ) )."MB"; ?><?php echo "\n"; ?>
 PHP Safe Mode:            <?php echo ini_get( 'safe_mode' ) ? "Yes" : "No\n"; ?>
 PHP Memory Limit:         <?php echo ini_get( 'memory_limit' ) . "\n"; ?>
 PHP Upload Max Size:      <?php echo ini_get( 'upload_max_filesize' ) . "\n"; ?>

--- a/inc/admin/class-fire-admin_page.php
+++ b/inc/admin/class-fire-admin_page.php
@@ -37,7 +37,7 @@ if ( ! class_exists( 'CZR_admin_page' ) ) :
    * @package Customizr
    * @since Customizr 1.1
    */
-    function tc_add_welcome_page() {
+    function czr_add_welcome_page() {
         $_name = __( 'About Customizr' , 'customizr' );
         $_name = CZR___::tc_is_pro() ? sprintf( '%s Pro', $_name ) : $_name;
 
@@ -57,7 +57,7 @@ if ( ! class_exists( 'CZR_admin_page' ) ) :
      * @package Customizr
      * @since Customizr 3.0.4
      */
-      function tc_welcome_panel() {
+      function czr_welcome_panel() {
 
         $is_help        = isset($_GET['help'])  ?  true : false;
         $_faq_url       = esc_url('http://docs.presscustomizr.com/category/90-faq-and-common-issues');
@@ -243,7 +243,7 @@ if ( ! class_exists( 'CZR_admin_page' ) ) :
    * @package Customizr
    * @since Customizr 3.0.5
    */
-    function tc_extract_changelog() {
+    function czr_extract_changelog() {
       if( ! file_exists(TC_BASE."readme.txt") ) {
         return;
       }
@@ -297,7 +297,7 @@ if ( ! class_exists( 'CZR_admin_page' ) ) :
     * Inspired by Easy Digital Download plugin by Pippin Williamson
     * @since 3.2.1
     */
-    function tc_config_infos() {
+    function czr_config_infos() {
       global $wpdb;
 
       ?>
@@ -387,7 +387,7 @@ Page For Posts:           <?php $id = get_option( 'page_for_posts' ); echo get_t
        *
        * @since 3.2.2
        */
-      function tc_let_to_num( $v ) {
+      function czr_let_to_num( $v ) {
         $l   = substr( $v, -1 );
         $ret = substr( $v, 0, -1 );
 
@@ -411,7 +411,7 @@ Page For Posts:           <?php $id = get_option( 'page_for_posts' ); echo get_t
     * fix the absolute positioning of the wp footer admin link in the welcome pages
     * @return void
     */
-    function tc_fix_wp_footer_link_style() {
+    function czr_fix_wp_footer_link_style() {
       /* if ( is_array(get_current_screen()) )
         array_walk_recursive(get_current_screen(), function(&$v) { $v = htmlspecialchars($v); }); */
       $screen = get_current_screen();

--- a/inc/admin/class-fire-admin_page.php
+++ b/inc/admin/class-fire-admin_page.php
@@ -19,15 +19,15 @@ if ( ! class_exists( 'CZR_admin_page' ) ) :
     function __construct () {
       self::$instance =& $this;
       //add welcome page in menu
-      add_action( 'admin_menu'             , array( $this , 'tc_add_welcome_page' ));
+      add_action( 'admin_menu'             , array( $this , 'czr_add_welcome_page' ));
       //changelog
-      add_action( '__after_welcome_panel'  , array( $this , 'tc_extract_changelog' ));
+      add_action( '__after_welcome_panel'  , array( $this , 'czr_extract_changelog' ));
       //config infos
-      add_action( '__after_welcome_panel'  , array( $this , 'tc_config_infos' ), 20 );
+      add_action( '__after_welcome_panel'  , array( $this , 'czr_config_infos' ), 20 );
       //build the support url
       $this -> support_url = CZR___::czr_is_pro() ? esc_url( sprintf('%ssupport' , CZR_WEBSITE ) ) : esc_url('wordpress.org/support/theme/customizr');
       //fix #wpfooter absolute positioning in the welcome and about pages
-      add_action( 'admin_print_styles'      , array( $this, 'tc_fix_wp_footer_link_style') );
+      add_action( 'admin_print_styles'      , array( $this, 'czr_fix_wp_footer_link_style') );
     }
 
 
@@ -46,7 +46,7 @@ if ( ! class_exists( 'CZR_admin_page' ) ) :
             $_name,   // Label in menu
             'edit_theme_options' ,          // Capability required
             'welcome.php' ,             // Menu slug, used to uniquely identify the page
-            array( $this , 'tc_welcome_panel' )         //function to be called to output the content of this page
+            array( $this , 'czr_welcome_panel' )         //function to be called to output the content of this page
         );
     }
 

--- a/inc/admin/class-tc-controls-settings.php
+++ b/inc/admin/class-tc-controls-settings.php
@@ -2,8 +2,8 @@
 /***************************************************
 * AUGMENTS WP CUSTOMIZE SETTINGS
 ***************************************************/
-if ( ! class_exists( 'TC_Customize_Setting') ) :
-  class TC_Customize_Setting extends WP_Customize_Setting {
+if ( ! class_exists( 'CZR_Customize_Setting') ) :
+  class CZR_Customize_Setting extends WP_Customize_Setting {
     /**
      * Fetch the value of the setting.
      *
@@ -76,8 +76,8 @@ endif;
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_controls' ) ) :
-	class TC_controls extends WP_Customize_Control	{
+if ( ! class_exists( 'CZR_controls' ) ) :
+	class CZR_controls extends WP_Customize_Control	{
 	    public $type;
 	    public $link;
 	    public $title;
@@ -208,7 +208,7 @@ if ( ! class_exists( 'TC_controls' ) ) :
 	        		printf('<label><span class="customize-control-title %1$s">%2$s</span><input type="text" value="%3$s" %4$s /></label>',
 	        			! empty( $this -> icon) ? $this -> icon : '',
 	        			$this->label,
-	        			call_user_func( array( TC_utils_settings_map::$instance, 'tc_sanitize_' . $this -> type), $this->value() ),
+	        			call_user_func( array( CZR_utils_settings_map::$instance, 'tc_sanitize_' . $this -> type), $this->value() ),
 	        			call_user_func( array( $this, 'get'.'_'.'link' ) )
 	        		);
 		        	break;
@@ -275,7 +275,7 @@ if ( ! class_exists( 'TC_controls' ) ) :
 
         case 'tc_theme_options[tc_skin]':
           $_data_hex  = '';
-          $_color_map = TC_utils::$inst -> tc_get_skin_color( 'all' );
+          $_color_map = CZR_utils::$inst -> tc_get_skin_color( 'all' );
           //Get the color map array structured as follow
           // array(
           //       'blue.css'        =>  array( '#08c', '#005580' ),
@@ -316,8 +316,8 @@ endif;
  * @since 3.4.19
  * @package      Customizr
 */
-if ( class_exists('WP_Customize_Cropped_Image_Control') && ! class_exists( 'TC_Customize_Cropped_Image_Control' ) ) :
-  class TC_Customize_Cropped_Image_Control extends WP_Customize_Cropped_Image_Control {
+if ( class_exists('WP_Customize_Cropped_Image_Control') && ! class_exists( 'CZR_Customize_Cropped_Image_Control' ) ) :
+  class CZR_Customize_Cropped_Image_Control extends WP_Customize_Cropped_Image_Control {
     public $type = 'tc_cropped_image';
     public $title;
     public $notice;
@@ -385,7 +385,7 @@ endif;
 /**************************************************************************************************
 * MULTIPICKER CLASSES
 ***************************************************************************************************/
-if ( ! class_exists( 'TC_Customize_Multipicker_Control' ) ) :
+if ( ! class_exists( 'CZR_Customize_Multipicker_Control' ) ) :
   /**
   * Customize Multi-picker Control Class
   *
@@ -393,7 +393,7 @@ if ( ! class_exists( 'TC_Customize_Multipicker_Control' ) ) :
   * @subpackage Customize
   * @since 3.4.10
   */
-  abstract class TC_Customize_Multipicker_Control extends TC_controls {
+  abstract class CZR_Customize_Multipicker_Control extends CZR_controls {
 
     public function render_content() {
 
@@ -427,8 +427,8 @@ if ( ! class_exists( 'TC_Customize_Multipicker_Control' ) ) :
   }//end class
 endif;
 
-if ( ! class_exists( 'TC_Customize_Multipicker_Categories_Control' ) ) :
-  class TC_Customize_Multipicker_Categories_Control extends TC_Customize_Multipicker_Control {
+if ( ! class_exists( 'CZR_Customize_Multipicker_Categories_Control' ) ) :
+  class CZR_Customize_Multipicker_Categories_Control extends CZR_Customize_Multipicker_Control {
 
     public function tc_get_dropdown_multipicker() {
       $cats_dropdown = wp_dropdown_categories(
@@ -438,7 +438,7 @@ if ( ! class_exists( 'TC_Customize_Multipicker_Categories_Control' ) ) :
               //hide empty, set it to false to avoid complains
               'hide_empty'         => 0 ,
               'echo'               => 0 ,
-              'walker'             => new TC_Walker_CategoryDropdown_Multipicker(),
+              'walker'             => new CZR_Walker_CategoryDropdown_Multipicker(),
               'hierarchical'       => 1,
               'class'              => 'select2 '.$this->type,
               'selected'           => implode(',', $this->value() )
@@ -462,8 +462,8 @@ endif;
  * we need to allow more than one "selected" attribute
  */
 
-if ( ! class_exists( 'TC_Walker_CategoryDropdown_Multipicker' ) ) :
-  class TC_Walker_CategoryDropdown_Multipicker extends Walker_CategoryDropdown {
+if ( ! class_exists( 'CZR_Walker_CategoryDropdown_Multipicker' ) ) :
+  class CZR_Walker_CategoryDropdown_Multipicker extends Walker_CategoryDropdown {
     /**
      * Start the element output.
      *
@@ -516,7 +516,7 @@ endif;
 * Old upload control used until v3.4.18, still used if current version of WP is < 4.3
 **********************************************************************************/
 
-if ( ! class_exists( 'TC_Customize_Upload_Control' ) ) :
+if ( ! class_exists( 'CZR_Customize_Upload_Control' ) ) :
   /**
    * Customize Upload Control Class
    *
@@ -524,7 +524,7 @@ if ( ! class_exists( 'TC_Customize_Upload_Control' ) ) :
    * @subpackage Customize
    * @since 3.4.0
    */
-  class TC_Customize_Upload_Control extends WP_Customize_Control {
+  class CZR_Customize_Upload_Control extends WP_Customize_Control {
     public $type    = 'tc_upload';
     public $removed = '';
     public $context;

--- a/inc/admin/class-tc-controls-settings.php
+++ b/inc/admin/class-tc-controls-settings.php
@@ -244,7 +244,7 @@ if ( ! class_exists( 'CZR_controls' ) ) :
 
 
 
-    private function tc_print_select_control($class) {
+    private function czr_print_select_control($class) {
       printf('<select %1$s class="%2$s">%3$s</select>',
         call_user_func( array( $this, 'get'.'_'.'link' ) ),
         $class,
@@ -253,7 +253,7 @@ if ( ! class_exists( 'CZR_controls' ) ) :
     }
 
 
-    private function tc_get_select_options() {
+    private function czr_get_select_options() {
       $_options_html = '';
       switch ( $this -> id ) {
         case 'tc_theme_options[tc_fonts]':
@@ -423,14 +423,14 @@ if ( ! class_exists( 'CZR_Customize_Multipicker_Control' ) ) :
     }
 
     //to define in the extended classes
-    abstract public function tc_get_dropdown_multipicker();
+    abstract public function czr_get_dropdown_multipicker();
   }//end class
 endif;
 
 if ( ! class_exists( 'CZR_Customize_Multipicker_Categories_Control' ) ) :
   class CZR_Customize_Multipicker_Categories_Control extends CZR_Customize_Multipicker_Control {
 
-    public function tc_get_dropdown_multipicker() {
+    public function czr_get_dropdown_multipicker() {
       $cats_dropdown = wp_dropdown_categories(
           array(
               'name'               => '_customize-'.$this->type,

--- a/inc/admin/class-tc-controls-settings.php
+++ b/inc/admin/class-tc-controls-settings.php
@@ -208,7 +208,7 @@ if ( ! class_exists( 'CZR_controls' ) ) :
 	        		printf('<label><span class="customize-control-title %1$s">%2$s</span><input type="text" value="%3$s" %4$s /></label>',
 	        			! empty( $this -> icon) ? $this -> icon : '',
 	        			$this->label,
-	        			call_user_func( array( CZR_utils_settings_map::$instance, 'tc_sanitize_' . $this -> type), $this->value() ),
+	        			call_user_func( array( CZR_utils_settings_map::$instance, 'czr_sanitize_' . $this -> type), $this->value() ),
 	        			call_user_func( array( $this, 'get'.'_'.'link' ) )
 	        		);
 		        	break;

--- a/inc/admin/class-tc-controls-settings.php
+++ b/inc/admin/class-tc-controls-settings.php
@@ -122,7 +122,7 @@ if ( ! class_exists( 'CZR_controls' ) ) :
     					<?php endif; ?>
     					<label>
     						<span class="customize-control-title"><?php echo $this->label; ?></span>
-    						<?php $this -> tc_print_select_control( in_array( $this->id, array( 'tc_theme_options[tc_fonts]', 'tc_theme_options[tc_skin]' ) ) ? 'select2' : '' ) ?>
+    						<?php $this -> czr_print_select_control( in_array( $this->id, array( 'tc_theme_options[tc_fonts]', 'tc_theme_options[tc_skin]' ) ) ? 'select2' : '' ) ?>
                 <?php if(!empty( $this -> notice)) : ?>
                   <span class="tc-notice"><?php echo $this -> notice ?></span>
                 <?php endif; ?>
@@ -248,7 +248,7 @@ if ( ! class_exists( 'CZR_controls' ) ) :
       printf('<select %1$s class="%2$s">%3$s</select>',
         call_user_func( array( $this, 'get'.'_'.'link' ) ),
         $class,
-        $this -> tc_get_select_options()
+        $this -> czr_get_select_options()
       );
     }
 
@@ -275,7 +275,7 @@ if ( ! class_exists( 'CZR_controls' ) ) :
 
         case 'tc_theme_options[tc_skin]':
           $_data_hex  = '';
-          $_color_map = CZR_utils::$inst -> tc_get_skin_color( 'all' );
+          $_color_map = CZR_utils::$inst -> czr_get_skin_color( 'all' );
           //Get the color map array structured as follow
           // array(
           //       'blue.css'        =>  array( '#08c', '#005580' ),
@@ -400,7 +400,7 @@ if ( ! class_exists( 'CZR_Customize_Multipicker_Control' ) ) :
       if ( ! $this -> type ) return;
       do_action( '__before_setting_control' , $this -> id );
 
-      $dropdown = $this -> tc_get_dropdown_multipicker();
+      $dropdown = $this -> czr_get_dropdown_multipicker();
 
       if ( empty( $dropdown ) ) return;
 

--- a/inc/admin/class-tc-controls-settings.php
+++ b/inc/admin/class-tc-controls-settings.php
@@ -122,7 +122,7 @@ if ( ! class_exists( 'CZR_controls' ) ) :
     					<?php endif; ?>
     					<label>
     						<span class="customize-control-title"><?php echo $this->label; ?></span>
-    						<?php $this -> czr_print_select_control( in_array( $this->id, array( 'tc_theme_options[tc_fonts]', 'tc_theme_options[tc_skin]' ) ) ? 'select2' : '' ) ?>
+    						<?php $this -> czr_fn_print_select_control( in_array( $this->id, array( 'tc_theme_options[tc_fonts]', 'tc_theme_options[tc_skin]' ) ) ? 'select2' : '' ) ?>
                 <?php if(!empty( $this -> notice)) : ?>
                   <span class="tc-notice"><?php echo $this -> notice ?></span>
                 <?php endif; ?>
@@ -208,7 +208,7 @@ if ( ! class_exists( 'CZR_controls' ) ) :
 	        		printf('<label><span class="customize-control-title %1$s">%2$s</span><input type="text" value="%3$s" %4$s /></label>',
 	        			! empty( $this -> icon) ? $this -> icon : '',
 	        			$this->label,
-	        			call_user_func( array( CZR_utils_settings_map::$instance, 'czr_sanitize_' . $this -> type), $this->value() ),
+	        			call_user_func( array( CZR_utils_settings_map::$instance, 'czr_fn_sanitize_' . $this -> type), $this->value() ),
 	        			call_user_func( array( $this, 'get'.'_'.'link' ) )
 	        		);
 		        	break;
@@ -244,16 +244,16 @@ if ( ! class_exists( 'CZR_controls' ) ) :
 
 
 
-    private function czr_print_select_control($class) {
+    private function czr_fn_print_select_control($class) {
       printf('<select %1$s class="%2$s">%3$s</select>',
         call_user_func( array( $this, 'get'.'_'.'link' ) ),
         $class,
-        $this -> czr_get_select_options()
+        $this -> czr_fn_get_select_options()
       );
     }
 
 
-    private function czr_get_select_options() {
+    private function czr_fn_get_select_options() {
       $_options_html = '';
       switch ( $this -> id ) {
         case 'tc_theme_options[tc_fonts]':
@@ -275,7 +275,7 @@ if ( ! class_exists( 'CZR_controls' ) ) :
 
         case 'tc_theme_options[tc_skin]':
           $_data_hex  = '';
-          $_color_map = CZR_utils::$inst -> czr_get_skin_color( 'all' );
+          $_color_map = CZR_utils::$inst -> czr_fn_get_skin_color( 'all' );
           //Get the color map array structured as follow
           // array(
           //       'blue.css'        =>  array( '#08c', '#005580' ),
@@ -400,7 +400,7 @@ if ( ! class_exists( 'CZR_Customize_Multipicker_Control' ) ) :
       if ( ! $this -> type ) return;
       do_action( '__before_setting_control' , $this -> id );
 
-      $dropdown = $this -> czr_get_dropdown_multipicker();
+      $dropdown = $this -> czr_fn_get_dropdown_multipicker();
 
       if ( empty( $dropdown ) ) return;
 
@@ -423,14 +423,14 @@ if ( ! class_exists( 'CZR_Customize_Multipicker_Control' ) ) :
     }
 
     //to define in the extended classes
-    abstract public function czr_get_dropdown_multipicker();
+    abstract public function czr_fn_get_dropdown_multipicker();
   }//end class
 endif;
 
 if ( ! class_exists( 'CZR_Customize_Multipicker_Categories_Control' ) ) :
   class CZR_Customize_Multipicker_Categories_Control extends CZR_Customize_Multipicker_Control {
 
-    public function czr_get_dropdown_multipicker() {
+    public function czr_fn_get_dropdown_multipicker() {
       $cats_dropdown = wp_dropdown_categories(
           array(
               'name'               => '_customize-'.$this->type,

--- a/inc/class-fire-init.php
+++ b/inc/class-fire-init.php
@@ -365,19 +365,19 @@ if ( ! class_exists( 'CZR_init' ) ) :
 
           //Set image options set by user @since v3.2.0
           //! must be included in utils to be available in admin for plugins like regenerate thumbnails
-          add_action( 'after_setup_theme'                      , array( $this, 'tc_set_user_defined_settings'));
+          add_action( 'after_setup_theme'                      , array( $this, 'czr_set_user_defined_settings'));
 
           //add the text domain, various theme supports : editor style, automatic-feed-links, post formats, post-thumbnails
-          add_action( 'after_setup_theme'                      , array( $this , 'tc_customizr_setup' ));
+          add_action( 'after_setup_theme'                      , array( $this , 'czr_customizr_setup' ));
           //registers the menu
-          add_action( 'after_setup_theme'                       , array( $this, 'tc_register_menus'));
+          add_action( 'after_setup_theme'                       , array( $this, 'czr_register_menus'));
 
           //add retina support for high resolution devices
-          add_filter( 'wp_generate_attachment_metadata'        , array( $this , 'tc_add_retina_support') , 10 , 2 );
-          add_filter( 'delete_attachment'                      , array( $this , 'tc_clean_retina_images') );
+          add_filter( 'wp_generate_attachment_metadata'        , array( $this , 'czr_add_retina_support') , 10 , 2 );
+          add_filter( 'delete_attachment'                      , array( $this , 'czr_clean_retina_images') );
 
           //add classes to body tag : fade effect on link hover, is_customizing. Since v3.2.0
-          add_filter('body_class'                              , array( $this , 'tc_set_body_classes') );
+          add_filter('body_class'                              , array( $this , 'czr_set_body_classes') );
 
       }//end of constructor
 
@@ -406,8 +406,8 @@ if ( ! class_exists( 'CZR_init' ) ) :
         }
 
         if ( isset ( $_options['tc_slider_change_default_img_size'] ) && 0 != esc_attr( $_options['tc_slider_change_default_img_size'] ) && isset ( $_options['tc_slider_default_height'] ) && 500 != esc_attr( $_options['tc_slider_default_height'] ) ) {
-            add_filter( 'tc_slider_full_size'    , array($this,  'tc_set_slider_img_height') );
-            add_filter( 'tc_slider_size'         , array($this,  'tc_set_slider_img_height') );
+            add_filter( 'tc_slider_full_size'    , array($this,  'czr_set_slider_img_height') );
+            add_filter( 'tc_slider_size'         , array($this,  'czr_set_slider_img_height') );
         }
 
 
@@ -426,9 +426,9 @@ if ( ! class_exists( 'CZR_init' ) ) :
         add_image_size( 'tc-grid', $tc_grid_size['width'], $_user_grid_height, $tc_grid_size['crop'] );
 
         if ( $_user_grid_height != $tc_grid_full_size['height'] )
-          add_filter( 'tc_grid_full_size', array( $this,  'tc_set_grid_img_height') );
+          add_filter( 'tc_grid_full_size', array( $this,  'czr_set_grid_img_height') );
         if ( $_user_grid_height != $tc_grid_size['height'] )
-          add_filter( 'tc_grid_size'     , array( $this,  'tc_set_grid_img_height') );
+          add_filter( 'tc_grid_size'     , array( $this,  'czr_set_grid_img_height') );
 
       }
 
@@ -520,10 +520,10 @@ if ( ! class_exists( 'CZR_init' ) ) :
         add_image_size( 'slider' , $slider_size['width'] , $slider_size['height'], $slider_size['crop'] );
 
         //add support for svg and svgz format in media upload
-        add_filter( 'upload_mimes'                        , array( $this , 'tc_custom_mtypes' ) );
+        add_filter( 'upload_mimes'                        , array( $this , 'czr_custom_mtypes' ) );
 
         //add help button to admin bar
-        add_action ( 'wp_before_admin_bar_render'          , array( $this , 'tc_add_help_button' ));
+        add_action ( 'wp_before_admin_bar_render'          , array( $this , 'czr_add_help_button' ));
       }
 
 
@@ -566,7 +566,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
         else
           $tc_get_style_src  = $remote_path ? $remote_path.$_sheet : TC_BASE_URL.'inc/assets/css/tc_common.css';
 
-        return apply_filters ( 'tc_get_style_src' , $tc_get_style_src , $_wot );
+        return apply_filters ( 'czr_get_style_src' , $tc_get_style_src , $_wot );
       }
 
 

--- a/inc/class-fire-init.php
+++ b/inc/class-fire-init.php
@@ -365,19 +365,19 @@ if ( ! class_exists( 'CZR_init' ) ) :
 
           //Set image options set by user @since v3.2.0
           //! must be included in utils to be available in admin for plugins like regenerate thumbnails
-          add_action( 'after_setup_theme'                      , array( $this, 'czr_set_user_defined_settings'));
+          add_action( 'after_setup_theme'                      , array( $this, 'czr_fn_set_user_defined_settings'));
 
           //add the text domain, various theme supports : editor style, automatic-feed-links, post formats, post-thumbnails
-          add_action( 'after_setup_theme'                      , array( $this , 'czr_customizr_setup' ));
+          add_action( 'after_setup_theme'                      , array( $this , 'czr_fn_customizr_setup' ));
           //registers the menu
-          add_action( 'after_setup_theme'                       , array( $this, 'czr_register_menus'));
+          add_action( 'after_setup_theme'                       , array( $this, 'czr_fn_register_menus'));
 
           //add retina support for high resolution devices
-          add_filter( 'wp_generate_attachment_metadata'        , array( $this , 'czr_add_retina_support') , 10 , 2 );
-          add_filter( 'delete_attachment'                      , array( $this , 'czr_clean_retina_images') );
+          add_filter( 'wp_generate_attachment_metadata'        , array( $this , 'czr_fn_add_retina_support') , 10 , 2 );
+          add_filter( 'delete_attachment'                      , array( $this , 'czr_fn_clean_retina_images') );
 
           //add classes to body tag : fade effect on link hover, is_customizing. Since v3.2.0
-          add_filter('body_class'                              , array( $this , 'czr_set_body_classes') );
+          add_filter('body_class'                              , array( $this , 'czr_fn_set_body_classes') );
 
       }//end of constructor
 
@@ -392,7 +392,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
       * @package Customizr
       * @since Customizr 3.1.23
       */
-      function czr_set_user_defined_settings() {
+      function czr_fn_set_user_defined_settings() {
         $_options = get_option('tc_theme_options');
         //add "rectangular" image size
         if ( isset ( $_options['tc_post_list_thumb_shape'] ) && false !== strpos(esc_attr( $_options['tc_post_list_thumb_shape'] ), 'rectangular') ) {
@@ -406,8 +406,8 @@ if ( ! class_exists( 'CZR_init' ) ) :
         }
 
         if ( isset ( $_options['tc_slider_change_default_img_size'] ) && 0 != esc_attr( $_options['tc_slider_change_default_img_size'] ) && isset ( $_options['tc_slider_default_height'] ) && 500 != esc_attr( $_options['tc_slider_default_height'] ) ) {
-            add_filter( 'tc_slider_full_size'    , array($this,  'czr_set_slider_img_height') );
-            add_filter( 'tc_slider_size'         , array($this,  'czr_set_slider_img_height') );
+            add_filter( 'tc_slider_full_size'    , array($this,  'czr_fn_set_slider_img_height') );
+            add_filter( 'tc_slider_size'         , array($this,  'czr_fn_set_slider_img_height') );
         }
 
 
@@ -426,9 +426,9 @@ if ( ! class_exists( 'CZR_init' ) ) :
         add_image_size( 'tc-grid', $tc_grid_size['width'], $_user_grid_height, $tc_grid_size['crop'] );
 
         if ( $_user_grid_height != $tc_grid_full_size['height'] )
-          add_filter( 'tc_grid_full_size', array( $this,  'czr_set_grid_img_height') );
+          add_filter( 'tc_grid_full_size', array( $this,  'czr_fn_set_grid_img_height') );
         if ( $_user_grid_height != $tc_grid_size['height'] )
-          add_filter( 'tc_grid_size'     , array( $this,  'czr_set_grid_img_height') );
+          add_filter( 'tc_grid_size'     , array( $this,  'czr_fn_set_grid_img_height') );
 
       }
 
@@ -442,7 +442,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
       * @since Customizr 3.2.0
       *
       */
-      function czr_set_slider_img_height( $_default_size ) {
+      function czr_fn_set_slider_img_height( $_default_size ) {
         $_options = get_option('tc_theme_options');
 
         $_default_size['height'] = esc_attr( $_options['tc_slider_default_height'] );
@@ -458,7 +458,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
       * @since Customizr 3.1.12
       *
       */
-      function czr_set_grid_img_height( $_default_size ) {
+      function czr_fn_set_grid_img_height( $_default_size ) {
         $_options = get_option('tc_theme_options');
 
         $_default_size['height'] =  esc_attr( $_options['tc_grid_thumb_height'] ) ;
@@ -475,7 +475,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
        * @since Customizr 1.0
        */
 
-      function czr_customizr_setup() {
+      function czr_fn_customizr_setup() {
         /* Set default content width for post images and media. */
         global $content_width;
         if (! isset( $content_width ) )
@@ -520,10 +520,10 @@ if ( ! class_exists( 'CZR_init' ) ) :
         add_image_size( 'slider' , $slider_size['width'] , $slider_size['height'], $slider_size['crop'] );
 
         //add support for svg and svgz format in media upload
-        add_filter( 'upload_mimes'                        , array( $this , 'czr_custom_mtypes' ) );
+        add_filter( 'upload_mimes'                        , array( $this , 'czr_fn_custom_mtypes' ) );
 
         //add help button to admin bar
-        add_action ( 'wp_before_admin_bar_render'          , array( $this , 'czr_add_help_button' ));
+        add_action ( 'wp_before_admin_bar_render'          , array( $this , 'czr_fn_add_help_button' ));
       }
 
 
@@ -531,7 +531,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
       /*
       * hook : after_setup_theme
       */
-      function czr_register_menus() {
+      function czr_fn_register_menus() {
         /* This theme uses wp_nav_menu() in one location. */
         register_nav_menu( 'main' , __( 'Main Menu' , 'customizr' ) );
         register_nav_menu( 'secondary' , __( 'Secondary (horizontal) Menu' , 'customizr' ) );
@@ -546,16 +546,16 @@ if ( ! class_exists( 'CZR_init' ) ) :
       * @package Customizr
       * @since Customizr 3.0.15
       */
-      function czr_get_style_src( $_wot = 'skin' ) {
-        $_sheet    = ( 'skin' == $_wot ) ? esc_attr( CZR_utils::$inst->czr_opt( 'tc_skin' ) ) : 'tc_common.css';
-        $_sheet    = $this -> czr_maybe_use_min_style( $_sheet );
+      function czr_fn_get_style_src( $_wot = 'skin' ) {
+        $_sheet    = ( 'skin' == $_wot ) ? esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_skin' ) ) : 'tc_common.css';
+        $_sheet    = $this -> czr_fn_maybe_use_min_style( $_sheet );
 
         //Finds the good path : are we in a child theme and is there a skin to override?
-        $remote_path    = ( CZR___::$instance -> czr_is_child() && file_exists(TC_BASE_CHILD .'inc/assets/css/' . $_sheet) ) ? TC_BASE_URL_CHILD .'inc/assets/css/' : false ;
+        $remote_path    = ( CZR___::$instance -> czr_fn_is_child() && file_exists(TC_BASE_CHILD .'inc/assets/css/' . $_sheet) ) ? TC_BASE_URL_CHILD .'inc/assets/css/' : false ;
         $remote_path    = ( ! $remote_path && file_exists(TC_BASE .'inc/assets/css/' . $_sheet) ) ? TC_BASE_URL .'inc/assets/css/' : $remote_path ;
         //Checks if there is a rtl version of common if needed
         if ( 'skin' != $_wot && ( is_rtl() || ( defined( 'WPLANG' ) && ( 'ar' == WPLANG || 'he_IL' == WPLANG ) ) ) ){
-          $remote_rtl_path   = ( CZR___::$instance -> czr_is_child() && file_exists(TC_BASE_CHILD .'inc/assets/css/rtl/' . $_sheet) ) ? TC_BASE_URL_CHILD .'inc/assets/css/rtl/' : false ;
+          $remote_rtl_path   = ( CZR___::$instance -> czr_fn_is_child() && file_exists(TC_BASE_CHILD .'inc/assets/css/rtl/' . $_sheet) ) ? TC_BASE_URL_CHILD .'inc/assets/css/rtl/' : false ;
           $remote_rtl_path   = ( ! $remote_rtl_path && file_exists(TC_BASE .'inc/assets/css/rtl/' . $_sheet) ) ? TC_BASE_URL .'inc/assets/css/rtl/' : $remote_rtl_path;
           $remote_path       = $remote_rtl_path ? $remote_rtl_path : $remote_path;
         }
@@ -566,7 +566,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
         else
           $tc_get_style_src  = $remote_path ? $remote_path.$_sheet : TC_BASE_URL.'inc/assets/css/tc_common.css';
 
-        return apply_filters ( 'czr_get_style_src' , $tc_get_style_src , $_wot );
+        return apply_filters ( 'czr_fn_get_style_src' , $tc_get_style_src , $_wot );
       }
 
 
@@ -584,8 +584,8 @@ if ( ! class_exists( 'CZR_init' ) ) :
       * @package Customizr
       * @since Customizr 3.4.19
       */
-      function czr_maybe_use_min_style( $_sheet ) {
-        if ( esc_attr( CZR_utils::$inst->czr_opt( 'tc_minified_skin' ) ) )
+      function czr_fn_maybe_use_min_style( $_sheet ) {
+        if ( esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_minified_skin' ) ) )
           $_sheet = ( defined('CZR_NOT_MINIFIED_CSS') && true === CZR_NOT_MINIFIED_CSS ) ? $_sheet : str_replace('.css', '.min.css', $_sheet);
         return $_sheet;
       }
@@ -598,7 +598,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
       * @package Customizr
       * @since Customizr 3.1.19
       */
-      function czr_custom_mtypes( $mimes ) {
+      function czr_fn_custom_mtypes( $mimes ) {
         if (! apply_filters( 'tc_add_svg_mime_type' , true ) )
           return $mimes;
 
@@ -617,9 +617,9 @@ if ( ! class_exists( 'CZR_init' ) ) :
      * @since Customizr 3.0.15
      * @credits http://wp.tutsplus.com/author/chrisbavota/
      */
-      function czr_add_retina_support( $metadata, $attachment_id ) {
+      function czr_fn_add_retina_support( $metadata, $attachment_id ) {
         //checks if retina is enabled in options
-        if ( 0 == CZR_utils::$inst->czr_opt( 'tc_retina_support' ) )
+        if ( 0 == CZR_utils::$inst->czr_fn_opt( 'tc_retina_support' ) )
           return $metadata;
 
         if ( ! is_array($metadata) )
@@ -627,7 +627,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
 
         //Create the retina image for the main file
         if ( is_array($metadata) && isset($metadata['width']) && isset($metadata['height']) )
-          $this -> czr_create_retina_images( get_attached_file( $attachment_id ), $metadata['width'], $metadata['height'] , false, $_is_intermediate = false );
+          $this -> czr_fn_create_retina_images( get_attached_file( $attachment_id ), $metadata['width'], $metadata['height'] , false, $_is_intermediate = false );
 
         //Create the retina images for each WP sizes
         foreach ( $metadata as $key => $data ) {
@@ -635,7 +635,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
               continue;
             foreach ( $data as $_size_name => $_attr ) {
                 if ( is_array( $_attr ) && isset($_attr['width']) && isset($_attr['height']) )
-                    $this -> czr_create_retina_images( get_attached_file( $attachment_id ), $_attr['width'], $_attr['height'], true, $_is_intermediate = true );
+                    $this -> czr_fn_create_retina_images( get_attached_file( $attachment_id ), $_attr['width'], $_attr['height'], true, $_is_intermediate = true );
             }
         }
         return $metadata;
@@ -650,7 +650,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
       * @since Customizr 3.0.15
       * @credits http://wp.tutsplus.com/author/chrisbavota/
       */
-      function czr_create_retina_images( $file, $width, $height, $crop = false , $_is_intermediate = true) {
+      function czr_fn_create_retina_images( $file, $width, $height, $crop = false , $_is_intermediate = true) {
           $resized_file = wp_get_image_editor( $file );
           if ( is_wp_error( $resized_file ) )
             return false;
@@ -686,7 +686,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
      * @since Customizr 3.0.15
      * @credits http://wp.tutsplus.com/author/chrisbavota/
      */
-      function czr_clean_retina_images( $attachment_id ) {
+      function czr_fn_clean_retina_images( $attachment_id ) {
         $meta = wp_get_attachment_metadata( $attachment_id );
         if ( !isset( $meta['file']) )
           return;
@@ -712,7 +712,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
       * @package Customizr
       * @since Customizr 1.0
       */
-      function czr_add_help_button() {
+      function czr_fn_add_help_button() {
          if ( current_user_can( 'edit_theme_options' ) ) {
            global $wp_admin_bar;
            $wp_admin_bar->add_menu( array(
@@ -736,18 +736,18 @@ if ( ! class_exists( 'CZR_init' ) ) :
       * @package Customizr
       * @since Customizr 3.2.0
       */
-      function czr_set_body_classes( $_classes ) {
-        if ( 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_link_hover_effect' ) ) )
+      function czr_fn_set_body_classes( $_classes ) {
+        if ( 0 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_link_hover_effect' ) ) )
           array_push( $_classes, 'tc-fade-hover-links' );
-        if ( CZR___::$instance -> czr_is_customizing() )
+        if ( CZR___::$instance -> czr_fn_is_customizing() )
           array_push( $_classes, 'is-customizing' );
         if ( wp_is_mobile() )
           array_push( $_classes, 'tc-is-mobile' );
-        if ( 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_enable_dropcap' ) ) )
-          array_push( $_classes, esc_attr( CZR_utils::$inst->czr_opt( 'tc_dropcap_design' ) ) );
+        if ( 0 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_enable_dropcap' ) ) )
+          array_push( $_classes, esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_dropcap_design' ) ) );
 
         //adds the layout
-        $_layout = CZR_utils::czr_get_layout( CZR_utils::czr_id() , 'sidebar' );
+        $_layout = CZR_utils::czr_fn_get_layout( CZR_utils::czr_fn_id() , 'sidebar' );
         if ( in_array( $_layout, array('b', 'l', 'r' , 'f') ) ) {
           array_push( $_classes, sprintf( 'tc-%s-sidebar',
             'f' == $_layout ? 'no' : $_layout

--- a/inc/class-fire-init.php
+++ b/inc/class-fire-init.php
@@ -392,7 +392,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
       * @package Customizr
       * @since Customizr 3.1.23
       */
-      function tc_set_user_defined_settings() {
+      function czr_set_user_defined_settings() {
         $_options = get_option('tc_theme_options');
         //add "rectangular" image size
         if ( isset ( $_options['tc_post_list_thumb_shape'] ) && false !== strpos(esc_attr( $_options['tc_post_list_thumb_shape'] ), 'rectangular') ) {
@@ -442,7 +442,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
       * @since Customizr 3.2.0
       *
       */
-      function tc_set_slider_img_height( $_default_size ) {
+      function czr_set_slider_img_height( $_default_size ) {
         $_options = get_option('tc_theme_options');
 
         $_default_size['height'] = esc_attr( $_options['tc_slider_default_height'] );
@@ -458,7 +458,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
       * @since Customizr 3.1.12
       *
       */
-      function tc_set_grid_img_height( $_default_size ) {
+      function czr_set_grid_img_height( $_default_size ) {
         $_options = get_option('tc_theme_options');
 
         $_default_size['height'] =  esc_attr( $_options['tc_grid_thumb_height'] ) ;
@@ -475,7 +475,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
        * @since Customizr 1.0
        */
 
-      function tc_customizr_setup() {
+      function czr_customizr_setup() {
         /* Set default content width for post images and media. */
         global $content_width;
         if (! isset( $content_width ) )
@@ -531,7 +531,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
       /*
       * hook : after_setup_theme
       */
-      function tc_register_menus() {
+      function czr_register_menus() {
         /* This theme uses wp_nav_menu() in one location. */
         register_nav_menu( 'main' , __( 'Main Menu' , 'customizr' ) );
         register_nav_menu( 'secondary' , __( 'Secondary (horizontal) Menu' , 'customizr' ) );
@@ -546,7 +546,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
       * @package Customizr
       * @since Customizr 3.0.15
       */
-      function tc_get_style_src( $_wot = 'skin' ) {
+      function czr_get_style_src( $_wot = 'skin' ) {
         $_sheet    = ( 'skin' == $_wot ) ? esc_attr( CZR_utils::$inst->tc_opt( 'tc_skin' ) ) : 'tc_common.css';
         $_sheet    = $this -> tc_maybe_use_min_style( $_sheet );
 
@@ -584,7 +584,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
       * @package Customizr
       * @since Customizr 3.4.19
       */
-      function tc_maybe_use_min_style( $_sheet ) {
+      function czr_maybe_use_min_style( $_sheet ) {
         if ( esc_attr( CZR_utils::$inst->tc_opt( 'tc_minified_skin' ) ) )
           $_sheet = ( defined('CZR_NOT_MINIFIED_CSS') && true === CZR_NOT_MINIFIED_CSS ) ? $_sheet : str_replace('.css', '.min.css', $_sheet);
         return $_sheet;
@@ -598,7 +598,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
       * @package Customizr
       * @since Customizr 3.1.19
       */
-      function tc_custom_mtypes( $mimes ) {
+      function czr_custom_mtypes( $mimes ) {
         if (! apply_filters( 'tc_add_svg_mime_type' , true ) )
           return $mimes;
 
@@ -617,7 +617,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
      * @since Customizr 3.0.15
      * @credits http://wp.tutsplus.com/author/chrisbavota/
      */
-      function tc_add_retina_support( $metadata, $attachment_id ) {
+      function czr_add_retina_support( $metadata, $attachment_id ) {
         //checks if retina is enabled in options
         if ( 0 == CZR_utils::$inst->tc_opt( 'tc_retina_support' ) )
           return $metadata;
@@ -650,7 +650,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
       * @since Customizr 3.0.15
       * @credits http://wp.tutsplus.com/author/chrisbavota/
       */
-      function tc_create_retina_images( $file, $width, $height, $crop = false , $_is_intermediate = true) {
+      function czr_create_retina_images( $file, $width, $height, $crop = false , $_is_intermediate = true) {
           $resized_file = wp_get_image_editor( $file );
           if ( is_wp_error( $resized_file ) )
             return false;
@@ -686,7 +686,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
      * @since Customizr 3.0.15
      * @credits http://wp.tutsplus.com/author/chrisbavota/
      */
-      function tc_clean_retina_images( $attachment_id ) {
+      function czr_clean_retina_images( $attachment_id ) {
         $meta = wp_get_attachment_metadata( $attachment_id );
         if ( !isset( $meta['file']) )
           return;
@@ -712,7 +712,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
       * @package Customizr
       * @since Customizr 1.0
       */
-      function tc_add_help_button() {
+      function czr_add_help_button() {
          if ( current_user_can( 'edit_theme_options' ) ) {
            global $wp_admin_bar;
            $wp_admin_bar->add_menu( array(
@@ -736,7 +736,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
       * @package Customizr
       * @since Customizr 3.2.0
       */
-      function tc_set_body_classes( $_classes ) {
+      function czr_set_body_classes( $_classes ) {
         if ( 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_link_hover_effect' ) ) )
           array_push( $_classes, 'tc-fade-hover-links' );
         if ( CZR___::$instance -> tc_is_customizing() )

--- a/inc/class-fire-init.php
+++ b/inc/class-fire-init.php
@@ -13,8 +13,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_init' ) ) :
-  class TC_init {
+if ( ! class_exists( 'CZR_init' ) ) :
+  class CZR_init {
       //declares the filtered default settings
       public $global_layout;
       public $tc_thumb_size;
@@ -547,15 +547,15 @@ if ( ! class_exists( 'TC_init' ) ) :
       * @since Customizr 3.0.15
       */
       function tc_get_style_src( $_wot = 'skin' ) {
-        $_sheet    = ( 'skin' == $_wot ) ? esc_attr( TC_utils::$inst->tc_opt( 'tc_skin' ) ) : 'tc_common.css';
+        $_sheet    = ( 'skin' == $_wot ) ? esc_attr( CZR_utils::$inst->tc_opt( 'tc_skin' ) ) : 'tc_common.css';
         $_sheet    = $this -> tc_maybe_use_min_style( $_sheet );
 
         //Finds the good path : are we in a child theme and is there a skin to override?
-        $remote_path    = ( TC___::$instance -> tc_is_child() && file_exists(TC_BASE_CHILD .'inc/assets/css/' . $_sheet) ) ? TC_BASE_URL_CHILD .'inc/assets/css/' : false ;
+        $remote_path    = ( CZR___::$instance -> tc_is_child() && file_exists(TC_BASE_CHILD .'inc/assets/css/' . $_sheet) ) ? TC_BASE_URL_CHILD .'inc/assets/css/' : false ;
         $remote_path    = ( ! $remote_path && file_exists(TC_BASE .'inc/assets/css/' . $_sheet) ) ? TC_BASE_URL .'inc/assets/css/' : $remote_path ;
         //Checks if there is a rtl version of common if needed
         if ( 'skin' != $_wot && ( is_rtl() || ( defined( 'WPLANG' ) && ( 'ar' == WPLANG || 'he_IL' == WPLANG ) ) ) ){
-          $remote_rtl_path   = ( TC___::$instance -> tc_is_child() && file_exists(TC_BASE_CHILD .'inc/assets/css/rtl/' . $_sheet) ) ? TC_BASE_URL_CHILD .'inc/assets/css/rtl/' : false ;
+          $remote_rtl_path   = ( CZR___::$instance -> tc_is_child() && file_exists(TC_BASE_CHILD .'inc/assets/css/rtl/' . $_sheet) ) ? TC_BASE_URL_CHILD .'inc/assets/css/rtl/' : false ;
           $remote_rtl_path   = ( ! $remote_rtl_path && file_exists(TC_BASE .'inc/assets/css/rtl/' . $_sheet) ) ? TC_BASE_URL .'inc/assets/css/rtl/' : $remote_rtl_path;
           $remote_path       = $remote_rtl_path ? $remote_rtl_path : $remote_path;
         }
@@ -572,7 +572,7 @@ if ( ! class_exists( 'TC_init' ) ) :
 
 
       /**
-      * //Move in TC_utils?
+      * //Move in CZR_utils?
       *
       * Returns the min or normal version of the passed css filename (basename.type)
       * depending on whether or not the minified version should be used
@@ -585,8 +585,8 @@ if ( ! class_exists( 'TC_init' ) ) :
       * @since Customizr 3.4.19
       */
       function tc_maybe_use_min_style( $_sheet ) {
-        if ( esc_attr( TC_utils::$inst->tc_opt( 'tc_minified_skin' ) ) )
-          $_sheet = ( defined('TC_NOT_MINIFIED_CSS') && true === TC_NOT_MINIFIED_CSS ) ? $_sheet : str_replace('.css', '.min.css', $_sheet);
+        if ( esc_attr( CZR_utils::$inst->tc_opt( 'tc_minified_skin' ) ) )
+          $_sheet = ( defined('CZR_NOT_MINIFIED_CSS') && true === CZR_NOT_MINIFIED_CSS ) ? $_sheet : str_replace('.css', '.min.css', $_sheet);
         return $_sheet;
       }
 
@@ -619,7 +619,7 @@ if ( ! class_exists( 'TC_init' ) ) :
      */
       function tc_add_retina_support( $metadata, $attachment_id ) {
         //checks if retina is enabled in options
-        if ( 0 == TC_utils::$inst->tc_opt( 'tc_retina_support' ) )
+        if ( 0 == CZR_utils::$inst->tc_opt( 'tc_retina_support' ) )
           return $metadata;
 
         if ( ! is_array($metadata) )
@@ -737,17 +737,17 @@ if ( ! class_exists( 'TC_init' ) ) :
       * @since Customizr 3.2.0
       */
       function tc_set_body_classes( $_classes ) {
-        if ( 0 != esc_attr( TC_utils::$inst->tc_opt( 'tc_link_hover_effect' ) ) )
+        if ( 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_link_hover_effect' ) ) )
           array_push( $_classes, 'tc-fade-hover-links' );
-        if ( TC___::$instance -> tc_is_customizing() )
+        if ( CZR___::$instance -> tc_is_customizing() )
           array_push( $_classes, 'is-customizing' );
         if ( wp_is_mobile() )
           array_push( $_classes, 'tc-is-mobile' );
-        if ( 0 != esc_attr( TC_utils::$inst->tc_opt( 'tc_enable_dropcap' ) ) )
-          array_push( $_classes, esc_attr( TC_utils::$inst->tc_opt( 'tc_dropcap_design' ) ) );
+        if ( 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_enable_dropcap' ) ) )
+          array_push( $_classes, esc_attr( CZR_utils::$inst->tc_opt( 'tc_dropcap_design' ) ) );
 
         //adds the layout
-        $_layout = TC_utils::tc_get_layout( TC_utils::tc_id() , 'sidebar' );
+        $_layout = CZR_utils::tc_get_layout( CZR_utils::tc_id() , 'sidebar' );
         if ( in_array( $_layout, array('b', 'l', 'r' , 'f') ) ) {
           array_push( $_classes, sprintf( 'tc-%s-sidebar',
             'f' == $_layout ? 'no' : $_layout

--- a/inc/class-fire-init.php
+++ b/inc/class-fire-init.php
@@ -566,7 +566,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
         else
           $tc_get_style_src  = $remote_path ? $remote_path.$_sheet : TC_BASE_URL.'inc/assets/css/tc_common.css';
 
-        return apply_filters ( 'czr_fn_get_style_src' , $tc_get_style_src , $_wot );
+        return apply_filters ( 'tc_get_style_src' , $tc_get_style_src , $_wot );
       }
 
 

--- a/inc/class-fire-init.php
+++ b/inc/class-fire-init.php
@@ -547,15 +547,15 @@ if ( ! class_exists( 'CZR_init' ) ) :
       * @since Customizr 3.0.15
       */
       function czr_get_style_src( $_wot = 'skin' ) {
-        $_sheet    = ( 'skin' == $_wot ) ? esc_attr( CZR_utils::$inst->tc_opt( 'tc_skin' ) ) : 'tc_common.css';
-        $_sheet    = $this -> tc_maybe_use_min_style( $_sheet );
+        $_sheet    = ( 'skin' == $_wot ) ? esc_attr( CZR_utils::$inst->czr_opt( 'tc_skin' ) ) : 'tc_common.css';
+        $_sheet    = $this -> czr_maybe_use_min_style( $_sheet );
 
         //Finds the good path : are we in a child theme and is there a skin to override?
-        $remote_path    = ( CZR___::$instance -> tc_is_child() && file_exists(TC_BASE_CHILD .'inc/assets/css/' . $_sheet) ) ? TC_BASE_URL_CHILD .'inc/assets/css/' : false ;
+        $remote_path    = ( CZR___::$instance -> czr_is_child() && file_exists(TC_BASE_CHILD .'inc/assets/css/' . $_sheet) ) ? TC_BASE_URL_CHILD .'inc/assets/css/' : false ;
         $remote_path    = ( ! $remote_path && file_exists(TC_BASE .'inc/assets/css/' . $_sheet) ) ? TC_BASE_URL .'inc/assets/css/' : $remote_path ;
         //Checks if there is a rtl version of common if needed
         if ( 'skin' != $_wot && ( is_rtl() || ( defined( 'WPLANG' ) && ( 'ar' == WPLANG || 'he_IL' == WPLANG ) ) ) ){
-          $remote_rtl_path   = ( CZR___::$instance -> tc_is_child() && file_exists(TC_BASE_CHILD .'inc/assets/css/rtl/' . $_sheet) ) ? TC_BASE_URL_CHILD .'inc/assets/css/rtl/' : false ;
+          $remote_rtl_path   = ( CZR___::$instance -> czr_is_child() && file_exists(TC_BASE_CHILD .'inc/assets/css/rtl/' . $_sheet) ) ? TC_BASE_URL_CHILD .'inc/assets/css/rtl/' : false ;
           $remote_rtl_path   = ( ! $remote_rtl_path && file_exists(TC_BASE .'inc/assets/css/rtl/' . $_sheet) ) ? TC_BASE_URL .'inc/assets/css/rtl/' : $remote_rtl_path;
           $remote_path       = $remote_rtl_path ? $remote_rtl_path : $remote_path;
         }
@@ -585,7 +585,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
       * @since Customizr 3.4.19
       */
       function czr_maybe_use_min_style( $_sheet ) {
-        if ( esc_attr( CZR_utils::$inst->tc_opt( 'tc_minified_skin' ) ) )
+        if ( esc_attr( CZR_utils::$inst->czr_opt( 'tc_minified_skin' ) ) )
           $_sheet = ( defined('CZR_NOT_MINIFIED_CSS') && true === CZR_NOT_MINIFIED_CSS ) ? $_sheet : str_replace('.css', '.min.css', $_sheet);
         return $_sheet;
       }
@@ -619,7 +619,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
      */
       function czr_add_retina_support( $metadata, $attachment_id ) {
         //checks if retina is enabled in options
-        if ( 0 == CZR_utils::$inst->tc_opt( 'tc_retina_support' ) )
+        if ( 0 == CZR_utils::$inst->czr_opt( 'tc_retina_support' ) )
           return $metadata;
 
         if ( ! is_array($metadata) )
@@ -627,7 +627,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
 
         //Create the retina image for the main file
         if ( is_array($metadata) && isset($metadata['width']) && isset($metadata['height']) )
-          $this -> tc_create_retina_images( get_attached_file( $attachment_id ), $metadata['width'], $metadata['height'] , false, $_is_intermediate = false );
+          $this -> czr_create_retina_images( get_attached_file( $attachment_id ), $metadata['width'], $metadata['height'] , false, $_is_intermediate = false );
 
         //Create the retina images for each WP sizes
         foreach ( $metadata as $key => $data ) {
@@ -635,7 +635,7 @@ if ( ! class_exists( 'CZR_init' ) ) :
               continue;
             foreach ( $data as $_size_name => $_attr ) {
                 if ( is_array( $_attr ) && isset($_attr['width']) && isset($_attr['height']) )
-                    $this -> tc_create_retina_images( get_attached_file( $attachment_id ), $_attr['width'], $_attr['height'], true, $_is_intermediate = true );
+                    $this -> czr_create_retina_images( get_attached_file( $attachment_id ), $_attr['width'], $_attr['height'], true, $_is_intermediate = true );
             }
         }
         return $metadata;
@@ -737,17 +737,17 @@ if ( ! class_exists( 'CZR_init' ) ) :
       * @since Customizr 3.2.0
       */
       function czr_set_body_classes( $_classes ) {
-        if ( 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_link_hover_effect' ) ) )
+        if ( 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_link_hover_effect' ) ) )
           array_push( $_classes, 'tc-fade-hover-links' );
-        if ( CZR___::$instance -> tc_is_customizing() )
+        if ( CZR___::$instance -> czr_is_customizing() )
           array_push( $_classes, 'is-customizing' );
         if ( wp_is_mobile() )
           array_push( $_classes, 'tc-is-mobile' );
-        if ( 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_enable_dropcap' ) ) )
-          array_push( $_classes, esc_attr( CZR_utils::$inst->tc_opt( 'tc_dropcap_design' ) ) );
+        if ( 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_enable_dropcap' ) ) )
+          array_push( $_classes, esc_attr( CZR_utils::$inst->czr_opt( 'tc_dropcap_design' ) ) );
 
         //adds the layout
-        $_layout = CZR_utils::tc_get_layout( CZR_utils::tc_id() , 'sidebar' );
+        $_layout = CZR_utils::czr_get_layout( CZR_utils::czr_id() , 'sidebar' );
         if ( in_array( $_layout, array('b', 'l', 'r' , 'f') ) ) {
           array_push( $_classes, sprintf( 'tc-%s-sidebar',
             'f' == $_layout ? 'no' : $_layout

--- a/inc/class-fire-placeholders.php
+++ b/inc/class-fire-placeholders.php
@@ -733,7 +733,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
       check_ajax_referer( 'tc-fp-notice-nonce', 'fpNoticeNonce' );
       switch ($_remove_action) {
         case 'remove_fp':
-          CZR_utils::$inst -> czr_fn_set_option( 'czr_fn_show_featured_pages' , 0 );
+          CZR_utils::$inst -> czr_fn_set_option( 'tc_show_featured_pages' , 0 );
         break;
 
         case 'remove_notice':
@@ -818,7 +818,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
       $_dont_display_conditions = array(
         ! is_user_logged_in() || ! current_user_can('edit_theme_options'),
         ! is_admin() && ! CZR_utils::$inst-> czr_fn_is_home(),
-        ! (bool)CZR_utils::$inst->czr_fn_opt('czr_fn_show_featured_pages'),
+        ! (bool)CZR_utils::$inst->czr_fn_opt('tc_show_featured_pages'),
         'disabled' == get_transient("tc_fp_notice"),
         self::$instance -> czr_fn_is_one_fp_set(),
         CZR___::czr_fn_is_pro(),

--- a/inc/class-fire-placeholders.php
+++ b/inc/class-fire-placeholders.php
@@ -30,7 +30,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * hook : init => because we need to fire this function before the admin_ajax.php call
     * @since v3.4+
     */
-    function tc_placeholders_ajax_setup() {
+    function czr_placeholders_ajax_setup() {
       if ( ! $this -> tc_is_front_help_enabled() )
         return;
       add_action( 'wp_ajax_dismiss_thumbnail_help'    , array( $this, 'tc_dismiss_thumbnail_help' ) );
@@ -52,7 +52,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * hook : wp => because we need to access some conditional tags like is_home when checking if the placeholder / notice are enabled
     * @since v3.4+
     */
-    function tc_placeholders_write_ajax_js_in_footer() {
+    function czr_placeholders_write_ajax_js_in_footer() {
       if ( ! $this -> tc_is_front_help_enabled() )
         return;
       if ( $this -> tc_is_thumbnail_help_on() )
@@ -91,7 +91,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function tc_dismiss_thumbnail_help() {
+    function czr_dismiss_thumbnail_help() {
       check_ajax_referer( 'tc-thumbnail-help-nonce', 'thumbnailNonce' );
       set_transient( 'tc_thumbnail_help', 'disabled' , 60*60*24*365*20 );//20 years of peace
       wp_die();
@@ -105,7 +105,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function tc_write_thumbnail_help_js() {
+    function czr_write_thumbnail_help_js() {
       ?>
       <script type="text/javascript" id="thumbnail-help">
         ( function( $ ) {
@@ -148,7 +148,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @return  bool
     * @since Customizr 3.3+
     */
-    static function tc_is_thumbnail_help_on() {
+    static function czr_is_thumbnail_help_on() {
       //never display when customizing
       if ( CZR___::$instance -> tc_is_customizing() )
         return;
@@ -185,7 +185,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function tc_dismiss_img_smartload_help() {
+    function czr_dismiss_img_smartload_help() {
       check_ajax_referer( 'tc-img-smartload-help-nonce', 'imgSmartLoadNonce' );
       set_transient( 'tc_img_smartload_help', 'disabled' , 60*60*24*365*20 );//20 years of peace
       wp_die();
@@ -197,7 +197,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    static function tc_get_smartload_help_block( $echo = false ) {
+    static function czr_get_smartload_help_block( $echo = false ) {
       //prepare js printing in the footer
       add_filter( 'tc_write_img_smartload_help_js', '__return_true' );
 
@@ -234,7 +234,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function tc_maybe_write_img_sarmtload_help_js() {
+    function czr_maybe_write_img_sarmtload_help_js() {
       if ( ! apply_filters( 'tc_write_img_smartload_help_js', false ) ) return;
       ?>
       <script type="text/javascript" id="img-smartload-help">
@@ -278,7 +278,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @return  bool
     * @since Customizr 3.4+
     */
-    static function tc_is_img_smartload_help_on( $text, $min_img_num = 2 ) {
+    static function czr_is_img_smartload_help_on( $text, $min_img_num = 2 ) {
       //never display when customizing
       if ( CZR___::$instance -> tc_is_customizing() )
         return;
@@ -322,7 +322,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function tc_dismiss_sidenav_help() {
+    function czr_dismiss_sidenav_help() {
       check_ajax_referer( 'tc-sidenav-help-nonce', 'sideNavNonce' );
       set_transient( 'tc_sidenav_help', 'disabled' , 60*60*24*365*20 );//20 years of peace
       wp_die();
@@ -336,7 +336,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function tc_write_sidenav_help_js() {
+    function czr_write_sidenav_help_js() {
       ?>
       <script type="text/javascript" id="sidenav-help">
         ( function( $ ) {
@@ -379,7 +379,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @return  bool
     * @since Customizr 3.3+
     */
-    static function tc_is_sidenav_help_on() {
+    static function czr_is_sidenav_help_on() {
       //never display when customizing
       if ( CZR___::$instance -> tc_is_customizing() )
         return;
@@ -418,7 +418,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    function tc_dismiss_second_menu_notice() {
+    function czr_dismiss_second_menu_notice() {
       check_ajax_referer( 'tc-second-menu-placeholder-nonce', 'secondMenuNonce' );
       set_transient( 'tc_second_menu_placehold', 'disabled' , 60*60*24*365*20 );//20 years of peace
       wp_die();
@@ -432,7 +432,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function tc_write_second_menu_placeholder_js() {
+    function czr_write_second_menu_placeholder_js() {
       ?>
       <script type="text/javascript" id="second-menu-placeholder">
         ( function( $ ) {
@@ -475,7 +475,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @return  bool
     * @since Customizr 3.3+
     */
-    static function tc_is_second_menu_placeholder_on() {
+    static function czr_is_second_menu_placeholder_on() {
       //never display when customizing
       if ( CZR___::$instance -> tc_is_customizing() )
         return;
@@ -508,7 +508,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    function tc_dismiss_main_menu_notice() {
+    function czr_dismiss_main_menu_notice() {
       check_ajax_referer( 'tc-main-menu-notice-nonce', 'mainMenuNonce' );
       set_transient( 'tc_main_menu_notice', 'disabled' , 60*60*24*365*20 );//20 years of peace
       wp_die();
@@ -522,7 +522,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function tc_write_main_menu_notice_js() {
+    function czr_write_main_menu_notice_js() {
       ?>
       <script type="text/javascript" id="main-menu-placeholder">
         ( function( $ ) {
@@ -565,7 +565,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @return  bool
     * @since Customizr 3.3+
     */
-    static function tc_is_main_menu_notice_on() {
+    static function czr_is_main_menu_notice_on() {
       //never display when customizing
       if ( CZR___::$instance -> tc_is_customizing() )
         return;
@@ -603,7 +603,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function tc_slider_notice_ajax_actions() {
+    function czr_slider_notice_ajax_actions() {
       if ( isset( $_POST['remove_action'] ) )
         $_remove_action = esc_attr( $_POST['remove_action'] );
       else
@@ -633,7 +633,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function tc_write_slider_notice_js() {
+    function czr_write_slider_notice_js() {
       ?>
       <script type="text/javascript" id="slider-notice-actions">
         ( function( $ ) {
@@ -685,7 +685,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @return  bool
     * @since Customizr 3.4+
     */
-    static function tc_is_slider_notice_on( $_position = null ) {
+    static function czr_is_slider_notice_on( $_position = null ) {
       //never display when customizing
       if ( CZR___::$instance -> tc_is_customizing() )
         return;
@@ -724,7 +724,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function tc_fp_notice_ajax_actions() {
+    function czr_fp_notice_ajax_actions() {
       if ( isset( $_POST['remove_action'] ) )
         $_remove_action = esc_attr( $_POST['remove_action'] );
       else
@@ -754,7 +754,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function tc_write_fp_notice_js() {
+    function czr_write_fp_notice_js() {
       ?>
       <script type="text/javascript" id="fp-notice-actions">
         ( function( $ ) {
@@ -806,7 +806,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @return  bool
     * @since Customizr 3.4+
     */
-    static function tc_is_fp_notice_on( $_position = null ) {
+    static function czr_is_fp_notice_on( $_position = null ) {
       //never display when customizing
       if ( CZR___::$instance -> tc_is_customizing() )
         return;
@@ -839,7 +839,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @return bool
     * @since v3.4+
     */
-    function tc_is_one_fp_set() {
+    function czr_is_one_fp_set() {
       $_fp_sets = array();
       $fp_ids = apply_filters( 'tc_featured_pages_ids' , CZR_init::$instance -> fp_ids);
       if ( ! is_array($fp_ids) )
@@ -863,7 +863,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    function tc_widget_placeholder_script() {
+    function czr_widget_placeholder_script() {
       ?>
       <script type="text/javascript" id="widget-placeholders">
         var tc_dismiss_widget_notice = function( _position, $_el ) {
@@ -910,7 +910,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    function tc_dismiss_widget_notice() {
+    function czr_dismiss_widget_notice() {
       check_ajax_referer( 'tc-widget-placeholder-nonce', 'WidgetNonce' );
       if ( isset( $_POST['position'] ) )
         $_pos = esc_attr( $_POST['position'] );
@@ -927,7 +927,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @return  bool
     * @since Customizr 3.3+
     */
-    static function tc_is_widget_placeholder_enabled( $_position = null ) {
+    static function czr_is_widget_placeholder_enabled( $_position = null ) {
       //never display when customizing
       if ( CZR___::$instance -> tc_is_customizing() )
         return;
@@ -947,7 +947,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @return  bool
     * @since Customizr 3.3+
     */
-    function tc_check_widget_placeholder_transient( $_position ){
+    function czr_check_widget_placeholder_transient( $_position ){
       return 'disabled' != get_transient("tc_widget_placehold_{$_position}");
     }
 
@@ -957,7 +957,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @since Customizr 3.4+
     * User option to enabe/disable all notices. Enabled by default.
     */
-    function tc_is_front_help_enabled(){
+    function czr_is_front_help_enabled(){
       return apply_filters( 'tc_is_front_help_enabled' , (bool)CZR_utils::$inst->tc_opt('tc_display_front_help') );
     }
 

--- a/inc/class-fire-placeholders.php
+++ b/inc/class-fire-placeholders.php
@@ -18,8 +18,8 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     static $instance;
     function __construct () {
       self::$instance =& $this;
-      add_action( 'init'           , array( $this, 'czr_placeholders_ajax_setup') );
-      add_action( 'wp'             , array( $this, 'czr_placeholders_write_ajax_js_in_footer') );
+      add_action( 'init'           , array( $this, 'czr_fn_placeholders_ajax_setup') );
+      add_action( 'wp'             , array( $this, 'czr_fn_placeholders_write_ajax_js_in_footer') );
     }
 
 
@@ -30,17 +30,17 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * hook : init => because we need to fire this function before the admin_ajax.php call
     * @since v3.4+
     */
-    function czr_placeholders_ajax_setup() {
-      if ( ! $this -> czr_is_front_help_enabled() )
+    function czr_fn_placeholders_ajax_setup() {
+      if ( ! $this -> czr_fn_is_front_help_enabled() )
         return;
-      add_action( 'wp_ajax_dismiss_thumbnail_help'    , array( $this, 'czr_dismiss_thumbnail_help' ) );
-      add_action( 'wp_ajax_dismiss_img_smartload_help', array( $this, 'czr_dismiss_img_smartload_help' ) );
-      add_action( 'wp_ajax_dismiss_sidenav_help'      , array( $this, 'czr_dismiss_sidenav_help' ) );
-      add_action( 'wp_ajax_dismiss_second_menu_notice', array( $this, 'czr_dismiss_second_menu_notice' ) );
-      add_action( 'wp_ajax_dismiss_main_menu_notice'  , array( $this, 'czr_dismiss_main_menu_notice' ) );
-      add_action( 'wp_ajax_slider_notice_actions'     , array( $this, 'czr_slider_notice_ajax_actions' ) );
-      add_action( 'wp_ajax_fp_notice_actions'         , array( $this, 'czr_fp_notice_ajax_actions' ) );
-      add_action( 'wp_ajax_dismiss_widget_notice'     , array( $this, 'czr_dismiss_widget_notice' ) );
+      add_action( 'wp_ajax_dismiss_thumbnail_help'    , array( $this, 'czr_fn_dismiss_thumbnail_help' ) );
+      add_action( 'wp_ajax_dismiss_img_smartload_help', array( $this, 'czr_fn_dismiss_img_smartload_help' ) );
+      add_action( 'wp_ajax_dismiss_sidenav_help'      , array( $this, 'czr_fn_dismiss_sidenav_help' ) );
+      add_action( 'wp_ajax_dismiss_second_menu_notice', array( $this, 'czr_fn_dismiss_second_menu_notice' ) );
+      add_action( 'wp_ajax_dismiss_main_menu_notice'  , array( $this, 'czr_fn_dismiss_main_menu_notice' ) );
+      add_action( 'wp_ajax_slider_notice_actions'     , array( $this, 'czr_fn_slider_notice_ajax_actions' ) );
+      add_action( 'wp_ajax_fp_notice_actions'         , array( $this, 'czr_fn_fp_notice_ajax_actions' ) );
+      add_action( 'wp_ajax_dismiss_widget_notice'     , array( $this, 'czr_fn_dismiss_widget_notice' ) );
     }
 
 
@@ -52,31 +52,31 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * hook : wp => because we need to access some conditional tags like is_home when checking if the placeholder / notice are enabled
     * @since v3.4+
     */
-    function czr_placeholders_write_ajax_js_in_footer() {
-      if ( ! $this -> czr_is_front_help_enabled() )
+    function czr_fn_placeholders_write_ajax_js_in_footer() {
+      if ( ! $this -> czr_fn_is_front_help_enabled() )
         return;
-      if ( $this -> czr_is_thumbnail_help_on() )
-          add_action( 'wp_footer'   , array( $this, 'czr_write_thumbnail_help_js'), 100 );
+      if ( $this -> czr_fn_is_thumbnail_help_on() )
+          add_action( 'wp_footer'   , array( $this, 'czr_fn_write_thumbnail_help_js'), 100 );
 
       /* The actual printing of the js is controlled with a filter inside the callback */
-      add_action( 'wp_footer'     , array( $this, 'czr_maybe_write_img_sarmtload_help_js'), 100 );
-      if ( $this -> czr_is_sidenav_help_on() )
-        add_action( 'wp_footer'   , array( $this, 'czr_write_sidenav_help_js'), 100 );
+      add_action( 'wp_footer'     , array( $this, 'czr_fn_maybe_write_img_sarmtload_help_js'), 100 );
+      if ( $this -> czr_fn_is_sidenav_help_on() )
+        add_action( 'wp_footer'   , array( $this, 'czr_fn_write_sidenav_help_js'), 100 );
 
-      if ( $this -> czr_is_second_menu_placeholder_on() )
-        add_action( 'wp_footer'   , array( $this, 'czr_write_second_menu_placeholder_js'), 100 );
+      if ( $this -> czr_fn_is_second_menu_placeholder_on() )
+        add_action( 'wp_footer'   , array( $this, 'czr_fn_write_second_menu_placeholder_js'), 100 );
 
-      if ( $this -> czr_is_main_menu_notice_on() )
-        add_action( 'wp_footer'   , array( $this, 'czr_write_main_menu_notice_js'), 100 );
+      if ( $this -> czr_fn_is_main_menu_notice_on() )
+        add_action( 'wp_footer'   , array( $this, 'czr_fn_write_main_menu_notice_js'), 100 );
 
-      if ( $this -> czr_is_slider_notice_on() )
-        add_action( 'wp_footer'   , array( $this, 'czr_write_slider_notice_js'), 100 );
+      if ( $this -> czr_fn_is_slider_notice_on() )
+        add_action( 'wp_footer'   , array( $this, 'czr_fn_write_slider_notice_js'), 100 );
 
-      if ( $this -> czr_is_fp_notice_on() )
-        add_action( 'wp_footer'   , array( $this, 'czr_write_fp_notice_js'), 100 );
+      if ( $this -> czr_fn_is_fp_notice_on() )
+        add_action( 'wp_footer'   , array( $this, 'czr_fn_write_fp_notice_js'), 100 );
 
-      if ( $this -> czr_is_widget_placeholder_enabled() )
-        add_action( 'wp_footer'   , array( $this, 'czr_widget_placeholder_script'), 100 );
+      if ( $this -> czr_fn_is_widget_placeholder_enabled() )
+        add_action( 'wp_footer'   , array( $this, 'czr_fn_widget_placeholder_script'), 100 );
     }
 
 
@@ -91,7 +91,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function czr_dismiss_thumbnail_help() {
+    function czr_fn_dismiss_thumbnail_help() {
       check_ajax_referer( 'tc-thumbnail-help-nonce', 'thumbnailNonce' );
       set_transient( 'tc_thumbnail_help', 'disabled' , 60*60*24*365*20 );//20 years of peace
       wp_die();
@@ -105,7 +105,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function czr_write_thumbnail_help_js() {
+    function czr_fn_write_thumbnail_help_js() {
       ?>
       <script type="text/javascript" id="thumbnail-help">
         ( function( $ ) {
@@ -148,9 +148,9 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @return  bool
     * @since Customizr 3.3+
     */
-    static function czr_is_thumbnail_help_on() {
+    static function czr_fn_is_thumbnail_help_on() {
       //never display when customizing
-      if ( CZR___::$instance -> czr_is_customizing() )
+      if ( CZR___::$instance -> czr_fn_is_customizing() )
         return;
 
       //always display in DEV mode
@@ -160,14 +160,14 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
       $_dont_display_conditions = array(
         ! is_user_logged_in() || ! current_user_can('edit_theme_options'),
         'disabled' == get_transient("tc_thumbnail_help"),
-        'hide' != CZR_utils::$inst->czr_opt('tc_single_post_thumb_location'),
+        'hide' != CZR_utils::$inst->czr_fn_opt('tc_single_post_thumb_location'),
         ! is_admin() && ! is_single(),
-        ! self::$instance -> czr_is_front_help_enabled()
+        ! self::$instance -> czr_fn_is_front_help_enabled()
       );
 
       //checks if at least one of the conditions is true
       return apply_filters(
-        'czr_is_thumbnail_help_on',
+        'czr_fn_is_thumbnail_help_on',
         ! (bool)array_sum($_dont_display_conditions)
       );
     }
@@ -185,7 +185,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function czr_dismiss_img_smartload_help() {
+    function czr_fn_dismiss_img_smartload_help() {
       check_ajax_referer( 'tc-img-smartload-help-nonce', 'imgSmartLoadNonce' );
       set_transient( 'tc_img_smartload_help', 'disabled' , 60*60*24*365*20 );//20 years of peace
       wp_die();
@@ -197,7 +197,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    static function czr_get_smartload_help_block( $echo = false ) {
+    static function czr_fn_get_smartload_help_block( $echo = false ) {
       //prepare js printing in the footer
       add_filter( 'tc_write_img_smartload_help_js', '__return_true' );
 
@@ -208,7 +208,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
           printf('<p><strong>%1$s</strong></p><p>%2$s</p>',
               __( "Did you know you can easily speed up your page load by deferring the loading of the non visible images?", "customizr" ),
               sprintf( __("%s and check the option 'Load images on scroll' under 'Website Performances' section.", "customizr"),
-                sprintf( '<strong><a href="%1$s" title="%2$s">%2$s</a></strong>', CZR_utils::czr_get_customizer_url( array( "control" => "tc_img_smart_load", "section" => "performances_sec" ) ), __( "Jump to the customizer now", "customizr") )
+                sprintf( '<strong><a href="%1$s" title="%2$s">%2$s</a></strong>', CZR_utils::czr_fn_get_customizer_url( array( "control" => "tc_img_smart_load", "section" => "performances_sec" ) ), __( "Jump to the customizer now", "customizr") )
               )
           );
           printf('<a class="tc-dismiss-notice" href="#" title="%1$s">%1$s x</a>',
@@ -234,7 +234,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function czr_maybe_write_img_sarmtload_help_js() {
+    function czr_fn_maybe_write_img_sarmtload_help_js() {
       if ( ! apply_filters( 'tc_write_img_smartload_help_js', false ) ) return;
       ?>
       <script type="text/javascript" id="img-smartload-help">
@@ -278,9 +278,9 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @return  bool
     * @since Customizr 3.4+
     */
-    static function czr_is_img_smartload_help_on( $text, $min_img_num = 2 ) {
+    static function czr_fn_is_img_smartload_help_on( $text, $min_img_num = 2 ) {
       //never display when customizing
-      if ( CZR___::$instance -> czr_is_customizing() )
+      if ( CZR___::$instance -> czr_fn_is_customizing() )
         return;
 
       if ( $min_img_num ) {
@@ -293,9 +293,9 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
         return true;
 
       $_dont_display_conditions = array(
-        1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_img_smart_load' ) ),
+        1 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_img_smart_load' ) ),
         ! is_user_logged_in() || ! current_user_can('edit_theme_options'),
-        ! self::$instance -> czr_is_front_help_enabled(),
+        ! self::$instance -> czr_fn_is_front_help_enabled(),
         'disabled' == get_transient("tc_img_smartload_help"),
         $min_img_num ? apply_filters('tc_img_smartload_help_n_images', $min_img_num ) > preg_match_all( '/(<img[^>]+>)/i', $text, $matches ) : false ,
         is_admin()
@@ -303,7 +303,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
 
       //checks if at least one of the conditions is true
       return apply_filters(
-        'czr_is_img_smartload_help_on',
+        'czr_fn_is_img_smartload_help_on',
         ! (bool) array_sum( $_dont_display_conditions )
       );
     }
@@ -322,7 +322,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function czr_dismiss_sidenav_help() {
+    function czr_fn_dismiss_sidenav_help() {
       check_ajax_referer( 'tc-sidenav-help-nonce', 'sideNavNonce' );
       set_transient( 'tc_sidenav_help', 'disabled' , 60*60*24*365*20 );//20 years of peace
       wp_die();
@@ -336,7 +336,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function czr_write_sidenav_help_js() {
+    function czr_fn_write_sidenav_help_js() {
       ?>
       <script type="text/javascript" id="sidenav-help">
         ( function( $ ) {
@@ -379,9 +379,9 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @return  bool
     * @since Customizr 3.3+
     */
-    static function czr_is_sidenav_help_on() {
+    static function czr_fn_is_sidenav_help_on() {
       //never display when customizing
-      if ( CZR___::$instance -> czr_is_customizing() )
+      if ( CZR___::$instance -> czr_fn_is_customizing() )
         return;
 
       //always display in DEV mode
@@ -390,15 +390,15 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
 
       $_dont_display_conditions = array(
         ! is_user_logged_in() || ! current_user_can('edit_theme_options'),
-        CZR_utils::$inst->czr_has_location_menu('main'),// => if the "main" location has a menu assigned
-        'navbar' == CZR_utils::$inst->czr_opt('tc_menu_style'),
+        CZR_utils::$inst->czr_fn_has_location_menu('main'),// => if the "main" location has a menu assigned
+        'navbar' == CZR_utils::$inst->czr_fn_opt('tc_menu_style'),
         'disabled' == get_transient("tc_sidenav_help"),
-        ! self::$instance -> czr_is_front_help_enabled()
+        ! self::$instance -> czr_fn_is_front_help_enabled()
       );
 
       //checks if at least one of the conditions is true
       return apply_filters(
-        'czr_is_sidenav_help_on',
+        'czr_fn_is_sidenav_help_on',
         ! (bool)array_sum($_dont_display_conditions)
       );
     }
@@ -418,7 +418,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    function czr_dismiss_second_menu_notice() {
+    function czr_fn_dismiss_second_menu_notice() {
       check_ajax_referer( 'tc-second-menu-placeholder-nonce', 'secondMenuNonce' );
       set_transient( 'tc_second_menu_placehold', 'disabled' , 60*60*24*365*20 );//20 years of peace
       wp_die();
@@ -432,7 +432,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function czr_write_second_menu_placeholder_js() {
+    function czr_fn_write_second_menu_placeholder_js() {
       ?>
       <script type="text/javascript" id="second-menu-placeholder">
         ( function( $ ) {
@@ -475,24 +475,24 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @return  bool
     * @since Customizr 3.3+
     */
-    static function czr_is_second_menu_placeholder_on() {
+    static function czr_fn_is_second_menu_placeholder_on() {
       //never display when customizing
-      if ( CZR___::$instance -> czr_is_customizing() )
+      if ( CZR___::$instance -> czr_fn_is_customizing() )
         return;
 
       //always display in DEV mode
       if ( defined('CZR_DEV') && true === CZR_DEV )
         return true;
       //don't display if main menu style is regular <=> 'navbar' == tc_menu_style
-      if ( 'navbar' == CZR_utils::$inst->czr_opt('tc_menu_style') )
+      if ( 'navbar' == CZR_utils::$inst->czr_fn_opt('tc_menu_style') )
         return false;
       //don't display if second menu is enabled : tc_display_second_menu
-      if ( (bool)CZR_utils::$inst->czr_opt('tc_display_second_menu') )
+      if ( (bool)CZR_utils::$inst->czr_fn_opt('tc_display_second_menu') )
         return false;
 
       return apply_filters(
         "tc_is_second_menu_placeholder_on",
-        self::$instance -> czr_is_front_help_enabled() && is_user_logged_in() && current_user_can('edit_theme_options') && 'disabled' != get_transient("tc_second_menu_placehold")
+        self::$instance -> czr_fn_is_front_help_enabled() && is_user_logged_in() && current_user_can('edit_theme_options') && 'disabled' != get_transient("tc_second_menu_placehold")
       );
     }
 
@@ -508,7 +508,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    function czr_dismiss_main_menu_notice() {
+    function czr_fn_dismiss_main_menu_notice() {
       check_ajax_referer( 'tc-main-menu-notice-nonce', 'mainMenuNonce' );
       set_transient( 'tc_main_menu_notice', 'disabled' , 60*60*24*365*20 );//20 years of peace
       wp_die();
@@ -522,7 +522,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function czr_write_main_menu_notice_js() {
+    function czr_fn_write_main_menu_notice_js() {
       ?>
       <script type="text/javascript" id="main-menu-placeholder">
         ( function( $ ) {
@@ -565,9 +565,9 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @return  bool
     * @since Customizr 3.3+
     */
-    static function czr_is_main_menu_notice_on() {
+    static function czr_fn_is_main_menu_notice_on() {
       //never display when customizing
-      if ( CZR___::$instance -> czr_is_customizing() )
+      if ( CZR___::$instance -> czr_fn_is_customizing() )
         return;
 
       //always display in DEV mode
@@ -576,15 +576,15 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
 
       $_dont_display_conditions = array(
         ! is_user_logged_in() || ! current_user_can('edit_theme_options'),
-        'navbar' != CZR_utils::$inst->czr_opt('tc_menu_style'),
-        (bool)CZR_utils::$inst->czr_opt('tc_display_second_menu'),
+        'navbar' != CZR_utils::$inst->czr_fn_opt('tc_menu_style'),
+        (bool)CZR_utils::$inst->czr_fn_opt('tc_display_second_menu'),
         'disabled' == get_transient("tc_main_menu_notice"),
-        ! self::$instance -> czr_is_front_help_enabled()
+        ! self::$instance -> czr_fn_is_front_help_enabled()
       );
 
       //checks if at least one of the conditions is true
       return apply_filters(
-        'czr_is_main_menu_notice_on',
+        'czr_fn_is_main_menu_notice_on',
         ! (bool)array_sum($_dont_display_conditions)
       );
     }
@@ -603,7 +603,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function czr_slider_notice_ajax_actions() {
+    function czr_fn_slider_notice_ajax_actions() {
       if ( isset( $_POST['remove_action'] ) )
         $_remove_action = esc_attr( $_POST['remove_action'] );
       else
@@ -612,7 +612,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
       check_ajax_referer( 'tc-slider-notice-nonce', 'sliderNoticeNonce' );
       switch ($_remove_action) {
         case 'remove_slider':
-          CZR_utils::$inst -> czr_set_option( 'tc_front_slider' , 0 );
+          CZR_utils::$inst -> czr_fn_set_option( 'tc_front_slider' , 0 );
         break;
 
         case 'remove_notice':
@@ -633,7 +633,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function czr_write_slider_notice_js() {
+    function czr_fn_write_slider_notice_js() {
       ?>
       <script type="text/javascript" id="slider-notice-actions">
         ( function( $ ) {
@@ -685,9 +685,9 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @return  bool
     * @since Customizr 3.4+
     */
-    static function czr_is_slider_notice_on( $_position = null ) {
+    static function czr_fn_is_slider_notice_on( $_position = null ) {
       //never display when customizing
-      if ( CZR___::$instance -> czr_is_customizing() )
+      if ( CZR___::$instance -> czr_fn_is_customizing() )
         return;
 
       //always display in DEV mode
@@ -696,15 +696,15 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
 
       $_dont_display_conditions = array(
         ! is_user_logged_in() || ! current_user_can('edit_theme_options'),
-        ! is_admin() && ! CZR_utils::$inst-> czr_is_home(),
-        'demo' != CZR_utils::$inst->czr_opt('tc_front_slider'),
+        ! is_admin() && ! CZR_utils::$inst-> czr_fn_is_home(),
+        'demo' != CZR_utils::$inst->czr_fn_opt('tc_front_slider'),
         'disabled' == get_transient("tc_slider_notice"),
-        ! self::$instance -> czr_is_front_help_enabled()
+        ! self::$instance -> czr_fn_is_front_help_enabled()
       );
 
       //checks if at least one of the conditions is true
       return apply_filters(
-        'czr_is_slider_notice_on',
+        'czr_fn_is_slider_notice_on',
         ! (bool)array_sum($_dont_display_conditions)
       );
     }
@@ -724,7 +724,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function czr_fp_notice_ajax_actions() {
+    function czr_fn_fp_notice_ajax_actions() {
       if ( isset( $_POST['remove_action'] ) )
         $_remove_action = esc_attr( $_POST['remove_action'] );
       else
@@ -733,7 +733,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
       check_ajax_referer( 'tc-fp-notice-nonce', 'fpNoticeNonce' );
       switch ($_remove_action) {
         case 'remove_fp':
-          CZR_utils::$inst -> czr_set_option( 'czr_show_featured_pages' , 0 );
+          CZR_utils::$inst -> czr_fn_set_option( 'czr_fn_show_featured_pages' , 0 );
         break;
 
         case 'remove_notice':
@@ -754,7 +754,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function czr_write_fp_notice_js() {
+    function czr_fn_write_fp_notice_js() {
       ?>
       <script type="text/javascript" id="fp-notice-actions">
         ( function( $ ) {
@@ -806,9 +806,9 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @return  bool
     * @since Customizr 3.4+
     */
-    static function czr_is_fp_notice_on( $_position = null ) {
+    static function czr_fn_is_fp_notice_on( $_position = null ) {
       //never display when customizing
-      if ( CZR___::$instance -> czr_is_customizing() )
+      if ( CZR___::$instance -> czr_fn_is_customizing() )
         return;
 
       //always display in DEV mode
@@ -817,18 +817,18 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
 
       $_dont_display_conditions = array(
         ! is_user_logged_in() || ! current_user_can('edit_theme_options'),
-        ! is_admin() && ! CZR_utils::$inst-> czr_is_home(),
-        ! (bool)CZR_utils::$inst->czr_opt('czr_show_featured_pages'),
+        ! is_admin() && ! CZR_utils::$inst-> czr_fn_is_home(),
+        ! (bool)CZR_utils::$inst->czr_fn_opt('czr_fn_show_featured_pages'),
         'disabled' == get_transient("tc_fp_notice"),
-        self::$instance -> czr_is_one_fp_set(),
-        CZR___::czr_is_pro(),
-        CZR_plugins_compat::$instance->czr_is_plugin_active('tc-unlimited-featured-pages/tc_unlimited_featured_pages.php'),
-        ! self::$instance -> czr_is_front_help_enabled()
+        self::$instance -> czr_fn_is_one_fp_set(),
+        CZR___::czr_fn_is_pro(),
+        CZR_plugins_compat::$instance->czr_fn_is_plugin_active('tc-unlimited-featured-pages/tc_unlimited_featured_pages.php'),
+        ! self::$instance -> czr_fn_is_front_help_enabled()
       );
 
       //checks if at least one of the conditions is true
       return apply_filters(
-        'czr_is_fp_notice_on',
+        'czr_fn_is_fp_notice_on',
         ! (bool)array_sum($_dont_display_conditions)
       );
     }
@@ -839,13 +839,13 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @return bool
     * @since v3.4+
     */
-    function czr_is_one_fp_set() {
+    function czr_fn_is_one_fp_set() {
       $_fp_sets = array();
       $fp_ids = apply_filters( 'tc_featured_pages_ids' , CZR_init::$instance -> fp_ids);
       if ( ! is_array($fp_ids) )
         return;
       foreach ($fp_ids as $fp_single_id ) {
-        $_fp_sets[] = (bool)CZR_utils::$inst->czr_opt( 'tc_featured_page_'.$fp_single_id );
+        $_fp_sets[] = (bool)CZR_utils::$inst->czr_fn_opt( 'tc_featured_page_'.$fp_single_id );
       }
       //returns true if at least one fp has been set.
       return (bool)array_sum($_fp_sets);
@@ -863,7 +863,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    function czr_widget_placeholder_script() {
+    function czr_fn_widget_placeholder_script() {
       ?>
       <script type="text/javascript" id="widget-placeholders">
         var tc_dismiss_widget_notice = function( _position, $_el ) {
@@ -895,7 +895,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
             var _position = $(this).attr('data-position');
             if ( ! _position || ! _position.length )
               return;
-            czr_dismiss_widget_notice( _position, $(this) );
+            czr_fn_dismiss_widget_notice( _position, $(this) );
           } );
         } );
       </script>
@@ -910,7 +910,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    function czr_dismiss_widget_notice() {
+    function czr_fn_dismiss_widget_notice() {
       check_ajax_referer( 'tc-widget-placeholder-nonce', 'WidgetNonce' );
       if ( isset( $_POST['position'] ) )
         $_pos = esc_attr( $_POST['position'] );
@@ -927,9 +927,9 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @return  bool
     * @since Customizr 3.3+
     */
-    static function czr_is_widget_placeholder_enabled( $_position = null ) {
+    static function czr_fn_is_widget_placeholder_enabled( $_position = null ) {
       //never display when customizing
-      if ( CZR___::$instance -> czr_is_customizing() )
+      if ( CZR___::$instance -> czr_fn_is_customizing() )
         return;
 
       //always display in DEV mode
@@ -939,7 +939,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
       $_position = is_null($_position) ? apply_filters('tc_widget_areas_position', array( 'sidebar', 'footer') ) : array($_position);
 
       return apply_filters( "tc_display_widget_placeholders",
-        self::$instance -> czr_is_front_help_enabled() && is_user_logged_in() && current_user_can('edit_theme_options') && array_sum( array_map( array( self::$instance , 'czr_check_widget_placeholder_transient'), $_position ) )
+        self::$instance -> czr_fn_is_front_help_enabled() && is_user_logged_in() && current_user_can('edit_theme_options') && array_sum( array_map( array( self::$instance , 'czr_fn_check_widget_placeholder_transient'), $_position ) )
       );
     }
 
@@ -947,7 +947,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @return  bool
     * @since Customizr 3.3+
     */
-    function czr_check_widget_placeholder_transient( $_position ){
+    function czr_fn_check_widget_placeholder_transient( $_position ){
       return 'disabled' != get_transient("tc_widget_placehold_{$_position}");
     }
 
@@ -957,8 +957,8 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @since Customizr 3.4+
     * User option to enabe/disable all notices. Enabled by default.
     */
-    function czr_is_front_help_enabled(){
-      return apply_filters( 'czr_is_front_help_enabled' , (bool)CZR_utils::$inst->czr_opt('tc_display_front_help') );
+    function czr_fn_is_front_help_enabled(){
+      return apply_filters( 'czr_fn_is_front_help_enabled' , (bool)CZR_utils::$inst->czr_fn_opt('tc_display_front_help') );
     }
 
   }//end of class

--- a/inc/class-fire-placeholders.php
+++ b/inc/class-fire-placeholders.php
@@ -31,7 +31,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @since v3.4+
     */
     function czr_placeholders_ajax_setup() {
-      if ( ! $this -> tc_is_front_help_enabled() )
+      if ( ! $this -> czr_is_front_help_enabled() )
         return;
       add_action( 'wp_ajax_dismiss_thumbnail_help'    , array( $this, 'tc_dismiss_thumbnail_help' ) );
       add_action( 'wp_ajax_dismiss_img_smartload_help', array( $this, 'tc_dismiss_img_smartload_help' ) );
@@ -53,29 +53,29 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * @since v3.4+
     */
     function czr_placeholders_write_ajax_js_in_footer() {
-      if ( ! $this -> tc_is_front_help_enabled() )
+      if ( ! $this -> czr_is_front_help_enabled() )
         return;
-      if ( $this -> tc_is_thumbnail_help_on() )
+      if ( $this -> czr_is_thumbnail_help_on() )
           add_action( 'wp_footer'   , array( $this, 'tc_write_thumbnail_help_js'), 100 );
 
       /* The actual printing of the js is controlled with a filter inside the callback */
       add_action( 'wp_footer'     , array( $this, 'tc_maybe_write_img_sarmtload_help_js'), 100 );
-      if ( $this -> tc_is_sidenav_help_on() )
+      if ( $this -> czr_is_sidenav_help_on() )
         add_action( 'wp_footer'   , array( $this, 'tc_write_sidenav_help_js'), 100 );
 
-      if ( $this -> tc_is_second_menu_placeholder_on() )
+      if ( $this -> czr_is_second_menu_placeholder_on() )
         add_action( 'wp_footer'   , array( $this, 'tc_write_second_menu_placeholder_js'), 100 );
 
-      if ( $this -> tc_is_main_menu_notice_on() )
+      if ( $this -> czr_is_main_menu_notice_on() )
         add_action( 'wp_footer'   , array( $this, 'tc_write_main_menu_notice_js'), 100 );
 
-      if ( $this -> tc_is_slider_notice_on() )
+      if ( $this -> czr_is_slider_notice_on() )
         add_action( 'wp_footer'   , array( $this, 'tc_write_slider_notice_js'), 100 );
 
-      if ( $this -> tc_is_fp_notice_on() )
+      if ( $this -> czr_is_fp_notice_on() )
         add_action( 'wp_footer'   , array( $this, 'tc_write_fp_notice_js'), 100 );
 
-      if ( $this -> tc_is_widget_placeholder_enabled() )
+      if ( $this -> czr_is_widget_placeholder_enabled() )
         add_action( 'wp_footer'   , array( $this, 'tc_widget_placeholder_script'), 100 );
     }
 
@@ -150,7 +150,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     */
     static function czr_is_thumbnail_help_on() {
       //never display when customizing
-      if ( CZR___::$instance -> tc_is_customizing() )
+      if ( CZR___::$instance -> czr_is_customizing() )
         return;
 
       //always display in DEV mode
@@ -160,9 +160,9 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
       $_dont_display_conditions = array(
         ! is_user_logged_in() || ! current_user_can('edit_theme_options'),
         'disabled' == get_transient("tc_thumbnail_help"),
-        'hide' != CZR_utils::$inst->tc_opt('tc_single_post_thumb_location'),
+        'hide' != CZR_utils::$inst->czr_opt('tc_single_post_thumb_location'),
         ! is_admin() && ! is_single(),
-        ! self::$instance -> tc_is_front_help_enabled()
+        ! self::$instance -> czr_is_front_help_enabled()
       );
 
       //checks if at least one of the conditions is true
@@ -208,7 +208,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
           printf('<p><strong>%1$s</strong></p><p>%2$s</p>',
               __( "Did you know you can easily speed up your page load by deferring the loading of the non visible images?", "customizr" ),
               sprintf( __("%s and check the option 'Load images on scroll' under 'Website Performances' section.", "customizr"),
-                sprintf( '<strong><a href="%1$s" title="%2$s">%2$s</a></strong>', CZR_utils::tc_get_customizer_url( array( "control" => "tc_img_smart_load", "section" => "performances_sec" ) ), __( "Jump to the customizer now", "customizr") )
+                sprintf( '<strong><a href="%1$s" title="%2$s">%2$s</a></strong>', CZR_utils::czr_get_customizer_url( array( "control" => "tc_img_smart_load", "section" => "performances_sec" ) ), __( "Jump to the customizer now", "customizr") )
               )
           );
           printf('<a class="tc-dismiss-notice" href="#" title="%1$s">%1$s x</a>',
@@ -280,7 +280,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     */
     static function czr_is_img_smartload_help_on( $text, $min_img_num = 2 ) {
       //never display when customizing
-      if ( CZR___::$instance -> tc_is_customizing() )
+      if ( CZR___::$instance -> czr_is_customizing() )
         return;
 
       if ( $min_img_num ) {
@@ -293,9 +293,9 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
         return true;
 
       $_dont_display_conditions = array(
-        1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_img_smart_load' ) ),
+        1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_img_smart_load' ) ),
         ! is_user_logged_in() || ! current_user_can('edit_theme_options'),
-        ! self::$instance -> tc_is_front_help_enabled(),
+        ! self::$instance -> czr_is_front_help_enabled(),
         'disabled' == get_transient("tc_img_smartload_help"),
         $min_img_num ? apply_filters('tc_img_smartload_help_n_images', $min_img_num ) > preg_match_all( '/(<img[^>]+>)/i', $text, $matches ) : false ,
         is_admin()
@@ -381,7 +381,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     */
     static function czr_is_sidenav_help_on() {
       //never display when customizing
-      if ( CZR___::$instance -> tc_is_customizing() )
+      if ( CZR___::$instance -> czr_is_customizing() )
         return;
 
       //always display in DEV mode
@@ -390,10 +390,10 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
 
       $_dont_display_conditions = array(
         ! is_user_logged_in() || ! current_user_can('edit_theme_options'),
-        CZR_utils::$inst->tc_has_location_menu('main'),// => if the "main" location has a menu assigned
-        'navbar' == CZR_utils::$inst->tc_opt('tc_menu_style'),
+        CZR_utils::$inst->czr_has_location_menu('main'),// => if the "main" location has a menu assigned
+        'navbar' == CZR_utils::$inst->czr_opt('tc_menu_style'),
         'disabled' == get_transient("tc_sidenav_help"),
-        ! self::$instance -> tc_is_front_help_enabled()
+        ! self::$instance -> czr_is_front_help_enabled()
       );
 
       //checks if at least one of the conditions is true
@@ -477,22 +477,22 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     */
     static function czr_is_second_menu_placeholder_on() {
       //never display when customizing
-      if ( CZR___::$instance -> tc_is_customizing() )
+      if ( CZR___::$instance -> czr_is_customizing() )
         return;
 
       //always display in DEV mode
       if ( defined('CZR_DEV') && true === CZR_DEV )
         return true;
       //don't display if main menu style is regular <=> 'navbar' == tc_menu_style
-      if ( 'navbar' == CZR_utils::$inst->tc_opt('tc_menu_style') )
+      if ( 'navbar' == CZR_utils::$inst->czr_opt('tc_menu_style') )
         return false;
       //don't display if second menu is enabled : tc_display_second_menu
-      if ( (bool)CZR_utils::$inst->tc_opt('tc_display_second_menu') )
+      if ( (bool)CZR_utils::$inst->czr_opt('tc_display_second_menu') )
         return false;
 
       return apply_filters(
         "tc_is_second_menu_placeholder_on",
-        self::$instance -> tc_is_front_help_enabled() && is_user_logged_in() && current_user_can('edit_theme_options') && 'disabled' != get_transient("tc_second_menu_placehold")
+        self::$instance -> czr_is_front_help_enabled() && is_user_logged_in() && current_user_can('edit_theme_options') && 'disabled' != get_transient("tc_second_menu_placehold")
       );
     }
 
@@ -567,7 +567,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     */
     static function czr_is_main_menu_notice_on() {
       //never display when customizing
-      if ( CZR___::$instance -> tc_is_customizing() )
+      if ( CZR___::$instance -> czr_is_customizing() )
         return;
 
       //always display in DEV mode
@@ -576,10 +576,10 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
 
       $_dont_display_conditions = array(
         ! is_user_logged_in() || ! current_user_can('edit_theme_options'),
-        'navbar' != CZR_utils::$inst->tc_opt('tc_menu_style'),
-        (bool)CZR_utils::$inst->tc_opt('tc_display_second_menu'),
+        'navbar' != CZR_utils::$inst->czr_opt('tc_menu_style'),
+        (bool)CZR_utils::$inst->czr_opt('tc_display_second_menu'),
         'disabled' == get_transient("tc_main_menu_notice"),
-        ! self::$instance -> tc_is_front_help_enabled()
+        ! self::$instance -> czr_is_front_help_enabled()
       );
 
       //checks if at least one of the conditions is true
@@ -612,7 +612,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
       check_ajax_referer( 'tc-slider-notice-nonce', 'sliderNoticeNonce' );
       switch ($_remove_action) {
         case 'remove_slider':
-          CZR_utils::$inst -> tc_set_option( 'tc_front_slider' , 0 );
+          CZR_utils::$inst -> czr_set_option( 'tc_front_slider' , 0 );
         break;
 
         case 'remove_notice':
@@ -687,7 +687,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     */
     static function czr_is_slider_notice_on( $_position = null ) {
       //never display when customizing
-      if ( CZR___::$instance -> tc_is_customizing() )
+      if ( CZR___::$instance -> czr_is_customizing() )
         return;
 
       //always display in DEV mode
@@ -696,10 +696,10 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
 
       $_dont_display_conditions = array(
         ! is_user_logged_in() || ! current_user_can('edit_theme_options'),
-        ! is_admin() && ! CZR_utils::$inst-> tc_is_home(),
-        'demo' != CZR_utils::$inst->tc_opt('tc_front_slider'),
+        ! is_admin() && ! CZR_utils::$inst-> czr_is_home(),
+        'demo' != CZR_utils::$inst->czr_opt('tc_front_slider'),
         'disabled' == get_transient("tc_slider_notice"),
-        ! self::$instance -> tc_is_front_help_enabled()
+        ! self::$instance -> czr_is_front_help_enabled()
       );
 
       //checks if at least one of the conditions is true
@@ -733,7 +733,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
       check_ajax_referer( 'tc-fp-notice-nonce', 'fpNoticeNonce' );
       switch ($_remove_action) {
         case 'remove_fp':
-          CZR_utils::$inst -> tc_set_option( 'tc_show_featured_pages' , 0 );
+          CZR_utils::$inst -> czr_set_option( 'tc_show_featured_pages' , 0 );
         break;
 
         case 'remove_notice':
@@ -808,7 +808,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     */
     static function czr_is_fp_notice_on( $_position = null ) {
       //never display when customizing
-      if ( CZR___::$instance -> tc_is_customizing() )
+      if ( CZR___::$instance -> czr_is_customizing() )
         return;
 
       //always display in DEV mode
@@ -817,13 +817,13 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
 
       $_dont_display_conditions = array(
         ! is_user_logged_in() || ! current_user_can('edit_theme_options'),
-        ! is_admin() && ! CZR_utils::$inst-> tc_is_home(),
-        ! (bool)CZR_utils::$inst->tc_opt('tc_show_featured_pages'),
+        ! is_admin() && ! CZR_utils::$inst-> czr_is_home(),
+        ! (bool)CZR_utils::$inst->czr_opt('tc_show_featured_pages'),
         'disabled' == get_transient("tc_fp_notice"),
-        self::$instance -> tc_is_one_fp_set(),
-        CZR___::tc_is_pro(),
-        CZR_plugins_compat::$instance->tc_is_plugin_active('tc-unlimited-featured-pages/tc_unlimited_featured_pages.php'),
-        ! self::$instance -> tc_is_front_help_enabled()
+        self::$instance -> czr_is_one_fp_set(),
+        CZR___::czr_is_pro(),
+        CZR_plugins_compat::$instance->czr_is_plugin_active('tc-unlimited-featured-pages/tc_unlimited_featured_pages.php'),
+        ! self::$instance -> czr_is_front_help_enabled()
       );
 
       //checks if at least one of the conditions is true
@@ -845,7 +845,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
       if ( ! is_array($fp_ids) )
         return;
       foreach ($fp_ids as $fp_single_id ) {
-        $_fp_sets[] = (bool)CZR_utils::$inst->tc_opt( 'tc_featured_page_'.$fp_single_id );
+        $_fp_sets[] = (bool)CZR_utils::$inst->czr_opt( 'tc_featured_page_'.$fp_single_id );
       }
       //returns true if at least one fp has been set.
       return (bool)array_sum($_fp_sets);
@@ -895,7 +895,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
             var _position = $(this).attr('data-position');
             if ( ! _position || ! _position.length )
               return;
-            tc_dismiss_widget_notice( _position, $(this) );
+            czr_dismiss_widget_notice( _position, $(this) );
           } );
         } );
       </script>
@@ -929,7 +929,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     */
     static function czr_is_widget_placeholder_enabled( $_position = null ) {
       //never display when customizing
-      if ( CZR___::$instance -> tc_is_customizing() )
+      if ( CZR___::$instance -> czr_is_customizing() )
         return;
 
       //always display in DEV mode
@@ -939,7 +939,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
       $_position = is_null($_position) ? apply_filters('tc_widget_areas_position', array( 'sidebar', 'footer') ) : array($_position);
 
       return apply_filters( "tc_display_widget_placeholders",
-        self::$instance -> tc_is_front_help_enabled() && is_user_logged_in() && current_user_can('edit_theme_options') && array_sum( array_map( array( self::$instance , 'tc_check_widget_placeholder_transient'), $_position ) )
+        self::$instance -> czr_is_front_help_enabled() && is_user_logged_in() && current_user_can('edit_theme_options') && array_sum( array_map( array( self::$instance , 'tc_check_widget_placeholder_transient'), $_position ) )
       );
     }
 
@@ -958,7 +958,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * User option to enabe/disable all notices. Enabled by default.
     */
     function czr_is_front_help_enabled(){
-      return apply_filters( 'tc_is_front_help_enabled' , (bool)CZR_utils::$inst->tc_opt('tc_display_front_help') );
+      return apply_filters( 'tc_is_front_help_enabled' , (bool)CZR_utils::$inst->czr_opt('tc_display_front_help') );
     }
 
   }//end of class

--- a/inc/class-fire-placeholders.php
+++ b/inc/class-fire-placeholders.php
@@ -167,7 +167,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
 
       //checks if at least one of the conditions is true
       return apply_filters(
-        'czr_fn_is_thumbnail_help_on',
+        'tc_is_thumbnail_help_on',
         ! (bool)array_sum($_dont_display_conditions)
       );
     }
@@ -303,7 +303,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
 
       //checks if at least one of the conditions is true
       return apply_filters(
-        'czr_fn_is_img_smartload_help_on',
+        'tc_is_img_smartload_help_on',
         ! (bool) array_sum( $_dont_display_conditions )
       );
     }
@@ -398,7 +398,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
 
       //checks if at least one of the conditions is true
       return apply_filters(
-        'czr_fn_is_sidenav_help_on',
+        'tc_is_sidenav_help_on',
         ! (bool)array_sum($_dont_display_conditions)
       );
     }
@@ -584,7 +584,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
 
       //checks if at least one of the conditions is true
       return apply_filters(
-        'czr_fn_is_main_menu_notice_on',
+        'tc_is_main_menu_notice_on',
         ! (bool)array_sum($_dont_display_conditions)
       );
     }
@@ -704,7 +704,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
 
       //checks if at least one of the conditions is true
       return apply_filters(
-        'czr_fn_is_slider_notice_on',
+        'tc_is_slider_notice_on',
         ! (bool)array_sum($_dont_display_conditions)
       );
     }
@@ -828,7 +828,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
 
       //checks if at least one of the conditions is true
       return apply_filters(
-        'czr_fn_is_fp_notice_on',
+        'tc_is_fp_notice_on',
         ! (bool)array_sum($_dont_display_conditions)
       );
     }
@@ -958,7 +958,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * User option to enabe/disable all notices. Enabled by default.
     */
     function czr_fn_is_front_help_enabled(){
-      return apply_filters( 'czr_fn_is_front_help_enabled' , (bool)CZR_utils::$inst->czr_fn_opt('tc_display_front_help') );
+      return apply_filters( 'tc_is_front_help_enabled' , (bool)CZR_utils::$inst->czr_fn_opt('tc_display_front_help') );
     }
 
   }//end of class

--- a/inc/class-fire-placeholders.php
+++ b/inc/class-fire-placeholders.php
@@ -12,8 +12,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_placeholders' ) ) :
-  class TC_placeholders {
+if ( ! class_exists( 'CZR_placeholders' ) ) :
+  class CZR_placeholders {
     //Access any method or var of the class with classname::$instance -> var or method():
     static $instance;
     function __construct () {
@@ -150,17 +150,17 @@ if ( ! class_exists( 'TC_placeholders' ) ) :
     */
     static function tc_is_thumbnail_help_on() {
       //never display when customizing
-      if ( TC___::$instance -> tc_is_customizing() )
+      if ( CZR___::$instance -> tc_is_customizing() )
         return;
 
       //always display in DEV mode
-      if ( defined('TC_DEV') && true === TC_DEV )
+      if ( defined('CZR_DEV') && true === CZR_DEV )
         return true;
 
       $_dont_display_conditions = array(
         ! is_user_logged_in() || ! current_user_can('edit_theme_options'),
         'disabled' == get_transient("tc_thumbnail_help"),
-        'hide' != TC_utils::$inst->tc_opt('tc_single_post_thumb_location'),
+        'hide' != CZR_utils::$inst->tc_opt('tc_single_post_thumb_location'),
         ! is_admin() && ! is_single(),
         ! self::$instance -> tc_is_front_help_enabled()
       );
@@ -208,7 +208,7 @@ if ( ! class_exists( 'TC_placeholders' ) ) :
           printf('<p><strong>%1$s</strong></p><p>%2$s</p>',
               __( "Did you know you can easily speed up your page load by deferring the loading of the non visible images?", "customizr" ),
               sprintf( __("%s and check the option 'Load images on scroll' under 'Website Performances' section.", "customizr"),
-                sprintf( '<strong><a href="%1$s" title="%2$s">%2$s</a></strong>', TC_utils::tc_get_customizer_url( array( "control" => "tc_img_smart_load", "section" => "performances_sec" ) ), __( "Jump to the customizer now", "customizr") )
+                sprintf( '<strong><a href="%1$s" title="%2$s">%2$s</a></strong>', CZR_utils::tc_get_customizer_url( array( "control" => "tc_img_smart_load", "section" => "performances_sec" ) ), __( "Jump to the customizer now", "customizr") )
               )
           );
           printf('<a class="tc-dismiss-notice" href="#" title="%1$s">%1$s x</a>',
@@ -280,7 +280,7 @@ if ( ! class_exists( 'TC_placeholders' ) ) :
     */
     static function tc_is_img_smartload_help_on( $text, $min_img_num = 2 ) {
       //never display when customizing
-      if ( TC___::$instance -> tc_is_customizing() )
+      if ( CZR___::$instance -> tc_is_customizing() )
         return;
 
       if ( $min_img_num ) {
@@ -289,11 +289,11 @@ if ( ! class_exists( 'TC_placeholders' ) ) :
       }
 
       //always display in DEV mode
-      if ( defined('TC_DEV') && true === TC_DEV )
+      if ( defined('CZR_DEV') && true === CZR_DEV )
         return true;
 
       $_dont_display_conditions = array(
-        1 == esc_attr( TC_utils::$inst->tc_opt( 'tc_img_smart_load' ) ),
+        1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_img_smart_load' ) ),
         ! is_user_logged_in() || ! current_user_can('edit_theme_options'),
         ! self::$instance -> tc_is_front_help_enabled(),
         'disabled' == get_transient("tc_img_smartload_help"),
@@ -381,17 +381,17 @@ if ( ! class_exists( 'TC_placeholders' ) ) :
     */
     static function tc_is_sidenav_help_on() {
       //never display when customizing
-      if ( TC___::$instance -> tc_is_customizing() )
+      if ( CZR___::$instance -> tc_is_customizing() )
         return;
 
       //always display in DEV mode
-      if ( defined('TC_DEV') && true === TC_DEV )
+      if ( defined('CZR_DEV') && true === CZR_DEV )
         return true;
 
       $_dont_display_conditions = array(
         ! is_user_logged_in() || ! current_user_can('edit_theme_options'),
-        TC_utils::$inst->tc_has_location_menu('main'),// => if the "main" location has a menu assigned
-        'navbar' == TC_utils::$inst->tc_opt('tc_menu_style'),
+        CZR_utils::$inst->tc_has_location_menu('main'),// => if the "main" location has a menu assigned
+        'navbar' == CZR_utils::$inst->tc_opt('tc_menu_style'),
         'disabled' == get_transient("tc_sidenav_help"),
         ! self::$instance -> tc_is_front_help_enabled()
       );
@@ -477,17 +477,17 @@ if ( ! class_exists( 'TC_placeholders' ) ) :
     */
     static function tc_is_second_menu_placeholder_on() {
       //never display when customizing
-      if ( TC___::$instance -> tc_is_customizing() )
+      if ( CZR___::$instance -> tc_is_customizing() )
         return;
 
       //always display in DEV mode
-      if ( defined('TC_DEV') && true === TC_DEV )
+      if ( defined('CZR_DEV') && true === CZR_DEV )
         return true;
       //don't display if main menu style is regular <=> 'navbar' == tc_menu_style
-      if ( 'navbar' == TC_utils::$inst->tc_opt('tc_menu_style') )
+      if ( 'navbar' == CZR_utils::$inst->tc_opt('tc_menu_style') )
         return false;
       //don't display if second menu is enabled : tc_display_second_menu
-      if ( (bool)TC_utils::$inst->tc_opt('tc_display_second_menu') )
+      if ( (bool)CZR_utils::$inst->tc_opt('tc_display_second_menu') )
         return false;
 
       return apply_filters(
@@ -567,17 +567,17 @@ if ( ! class_exists( 'TC_placeholders' ) ) :
     */
     static function tc_is_main_menu_notice_on() {
       //never display when customizing
-      if ( TC___::$instance -> tc_is_customizing() )
+      if ( CZR___::$instance -> tc_is_customizing() )
         return;
 
       //always display in DEV mode
-      if ( defined('TC_DEV') && true === TC_DEV )
+      if ( defined('CZR_DEV') && true === CZR_DEV )
         return true;
 
       $_dont_display_conditions = array(
         ! is_user_logged_in() || ! current_user_can('edit_theme_options'),
-        'navbar' != TC_utils::$inst->tc_opt('tc_menu_style'),
-        (bool)TC_utils::$inst->tc_opt('tc_display_second_menu'),
+        'navbar' != CZR_utils::$inst->tc_opt('tc_menu_style'),
+        (bool)CZR_utils::$inst->tc_opt('tc_display_second_menu'),
         'disabled' == get_transient("tc_main_menu_notice"),
         ! self::$instance -> tc_is_front_help_enabled()
       );
@@ -612,7 +612,7 @@ if ( ! class_exists( 'TC_placeholders' ) ) :
       check_ajax_referer( 'tc-slider-notice-nonce', 'sliderNoticeNonce' );
       switch ($_remove_action) {
         case 'remove_slider':
-          TC_utils::$inst -> tc_set_option( 'tc_front_slider' , 0 );
+          CZR_utils::$inst -> tc_set_option( 'tc_front_slider' , 0 );
         break;
 
         case 'remove_notice':
@@ -687,17 +687,17 @@ if ( ! class_exists( 'TC_placeholders' ) ) :
     */
     static function tc_is_slider_notice_on( $_position = null ) {
       //never display when customizing
-      if ( TC___::$instance -> tc_is_customizing() )
+      if ( CZR___::$instance -> tc_is_customizing() )
         return;
 
       //always display in DEV mode
-      if ( defined('TC_DEV') && true === TC_DEV )
+      if ( defined('CZR_DEV') && true === CZR_DEV )
         return true;
 
       $_dont_display_conditions = array(
         ! is_user_logged_in() || ! current_user_can('edit_theme_options'),
-        ! is_admin() && ! TC_utils::$inst-> tc_is_home(),
-        'demo' != TC_utils::$inst->tc_opt('tc_front_slider'),
+        ! is_admin() && ! CZR_utils::$inst-> tc_is_home(),
+        'demo' != CZR_utils::$inst->tc_opt('tc_front_slider'),
         'disabled' == get_transient("tc_slider_notice"),
         ! self::$instance -> tc_is_front_help_enabled()
       );
@@ -733,7 +733,7 @@ if ( ! class_exists( 'TC_placeholders' ) ) :
       check_ajax_referer( 'tc-fp-notice-nonce', 'fpNoticeNonce' );
       switch ($_remove_action) {
         case 'remove_fp':
-          TC_utils::$inst -> tc_set_option( 'tc_show_featured_pages' , 0 );
+          CZR_utils::$inst -> tc_set_option( 'tc_show_featured_pages' , 0 );
         break;
 
         case 'remove_notice':
@@ -808,21 +808,21 @@ if ( ! class_exists( 'TC_placeholders' ) ) :
     */
     static function tc_is_fp_notice_on( $_position = null ) {
       //never display when customizing
-      if ( TC___::$instance -> tc_is_customizing() )
+      if ( CZR___::$instance -> tc_is_customizing() )
         return;
 
       //always display in DEV mode
-      if ( defined('TC_DEV') && true === TC_DEV )
+      if ( defined('CZR_DEV') && true === CZR_DEV )
         return true;
 
       $_dont_display_conditions = array(
         ! is_user_logged_in() || ! current_user_can('edit_theme_options'),
-        ! is_admin() && ! TC_utils::$inst-> tc_is_home(),
-        ! (bool)TC_utils::$inst->tc_opt('tc_show_featured_pages'),
+        ! is_admin() && ! CZR_utils::$inst-> tc_is_home(),
+        ! (bool)CZR_utils::$inst->tc_opt('tc_show_featured_pages'),
         'disabled' == get_transient("tc_fp_notice"),
         self::$instance -> tc_is_one_fp_set(),
-        TC___::tc_is_pro(),
-        TC_plugins_compat::$instance->tc_is_plugin_active('tc-unlimited-featured-pages/tc_unlimited_featured_pages.php'),
+        CZR___::tc_is_pro(),
+        CZR_plugins_compat::$instance->tc_is_plugin_active('tc-unlimited-featured-pages/tc_unlimited_featured_pages.php'),
         ! self::$instance -> tc_is_front_help_enabled()
       );
 
@@ -841,11 +841,11 @@ if ( ! class_exists( 'TC_placeholders' ) ) :
     */
     function tc_is_one_fp_set() {
       $_fp_sets = array();
-      $fp_ids = apply_filters( 'tc_featured_pages_ids' , TC_init::$instance -> fp_ids);
+      $fp_ids = apply_filters( 'tc_featured_pages_ids' , CZR_init::$instance -> fp_ids);
       if ( ! is_array($fp_ids) )
         return;
       foreach ($fp_ids as $fp_single_id ) {
-        $_fp_sets[] = (bool)TC_utils::$inst->tc_opt( 'tc_featured_page_'.$fp_single_id );
+        $_fp_sets[] = (bool)CZR_utils::$inst->tc_opt( 'tc_featured_page_'.$fp_single_id );
       }
       //returns true if at least one fp has been set.
       return (bool)array_sum($_fp_sets);
@@ -929,11 +929,11 @@ if ( ! class_exists( 'TC_placeholders' ) ) :
     */
     static function tc_is_widget_placeholder_enabled( $_position = null ) {
       //never display when customizing
-      if ( TC___::$instance -> tc_is_customizing() )
+      if ( CZR___::$instance -> tc_is_customizing() )
         return;
 
       //always display in DEV mode
-      if ( defined('TC_DEV') && true === TC_DEV )
+      if ( defined('CZR_DEV') && true === CZR_DEV )
         return true;
 
       $_position = is_null($_position) ? apply_filters('tc_widget_areas_position', array( 'sidebar', 'footer') ) : array($_position);
@@ -958,7 +958,7 @@ if ( ! class_exists( 'TC_placeholders' ) ) :
     * User option to enabe/disable all notices. Enabled by default.
     */
     function tc_is_front_help_enabled(){
-      return apply_filters( 'tc_is_front_help_enabled' , (bool)TC_utils::$inst->tc_opt('tc_display_front_help') );
+      return apply_filters( 'tc_is_front_help_enabled' , (bool)CZR_utils::$inst->tc_opt('tc_display_front_help') );
     }
 
   }//end of class

--- a/inc/class-fire-placeholders.php
+++ b/inc/class-fire-placeholders.php
@@ -18,8 +18,8 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     static $instance;
     function __construct () {
       self::$instance =& $this;
-      add_action( 'init'           , array( $this, 'tc_placeholders_ajax_setup') );
-      add_action( 'wp'             , array( $this, 'tc_placeholders_write_ajax_js_in_footer') );
+      add_action( 'init'           , array( $this, 'czr_placeholders_ajax_setup') );
+      add_action( 'wp'             , array( $this, 'czr_placeholders_write_ajax_js_in_footer') );
     }
 
 
@@ -33,14 +33,14 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     function czr_placeholders_ajax_setup() {
       if ( ! $this -> czr_is_front_help_enabled() )
         return;
-      add_action( 'wp_ajax_dismiss_thumbnail_help'    , array( $this, 'tc_dismiss_thumbnail_help' ) );
-      add_action( 'wp_ajax_dismiss_img_smartload_help', array( $this, 'tc_dismiss_img_smartload_help' ) );
-      add_action( 'wp_ajax_dismiss_sidenav_help'      , array( $this, 'tc_dismiss_sidenav_help' ) );
-      add_action( 'wp_ajax_dismiss_second_menu_notice', array( $this, 'tc_dismiss_second_menu_notice' ) );
-      add_action( 'wp_ajax_dismiss_main_menu_notice'  , array( $this, 'tc_dismiss_main_menu_notice' ) );
-      add_action( 'wp_ajax_slider_notice_actions'     , array( $this, 'tc_slider_notice_ajax_actions' ) );
-      add_action( 'wp_ajax_fp_notice_actions'         , array( $this, 'tc_fp_notice_ajax_actions' ) );
-      add_action( 'wp_ajax_dismiss_widget_notice'     , array( $this, 'tc_dismiss_widget_notice' ) );
+      add_action( 'wp_ajax_dismiss_thumbnail_help'    , array( $this, 'czr_dismiss_thumbnail_help' ) );
+      add_action( 'wp_ajax_dismiss_img_smartload_help', array( $this, 'czr_dismiss_img_smartload_help' ) );
+      add_action( 'wp_ajax_dismiss_sidenav_help'      , array( $this, 'czr_dismiss_sidenav_help' ) );
+      add_action( 'wp_ajax_dismiss_second_menu_notice', array( $this, 'czr_dismiss_second_menu_notice' ) );
+      add_action( 'wp_ajax_dismiss_main_menu_notice'  , array( $this, 'czr_dismiss_main_menu_notice' ) );
+      add_action( 'wp_ajax_slider_notice_actions'     , array( $this, 'czr_slider_notice_ajax_actions' ) );
+      add_action( 'wp_ajax_fp_notice_actions'         , array( $this, 'czr_fp_notice_ajax_actions' ) );
+      add_action( 'wp_ajax_dismiss_widget_notice'     , array( $this, 'czr_dismiss_widget_notice' ) );
     }
 
 
@@ -56,27 +56,27 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
       if ( ! $this -> czr_is_front_help_enabled() )
         return;
       if ( $this -> czr_is_thumbnail_help_on() )
-          add_action( 'wp_footer'   , array( $this, 'tc_write_thumbnail_help_js'), 100 );
+          add_action( 'wp_footer'   , array( $this, 'czr_write_thumbnail_help_js'), 100 );
 
       /* The actual printing of the js is controlled with a filter inside the callback */
-      add_action( 'wp_footer'     , array( $this, 'tc_maybe_write_img_sarmtload_help_js'), 100 );
+      add_action( 'wp_footer'     , array( $this, 'czr_maybe_write_img_sarmtload_help_js'), 100 );
       if ( $this -> czr_is_sidenav_help_on() )
-        add_action( 'wp_footer'   , array( $this, 'tc_write_sidenav_help_js'), 100 );
+        add_action( 'wp_footer'   , array( $this, 'czr_write_sidenav_help_js'), 100 );
 
       if ( $this -> czr_is_second_menu_placeholder_on() )
-        add_action( 'wp_footer'   , array( $this, 'tc_write_second_menu_placeholder_js'), 100 );
+        add_action( 'wp_footer'   , array( $this, 'czr_write_second_menu_placeholder_js'), 100 );
 
       if ( $this -> czr_is_main_menu_notice_on() )
-        add_action( 'wp_footer'   , array( $this, 'tc_write_main_menu_notice_js'), 100 );
+        add_action( 'wp_footer'   , array( $this, 'czr_write_main_menu_notice_js'), 100 );
 
       if ( $this -> czr_is_slider_notice_on() )
-        add_action( 'wp_footer'   , array( $this, 'tc_write_slider_notice_js'), 100 );
+        add_action( 'wp_footer'   , array( $this, 'czr_write_slider_notice_js'), 100 );
 
       if ( $this -> czr_is_fp_notice_on() )
-        add_action( 'wp_footer'   , array( $this, 'tc_write_fp_notice_js'), 100 );
+        add_action( 'wp_footer'   , array( $this, 'czr_write_fp_notice_js'), 100 );
 
       if ( $this -> czr_is_widget_placeholder_enabled() )
-        add_action( 'wp_footer'   , array( $this, 'tc_widget_placeholder_script'), 100 );
+        add_action( 'wp_footer'   , array( $this, 'czr_widget_placeholder_script'), 100 );
     }
 
 
@@ -167,7 +167,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
 
       //checks if at least one of the conditions is true
       return apply_filters(
-        'tc_is_thumbnail_help_on',
+        'czr_is_thumbnail_help_on',
         ! (bool)array_sum($_dont_display_conditions)
       );
     }
@@ -303,7 +303,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
 
       //checks if at least one of the conditions is true
       return apply_filters(
-        'tc_is_img_smartload_help_on',
+        'czr_is_img_smartload_help_on',
         ! (bool) array_sum( $_dont_display_conditions )
       );
     }
@@ -398,7 +398,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
 
       //checks if at least one of the conditions is true
       return apply_filters(
-        'tc_is_sidenav_help_on',
+        'czr_is_sidenav_help_on',
         ! (bool)array_sum($_dont_display_conditions)
       );
     }
@@ -584,7 +584,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
 
       //checks if at least one of the conditions is true
       return apply_filters(
-        'tc_is_main_menu_notice_on',
+        'czr_is_main_menu_notice_on',
         ! (bool)array_sum($_dont_display_conditions)
       );
     }
@@ -704,7 +704,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
 
       //checks if at least one of the conditions is true
       return apply_filters(
-        'tc_is_slider_notice_on',
+        'czr_is_slider_notice_on',
         ! (bool)array_sum($_dont_display_conditions)
       );
     }
@@ -733,7 +733,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
       check_ajax_referer( 'tc-fp-notice-nonce', 'fpNoticeNonce' );
       switch ($_remove_action) {
         case 'remove_fp':
-          CZR_utils::$inst -> czr_set_option( 'tc_show_featured_pages' , 0 );
+          CZR_utils::$inst -> czr_set_option( 'czr_show_featured_pages' , 0 );
         break;
 
         case 'remove_notice':
@@ -818,7 +818,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
       $_dont_display_conditions = array(
         ! is_user_logged_in() || ! current_user_can('edit_theme_options'),
         ! is_admin() && ! CZR_utils::$inst-> czr_is_home(),
-        ! (bool)CZR_utils::$inst->czr_opt('tc_show_featured_pages'),
+        ! (bool)CZR_utils::$inst->czr_opt('czr_show_featured_pages'),
         'disabled' == get_transient("tc_fp_notice"),
         self::$instance -> czr_is_one_fp_set(),
         CZR___::czr_is_pro(),
@@ -828,7 +828,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
 
       //checks if at least one of the conditions is true
       return apply_filters(
-        'tc_is_fp_notice_on',
+        'czr_is_fp_notice_on',
         ! (bool)array_sum($_dont_display_conditions)
       );
     }
@@ -939,7 +939,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
       $_position = is_null($_position) ? apply_filters('tc_widget_areas_position', array( 'sidebar', 'footer') ) : array($_position);
 
       return apply_filters( "tc_display_widget_placeholders",
-        self::$instance -> czr_is_front_help_enabled() && is_user_logged_in() && current_user_can('edit_theme_options') && array_sum( array_map( array( self::$instance , 'tc_check_widget_placeholder_transient'), $_position ) )
+        self::$instance -> czr_is_front_help_enabled() && is_user_logged_in() && current_user_can('edit_theme_options') && array_sum( array_map( array( self::$instance , 'czr_check_widget_placeholder_transient'), $_position ) )
       );
     }
 
@@ -958,7 +958,7 @@ if ( ! class_exists( 'CZR_placeholders' ) ) :
     * User option to enabe/disable all notices. Enabled by default.
     */
     function czr_is_front_help_enabled(){
-      return apply_filters( 'tc_is_front_help_enabled' , (bool)CZR_utils::$inst->czr_opt('tc_display_front_help') );
+      return apply_filters( 'czr_is_front_help_enabled' , (bool)CZR_utils::$inst->czr_opt('tc_display_front_help') );
     }
 
   }//end of class

--- a/inc/class-fire-plugins_compat.php
+++ b/inc/class-fire-plugins_compat.php
@@ -445,7 +445,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       // 1) We cannot use translated string for the "name" param (which actually they say should be in a readable format ..)
       // 2) We need a way to use the same "name" both when registering the string to translate and retrieving its translations
       function czr_fn_wpml_get_options_names_config() {
-        $_wp_cache_key     = 'czr_fn_wpml_get_options_names_config';
+        $_wp_cache_key     = 'tc_wpml_get_options_names_config';
         $option_name_assoc = wp_cache_get( $_wp_cache_key );
 
         if ( false === $option_name_assoc ) {

--- a/inc/class-fire-plugins_compat.php
+++ b/inc/class-fire-plugins_compat.php
@@ -492,7 +492,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       }
 
       //credits: @Srdjan -> filter the slides in the current language
-      function sliders_filter( $sliders ) {
+      function czr_fn_wpml_sliders_filter( $sliders ) {
         if ( is_array( $sliders ) )
           foreach ( $sliders as $name => $slides ) {
             foreach ( $slides as $key => $attachment_id ) {
@@ -514,18 +514,18 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         return $sliders;
       }
       //credits: @Srdjan,
-      function add_theme_options_filter() {
-        add_filter( 'option_tc_theme_options', 'theme_options_filter', 99 );
+      function czr_fn_wpml_add_theme_options_filter() {
+        add_filter( 'option_tc_theme_options', 'czr_fn_wpml_theme_options_filter', 99 );
       }
       //credits: @Srdjan
-      function theme_options_filter( $options ) {
+      function czr_fn_wpml_theme_options_filter( $options ) {
         if ( isset( $options['tc_sliders'] ) ) {
-            $options['tc_sliders'] = sliders_filter( $options['tc_sliders'] );
+            $options['tc_sliders'] = czr_fn_wpml_sliders_filter( $options['tc_sliders'] );
         }
         return $options;
       }
       //credits: @Srdjan
-      function edit_attachment_action( $attachment_id ) {
+      function czr_fn_wpml_edit_attachment_action( $attachment_id ) {
         $languages = apply_filters( 'wpml_active_languages', array() );
         // TODO check which meta keys are a must
         $meta_data = get_post_custom( $attachment_id );
@@ -541,12 +541,12 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         }
       }
 
-      function pre_update_option_filter( $options ) {
+      function czr_fn_wpml_pre_update_option_filter( $options ) {
         if ( isset( $options['tc_sliders'] ) ) {
             // Force default language
             $current_language = CZR_plugins_compat::$instance->current_language;
             CZR_plugins_compat::$instance->current_language = CZR_plugins_compat::$instance->default_language;
-            $options['tc_sliders'] = sliders_filter( $options['tc_sliders'] );
+            $options['tc_sliders'] = czr_fn_wpml_sliders_filter( $options['tc_sliders'] );
             CZR_plugins_compat::$instance->current_language = $current_language;
         }
         return $options;
@@ -595,12 +595,12 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
         //credits @Srdjan
         // Filter slides in admin screens
-        add_action( '__attachment_slider_infos', 'add_theme_options_filter', 9 );
-        add_action( '__post_slider_infos', 'add_theme_options_filter', 9 );
+        add_action( '__attachment_slider_infos', 'czr_fn_wpml_add_theme_options_filter', 9 );
+        add_action( '__post_slider_infos', 'czr_fn_wpml_add_theme_options_filter', 9 );
         // Update translated slide post meta
-        add_action( 'edit_attachment', 'edit_attachment_action', 99 );
+        add_action( 'edit_attachment', 'czr_fn_wpml_edit_attachment_action', 99 );
         // Pre-save hook
-        add_filter( 'pre_update_option_tc_theme_options', 'pre_update_option_filter', 99 );
+        add_filter( 'pre_update_option_tc_theme_options', 'czr_fn_wpml_pre_update_option_filter', 99 );
 
       }// end tc_wpml_admin_setup function
 
@@ -639,7 +639,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
             add_filter("tc_opt_$tc_wpml_option", 'czr_fn_wpml_t_opt', 20 );
 
           //translates sliders? credits @Srdjan
-          add_filter( 'tc_opt_tc_sliders', 'sliders_filter', 99 );
+          add_filter( 'tc_opt_tc_sliders', 'czr_fn_wpml_sliders_filter', 99 );
 
         }
         /*A) FP*/

--- a/inc/class-fire-plugins_compat.php
+++ b/inc/class-fire-plugins_compat.php
@@ -37,7 +37,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    function tc_set_plugins_supported() {
+    function czr_set_plugins_supported() {
       //add support for plugins (added in v3.1+)
       add_theme_support( 'jetpack' );
       add_theme_support( 'bbpress' );
@@ -62,7 +62,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.0.15
     */
-    function tc_plugins_compatibility() {
+    function czr_plugins_compatibility() {
       /* JETPACK */
       //adds compatibilty with the jetpack image carousel and photon
       if ( current_theme_supports( 'jetpack' ) && $this -> tc_is_plugin_active('jetpack/jetpack.php') )
@@ -136,7 +136,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    private function tc_set_jetpack_compat() {
+    private function czr_set_jetpack_compat() {
       //jetpack image carousel
       //this filter doesn't exist anymore it has been replaced by
       //tc_is_gallery_enabled
@@ -156,7 +156,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       //the width/height will not be erronously recalculated
       if ( class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'photon' ) )
         add_filter( 'tc_img_smartloaded', 'tc_jp_smartload_img');
-      function tc_jp_smartload_img( $img ) {
+      function czr_jp_smartload_img( $img ) {
         return str_replace( 'data-recalc-dims', 'data-tcjp-recalc-dims', $img );
       }
     }//end jetpack compat
@@ -170,44 +170,44 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    private function tc_set_bbpress_compat() {
+    private function czr_set_bbpress_compat() {
       // hide tax archive title
       add_filter( 'tc_show_tax_archive_title', 'tc_bbpress_disable_tax_archive_title');
-      function tc_bbpress_disable_tax_archive_title( $bool ){
+      function czr_bbpress_disable_tax_archive_title( $bool ){
         return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
       }
 
       //disables thumbnails and excerpt for post lists
       add_filter( 'tc_show_post_list_thumb', 'tc_bbpress_disable_thumbnail' );
-      function tc_bbpress_disable_thumbnail($bool) {
+      function czr_bbpress_disable_thumbnail($bool) {
          return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
       }
       add_filter( 'tc_show_excerpt', 'tc_bbpress_disable_excerpt' );
-      function tc_bbpress_disable_excerpt($bool) {
+      function czr_bbpress_disable_excerpt($bool) {
          return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
       }
 
       //disables Customizr author infos on forums
       add_filter( 'tc_show_author_metas_in_post', 'tc_bbpress_disable_author_meta' );
-      function tc_bbpress_disable_author_meta($bool) {
+      function czr_bbpress_disable_author_meta($bool) {
         return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
       }
 
       //disables post navigation
       add_filter( 'tc_show_post_navigation', 'tc_bbpress_disable_post_navigation' );
-      function tc_bbpress_disable_post_navigation($bool) {
+      function czr_bbpress_disable_post_navigation($bool) {
          return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
       }
 
       //disables post metas
       add_filter( 'tc_show_post_metas', 'tc_bbpress_disable_post_metas', 100);
-      function tc_bbpress_disable_post_metas($bool) {
+      function czr_bbpress_disable_post_metas($bool) {
          return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
       }
 
       //disable the grid
       add_filter( 'tc_set_grid_hooks' , 'tc_bbpress_disable_grid', 100 );
-      function tc_bbpress_disable_grid($bool) {
+      function czr_bbpress_disable_grid($bool) {
          return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
       }
     }
@@ -218,9 +218,9 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    private function tc_set_buddypress_compat() {
+    private function czr_set_buddypress_compat() {
       add_filter( 'tc_are_comments_enabled', 'tc_buddypress_disable_comments' );
-      function tc_buddypress_disable_comments($bool){
+      function czr_buddypress_disable_comments($bool){
         return ( is_page() && function_exists('is_buddypress') && is_buddypress() ) ? false : $bool;
       }
       //disable smartload in change-avatar buddypress profile page
@@ -235,7 +235,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       //anyways this page is not a regular "front" page as it pertains more to a "backend" side
       //if we can call it that way.
       add_action( 'xprofile_screen_change_avatar', 'tc_buddypress_maybe_disable_img_smartload' );
-      function tc_buddypress_maybe_disable_img_smartload() {
+      function czr_buddypress_maybe_disable_img_smartload() {
         add_filter( 'tc_opt_tc_img_smart_load', '__return_false' );
       }
     }
@@ -246,17 +246,17 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    private function tc_set_qtranslatex_compat() {
-      function tc_url_lang($url) {
+    private function czr_set_qtranslatex_compat() {
+      function czr_url_lang($url) {
         return ( function_exists( 'qtrans_convertURL' ) ) ? qtrans_convertURL($url) : $url;
       }
-      function tc_apply_qtranslate ($text) {
+      function czr_apply_qtranslate ($text) {
         return call_user_func(  '__' , $text );
       }
-      function tc_remove_char_limit() {
+      function czr_remove_char_limit() {
         return 99999;
       }
-      function tc_change_transport( $value , $set ) {
+      function czr_change_transport( $value , $set ) {
         return ('transport' == $set) ? 'refresh' : $value;
       }
 
@@ -294,7 +294,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
       //posts slider (this filter is not fired in admin )
       add_filter('tc_posts_slider_pre_model', 'tc_posts_slider_qtranslate');
-      function tc_posts_slider_qtranslate( $pre_slides ){
+      function czr_posts_slider_qtranslate( $pre_slides ){
         if ( empty($pre_slides) )
           return $pre_slides;
 
@@ -331,7 +331,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    private function tc_set_polylang_compat() {
+    private function czr_set_polylang_compat() {
       // Disable posts slider transient caching
       add_filter('tc_posts_slider_use_transient', '__return_false');
 
@@ -339,7 +339,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       if ( function_exists( 'pll_register_string' ) )
         add_action( 'admin_init', 'tc_pll_strings_setup' );
 
-      function tc_pll_strings_setup() {
+      function czr_pll_strings_setup() {
         // grab theme options
         $tc_options = tc__f('__options');
         // grab settings map, useful for some options labels
@@ -388,7 +388,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         * Tax filtering (home/blog posts filtered by cat)
         * @param array of term ids
         */
-        function tc_pll_translate_tax( $term_ids ){
+        function czr_pll_translate_tax( $term_ids ){
           if ( ! ( is_array( $term_ids ) && ! empty( $term_ids ) ) )
             return $term_ids;
 
@@ -429,7 +429,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         //Featured pages ids "translation"
         // Substitute any page id with the equivalent page in current language (if found)
         add_filter( 'tc_fp_id', 'tc_pll_page_id', 20 );
-        function tc_pll_page_id( $fp_page_id ) {
+        function czr_pll_page_id( $fp_page_id ) {
           return is_int( pll_get_post( $fp_page_id ) ) ? pll_get_post( $fp_page_id ) : $fp_page_id;
         }
       }//end Front
@@ -442,7 +442,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    private function tc_set_wpml_compat() {
+    private function czr_set_wpml_compat() {
       //credits : @Srdjan
       $this->default_language = apply_filters( 'wpml_default_language', null );
       $this->current_language = apply_filters( 'wpml_current_language', null );
@@ -461,7 +461,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       // This means that
       // 1) We cannot use translated string for the "name" param (which actually they say should be in a readable format ..)
       // 2) We need a way to use the same "name" both when registering the string to translate and retrieving its translations
-      function tc_wpml_get_options_names_config() {
+      function czr_wpml_get_options_names_config() {
         $_wp_cache_key     = 'tc_wpml_get_options_names_config';
         $option_name_assoc = wp_cache_get( $_wp_cache_key );
 
@@ -500,7 +500,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
       //Wras wpml_object_id in a more convenient function which recursevely translates array of values
       //$object can be an array or a single value
-      function tc_wpml_object_id( $object_id, $type ) {
+      function czr_wpml_object_id( $object_id, $type ) {
         if ( empty( $object_id ) )
           return $object_id;
         if ( is_array( $object_id ) )
@@ -571,7 +571,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
       add_action( 'admin_init', 'tc_wpml_admin_setup' );
 
-      function tc_wpml_admin_setup() {
+      function czr_wpml_admin_setup() {
         // If wpml-string-translation is active perform admin pages translation
         if ( function_exists( 'icl_register_string' ) ) {
           $tc_wpml_option_name = tc_wpml_get_options_names_config();
@@ -597,7 +597,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         //if we change this option in the Customizer with lang IT removing B, e.g., when we switch to EN we'll have that the array of cats contains just A, as it as been overwritten with the new setting
         if ( CZR___::$instance -> tc_is_customize_left_panel() )
           add_filter( 'option_tc_theme_options', 'tc_wpml_customizer_options_transpose' );
-        function tc_wpml_customizer_options_transpose( $options ) {
+        function czr_wpml_customizer_options_transpose( $options ) {
           $options_to_transpose = apply_filters ( 'tc_wpml_customizer_translate_options', array(
             'page'     => ( ! class_exists('TC_fpu') && ! class_exists('TC_fpc') ) ? array( 'tc_featured_page_one', 'tc_featured_page_two', 'tc_featured_page_three' ) : array(),
             'category' => array( 'tc_blog_restrict_by_cat' )
@@ -629,19 +629,19 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
           /*** TC - WPML bind, wrap WPML string translator function into convenient tc functions ***/
           //define our icl_t wrapper for options filtered with tc_opt_{$option}
           if ( ! function_exists( 'tc_wpml_t_opt' ) ) {
-            function tc_wpml_t_opt( $string ) {
+            function czr_wpml_t_opt( $string ) {
               return tc_wpml_t( $string, str_replace('tc_opt_', '', current_filter() ) );
             }
           }
           //special function for the post slider button text pre trim filter
           if ( ! function_exists( 'tc_wpml_t_ps_button_text' ) ) {
-            function tc_wpml_t_ps_button_text( $string ) {
+            function czr_wpml_t_ps_button_text( $string ) {
               return tc_wpml_t( $string, 'tc_posts_slider_button_text' );
             }
           }
           //define our icl_t wrapper
           if ( ! function_exists( 'tc_wpml_t' ) ) {
-            function tc_wpml_t( $string, $opt ) {
+            function czr_wpml_t( $string, $opt ) {
               $tc_wpml_options_names = tc_wpml_get_options_names_config();
               return icl_t( TC_WPML_CONTEXT, $tc_wpml_options_names[$opt], $string );
             }
@@ -662,7 +662,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         /*A) FP*/
         // Featured pages ids "translation"
         add_filter( 'tc_fp_id', 'tc_wpml_page_id', 20 );
-        function tc_wpml_page_id( $fp_page_id ) {
+        function czr_wpml_page_id( $fp_page_id ) {
           return tc_wpml_object_id( $fp_page_id, 'page');
         }
 
@@ -673,7 +673,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         * AFAIK wpml needs to exactly know which kind of tax we're looking for, category, tag ecc..
         * @param array of term ids
         */
-        function tc_wpml_translate_cat( $cat_ids ){
+        function czr_wpml_translate_cat( $cat_ids ){
           if ( ! ( is_array( $cat_ids ) && ! empty( $cat_ids ) ) )
             return $cat_ids;
           return array_unique( tc_wpml_object_id( $cat_ids, 'category' ) );
@@ -717,12 +717,12 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    private function tc_set_the_events_calendar_compat() {
+    private function czr_set_the_events_calendar_compat() {
       /*
       * Are we in the Events list context?
       */
       if ( ! ( function_exists( 'tc_is_tec_events_list' ) ) ) {
-        function tc_is_tec_events_list() {
+        function czr_is_tec_events_list() {
           return function_exists( 'tribe_is_event_query' ) && tribe_is_event_query() && is_post_type_archive();
         }
       }
@@ -730,26 +730,26 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       * Are we in single Event context?
       */
       if ( ! ( function_exists( 'tc_is_tec_single_event' ) ) ) {
-        function tc_is_tec_single_event() {
+        function czr_is_tec_single_event() {
           return function_exists( 'tribe_is_event_query' ) && tribe_is_event_query() && is_single();
         }
       }
       // hide tax archive title
       add_filter( 'tc_show_tax_archive_title', 'tc_tec_disable_tax_archive_title');
-      function tc_tec_disable_tax_archive_title( $bool ) {
+      function czr_tec_disable_tax_archive_title( $bool ) {
         return tc_is_tec_events_list() ? false : $bool;
       }
 
       // Events archive is displayed, wrongly, we our post lists classes, we have to prevent this
       add_filter( 'tc_post_list_controller', 'tc_tec_disable_post_list');
       add_filter( 'tc_is_grid_enabled', 'tc_tec_disable_post_list');
-      function tc_tec_disable_post_list( $bool ) {
+      function czr_tec_disable_post_list( $bool ) {
         return tc_is_tec_events_list() ? false : $bool;
       }
 
       // Now we have to display a post or page content
       add_filter( 'tc_show_single_post_content', 'tc_tec_show_content' );
-      function tc_tec_show_content( $bool ) {
+      function czr_tec_show_content( $bool ) {
         //2 cases:
         //1 - in events lists - we force showing single post content
         //2 - in single events we have to prevent showing both page and post content
@@ -765,24 +765,24 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       // for their own reasons. This impacts on our breadcrumb 'cause we use the function post_type_archive_title() to build up the trail arg in posty_type_archives contexts.
       // What we do here is unhooking their callback before the breadcrumb is built and re-hook it after it has been displayed
       add_action( 'wp_head', 'tc_tec_allow_display_breadcrumb_in_month_view');
-      function tc_tec_allow_display_breadcrumb_in_month_view() {
+      function czr_tec_allow_display_breadcrumb_in_month_view() {
         if ( ! ( tc_is_tec_events_list() && function_exists( 'tribe_is_month' ) && tribe_is_month() ) )
           return;
 
         add_filter( 'tc_breadcrumb_trail_args', 'tc_tec_unhook_empty_post_type_archive_title');
-        function tc_tec_unhook_empty_post_type_archive_title( $args = null ) {
+        function czr_tec_unhook_empty_post_type_archive_title( $args = null ) {
           remove_filter( 'post_type_archive_title', '__return_false', 10 );
           return $args;
         }
         add_filter( 'tc_breadcrumb_trail_display', 'tc_tec_rehook_empty_post_type_archive_title', PHP_INT_MAX );
-        function tc_tec_rehook_empty_post_type_archive_title( $breadcrumb = null ) {
+        function czr_tec_rehook_empty_post_type_archive_title( $breadcrumb = null ) {
           add_filter( 'post_type_archive_title', '__return_false', 10 );
           return $breadcrumb;
         }
       }
       //disables post navigation in single tec pages
       add_filter( 'tc_show_post_navigation', 'tc_tec_disable_post_navigation' );
-      function tc_tec_disable_post_navigation($bool) {
+      function czr_tec_disable_post_navigation($bool) {
         return ( tc_is_tec_single_event() ) ? false : $bool;
       }
     }//end the-events-calendar compat
@@ -795,9 +795,9 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    private function tc_set_optimizepress_compat() {
+    private function czr_set_optimizepress_compat() {
       add_action('wp_print_scripts', 'tc_op_dequeue_fancybox_js');
-      function tc_op_dequeue_fancybox_js(){
+      function czr_op_dequeue_fancybox_js(){
         if ( function_exists('is_le_page') ){
           /* Op Back End: Dequeue tc-scripts */
           if ( is_le_page() || defined('OP_LIVEEDITOR') ) {
@@ -814,7 +814,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
       /* Remove fancybox loading icon*/
       add_action('wp_footer','tc_op_remove_fancyboxloading');
-      function tc_op_remove_fancyboxloading(){
+      function czr_op_remove_fancyboxloading(){
         echo "<script>
                 if (typeof(opjq) !== 'undefined') {
                   opjq(document).ready(function(){
@@ -833,7 +833,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    private function tc_set_sensei_compat() {
+    private function czr_set_sensei_compat() {
       //unkooks the default sensei wrappers and add customizr's content wrapper and action hooks
       global $woothemes_sensei;
       remove_action( 'sensei_before_main_content', array( $woothemes_sensei->frontend, 'sensei_output_content_wrapper' ), 10 );
@@ -843,7 +843,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       add_action('sensei_after_main_content', 'tc_sensei_wrappers', 10);
 
 
-      function tc_sensei_wrappers() {
+      function czr_sensei_wrappers() {
         switch ( current_filter() ) {
           case 'sensei_before_main_content': CZR_plugins_compat::$instance -> tc_mainwrapper_start();
                                              break;
@@ -855,18 +855,18 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
       // hide tax archive title
       add_filter( 'tc_show_tax_archive_title', 'tc_sensei_disable_tax_archive_title');
-      function tc_sensei_disable_tax_archive_title( $bool ){
+      function czr_sensei_disable_tax_archive_title( $bool ){
         return ( function_exists('is_sensei') && is_sensei() ) ? false : $bool;
       }
 
       //disables post navigation
       add_filter( 'tc_show_post_navigation', 'tc_sensei_disable_post_navigation' );
-      function tc_sensei_disable_post_navigation($bool) {
+      function czr_sensei_disable_post_navigation($bool) {
         return ( function_exists('is_sensei') && is_sensei() ) ? false : $bool;
       }
       //removes post comment action on after_loop hook
       add_filter( 'tc_are_comments_enabled', 'tc_sensei_disable_comments' );
-      function tc_sensei_disable_comments($bool) {
+      function czr_sensei_disable_comments($bool) {
         return ( function_exists('is_sensei') && is_sensei() ) ? false : $bool;
       }
     }//end sensei compat
@@ -880,7 +880,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    private function tc_set_woocomerce_compat() {
+    private function czr_set_woocomerce_compat() {
       //unkooks the default woocommerce wrappersv and add customizr's content wrapper and action hooks
       remove_action( 'woocommerce_before_main_content', 'woocommerce_output_content_wrapper', 10);
       remove_action( 'woocommerce_after_main_content', 'woocommerce_output_content_wrapper_end', 10);
@@ -891,7 +891,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       if ( apply_filters( 'tc_disable_woocommerce_breadcrumb', true ) )
         remove_action( 'woocommerce_before_main_content', 'woocommerce_breadcrumb', 20, 0 );
 
-      function tc_woocommerce_wrappers() {
+      function czr_woocommerce_wrappers() {
         switch ( current_filter() ) {
           case 'woocommerce_before_main_content': CZR_plugins_compat::$instance -> tc_mainwrapper_start();
                                                   break;
@@ -901,13 +901,13 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         }//end of switch on hook
       }//end of nested function
       //Helper
-      function tc_wc_is_checkout_cart() {
+      function czr_wc_is_checkout_cart() {
         return is_checkout() || is_cart() || defined('WOOCOMMERCE_CHECKOUT') || defined('WOOCOMMERCE_CART');
       }
       // use Customizr title
       // initially used to display the edit button
       add_filter( 'the_title', 'tc_woocommerce_the_title' );
-      function tc_woocommerce_the_title( $_title ){
+      function czr_woocommerce_the_title( $_title ){
         if ( function_exists('is_woocommerce') && is_woocommerce() && ! is_page() )
             return apply_filters( 'tc_title_text', $_title );
         return $_title;
@@ -915,18 +915,18 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
       // hide tax archive title
       add_filter( 'tc_show_tax_archive_title', 'tc_woocommerce_disable_tax_archive_title');
-      function tc_woocommerce_disable_tax_archive_title( $bool ){
+      function czr_woocommerce_disable_tax_archive_title( $bool ){
         return ( function_exists('is_woocommerce') && is_woocommerce() ) ? false : $bool;
       }
 
       //allow slider in the woocommerce shop page
       add_filter('tc_show_slider', 'tc_woocommerce_enable_shop_slider');
-      function tc_woocommerce_enable_shop_slider( $bool ){
+      function czr_woocommerce_enable_shop_slider( $bool ){
         return ( function_exists('is_woocommerce') && is_woocommerce() && function_exists('is_shop') && is_shop() ) ? true : $bool;
       }
       //to allow the slider in the woocommerce shop page we need the shop page id
       add_filter('tc_slider_get_real_id', 'tc_woocommerce_shop_page_id');
-      function tc_woocommerce_shop_page_id( $id ){
+      function czr_woocommerce_shop_page_id( $id ){
         return ( function_exists('is_woocommerce') && is_woocommerce() && function_exists('is_shop') && is_shop() && function_exists('wc_get_page_id') ) ? wc_get_page_id('shop') : $id;
       }
 
@@ -938,20 +938,20 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
       //disables post navigation
       add_filter( 'tc_show_post_navigation', 'tc_woocommerce_disable_post_navigation' );
-      function tc_woocommerce_disable_post_navigation($bool) {
+      function czr_woocommerce_disable_post_navigation($bool) {
          return ( function_exists('is_woocommerce') && is_woocommerce() ) ? false : $bool;
       }
 
 
       //removes post comment action on after_loop hook
       add_filter( 'tc_are_comments_enabled', 'tc_woocommerce_disable_comments' );
-      function tc_woocommerce_disable_comments($bool) {
+      function czr_woocommerce_disable_comments($bool) {
          return ( function_exists('is_woocommerce') && is_woocommerce() ) ? false : $bool;
       }
 
       //link smooth scroll: exclude woocommerce tabs
       add_filter( 'tc_anchor_smoothscroll_excl', 'tc_woocommerce_disable_link_scroll' );
-      function tc_woocommerce_disable_link_scroll( $excl ){
+      function czr_woocommerce_disable_link_scroll( $excl ){
         if ( false == esc_attr( CZR_utils::$inst->tc_opt('tc_link_scroll') ) ) return $excl;
 
         if ( function_exists('is_woocommerce') && is_woocommerce() ) {
@@ -972,7 +972,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
       //changes customizr meta boxes priority (slider and layout not on top) if displaying woocommerce products in admin
       add_filter( 'tc_post_meta_boxes_priority', 'tc_woocommerce_change_meta_boxes_priority' , 2 , 10 );
-      function tc_woocommerce_change_meta_boxes_priority($priority , $screen) {
+      function czr_woocommerce_change_meta_boxes_priority($priority , $screen) {
          return ( 'product' == $screen ) ? 'default' : $priority ;
       }
 
@@ -980,20 +980,20 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       // Allow HEADER CART OPTIONS in the customizer
       // Returns a callback function needed by 'active_callback' to enable the options in the customizer
       add_filter( 'tc_woocommerce_options_enabled', 'tc_woocommerce_options_enabled_cb' );
-      function tc_woocommerce_options_enabled_cb() {
+      function czr_woocommerce_options_enabled_cb() {
         return '__return_true';
       }
 
       /* rendering the cart icon in the header */
       //narrow the tagline
       add_filter( 'tc_tagline_class', 'tc_woocommerce_force_tagline_width', 100 );
-      function tc_woocommerce_force_tagline_width( $_class ) {
+      function czr_woocommerce_force_tagline_width( $_class ) {
         return 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_woocommerce_header_cart' ) ) ? 'span6' : $_class ;
       }
 
       // Ensure cart contents update when products are added to the cart via AJAX (place the following in functions.php)
       add_filter( 'woocommerce_add_to_cart_fragments', 'tc_woocommerce_add_to_cart_fragment' );
-      function tc_woocommerce_add_to_cart_fragment( $fragments ) {
+      function czr_woocommerce_add_to_cart_fragment( $fragments ) {
         if ( 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_woocommerce_header_cart' ) ) ) {
           $_cart_count = WC()->cart->get_cart_contents_count();
           $fragments['span.tc-wc-count'] = sprintf( '<span class="count btn-link tc-wc-count">%1$s</span>', $_cart_count ? $_cart_count : '' );
@@ -1003,7 +1003,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
       //print the cart menu in the header
       add_action( '__navbar', 'tc_woocommerce_header_cart', is_rtl() ? 9 : 19 );
-      function tc_woocommerce_header_cart() {
+      function czr_woocommerce_header_cart() {
         if ( 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_woocommerce_header_cart' ) ) )
           return;
 
@@ -1038,7 +1038,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
       //add woommerce header cart classes to the header (sticky enabled)
       add_filter( 'tc_header_classes'   , 'tc_woocommerce_set_header_classes');
-      function tc_woocommerce_set_header_classes( $_classes ) {
+      function czr_woocommerce_set_header_classes( $_classes ) {
         if ( 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_woocommerce_header_cart' ) ) )
           $_classes[]          = ( 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_woocommerce_header_cart_sticky' ) ) ) ? 'tc-wccart-off' : 'tc-wccart-on';
         return $_classes;
@@ -1046,7 +1046,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
       //add woocommerce header cart CSS
       add_filter('tc_user_options_style', 'tc_woocommerce_header_cart_css');
-      function tc_woocommerce_header_cart_css( $_css ) {
+      function czr_woocommerce_header_cart_css( $_css ) {
         if ( 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_woocommerce_header_cart' ) ) )
           return $_css;
 
@@ -1155,10 +1155,10 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    private function tc_set_vc_compat() {
+    private function czr_set_vc_compat() {
       //link smooth scroll: exclude all anchor links inside vc wrappers (.vc_row)
       add_filter( 'tc_anchor_smoothscroll_excl', 'tc_vc_disable_link_scroll' );
-      function tc_vc_disable_link_scroll( $excl ){
+      function czr_vc_disable_link_scroll( $excl ){
         if ( false == esc_attr( CZR_utils::$inst->tc_opt('tc_link_scroll') ) ) return $excl;
 
         if ( ! is_array( $excl ) )
@@ -1183,22 +1183,22 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    private function tc_set_disqus_compat() {
+    private function czr_set_disqus_compat() {
       if ( ! function_exists( 'tc_disqus_comments_enabled' ) ) {
-        function tc_disqus_comments_enabled() {
+        function czr_disqus_comments_enabled() {
           return function_exists( 'dsq_is_installed' ) && function_exists( 'dsq_can_replace' )
                  && dsq_is_installed() && dsq_can_replace();
         }
       }
       //replace the default comment link anchor with a more descriptive disqus anchor
       add_filter( 'tc_bubble_comment_anchor', 'tc_disqus_bubble_comment_anchor' );
-      function tc_disqus_bubble_comment_anchor( $anchor ) {
+      function czr_disqus_bubble_comment_anchor( $anchor ) {
         return tc_disqus_comments_enabled() ? '#tc-disqus-comments' : $anchor;
       }
       //wrap disqus comments template in a convenient div
       add_action( 'tc_before_comments_template' , 'tc_disqus_comments_wrapper' );
       add_action( 'tc_after_comments_template'  , 'tc_disqus_comments_wrapper' );
-      function tc_disqus_comments_wrapper() {
+      function czr_disqus_comments_wrapper() {
         if ( ! tc_disqus_comments_enabled() )
           return;
 
@@ -1217,9 +1217,9 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    private function tc_set_uris_compat() {
+    private function czr_set_uris_compat() {
       add_filter ( 'tc_img_smart_load_options', 'tc_uris_disable_img_smartload' ) ;
-      function tc_uris_disable_img_smartload( $options ){
+      function czr_uris_disable_img_smartload( $options ){
         if ( ! is_array( $options ) )
           $options = array();
 
@@ -1245,7 +1245,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     *
     * originally used for woocommerce compatibility
     */
-    function tc_mainwrapper_start() {
+    function czr_mainwrapper_start() {
       ?>
       <div id="main-wrapper" class="<?php echo implode(' ', apply_filters( 'tc_main_wrapper_classes' , array('container') ) ) ?>">
 
@@ -1262,7 +1262,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       <?php
     }
 
-    function tc_mainwrapper_end() {
+    function czr_mainwrapper_end() {
       ?>
                 <?php do_action ('__after_loop');##hook of the comments and the posts navigation with priorities 10 and 20 ?>
 
@@ -1291,7 +1291,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @param string $plugin Base plugin path from plugins directory.
     * @return bool True, if in the active plugins list. False, not in the list.
     */
-    function tc_is_plugin_active( $plugin ) {
+    function czr_is_plugin_active( $plugin ) {
       return in_array( $plugin, (array) get_option( 'active_plugins', array() ) ) || $this -> tc_is_plugin_active_for_network( $plugin );
     }
 
@@ -1306,7 +1306,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @param string $plugin Base plugin path from plugins directory.
     * @return bool True, if active for the network, otherwise false.
     */
-    function tc_is_plugin_active_for_network( $plugin ) {
+    function czr_is_plugin_active_for_network( $plugin ) {
       if ( ! is_multisite() )
         return false;
 
@@ -1317,7 +1317,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       return false;
     }
 
-    public function tc_get_string_options_to_translate() {
+    public function czr_get_string_options_to_translate() {
       $string_options = array(
         'tc_front_slider',
         'tc_posts_slider_button_text',

--- a/inc/class-fire-plugins_compat.php
+++ b/inc/class-fire-plugins_compat.php
@@ -21,8 +21,8 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
       self::$instance =& $this;
       //add various plugins compatibilty (Jetpack, Bbpress, Qtranslate, Woocommerce, The Event Calendar ...)
-      add_action ('after_setup_theme'          , array( $this , 'czr_set_plugins_supported'), 20 );
-      add_action ('after_setup_theme'          , array( $this , 'czr_plugins_compatibility'), 30 );
+      add_action ('after_setup_theme'          , array( $this , 'czr_fn_set_plugins_supported'), 20 );
+      add_action ('after_setup_theme'          , array( $this , 'czr_fn_plugins_compatibility'), 30 );
       // remove qtranslateX theme options filter
       remove_filter('option_tc_theme_options', 'qtranxf_translate_option', 5);
     }//end of constructor
@@ -37,7 +37,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    function czr_set_plugins_supported() {
+    function czr_fn_set_plugins_supported() {
       //add support for plugins (added in v3.1+)
       add_theme_support( 'jetpack' );
       add_theme_support( 'bbpress' );
@@ -62,70 +62,70 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.0.15
     */
-    function czr_plugins_compatibility() {
+    function czr_fn_plugins_compatibility() {
       /* JETPACK */
       //adds compatibilty with the jetpack image carousel and photon
-      if ( current_theme_supports( 'jetpack' ) && $this -> czr_is_plugin_active('jetpack/jetpack.php') )
-        $this -> czr_set_jetpack_compat();
+      if ( current_theme_supports( 'jetpack' ) && $this -> czr_fn_is_plugin_active('jetpack/jetpack.php') )
+        $this -> czr_fn_set_jetpack_compat();
 
       /* BBPRESS */
       //if bbpress is installed and activated, we can check the existence of the contextual boolean function is_bbpress() to execute some code
-      if ( current_theme_supports( 'bbpress' ) && $this -> czr_is_plugin_active('bbpress/bbpress.php') )
-        $this -> czr_set_bbpress_compat();
+      if ( current_theme_supports( 'bbpress' ) && $this -> czr_fn_is_plugin_active('bbpress/bbpress.php') )
+        $this -> czr_fn_set_bbpress_compat();
 
       /* BUDDYPRESS */
       //if buddypress is installed and activated, we can check the existence of the contextual boolean function is_buddypress() to execute some code
       // we have to use buddy-press instead of buddypress as string for theme support as buddypress makes some checks on current_theme_supports('buddypress') which result in not using its templates
-      if ( current_theme_supports( 'buddy-press' ) && $this -> czr_is_plugin_active('buddypress/bp-loader.php') )
-        $this -> czr_set_buddypress_compat();
+      if ( current_theme_supports( 'buddy-press' ) && $this -> czr_fn_is_plugin_active('buddypress/bp-loader.php') )
+        $this -> czr_fn_set_buddypress_compat();
 
       /*
       * QTranslatex
       * Credits : @acub, http://websiter.ro
       */
-      if ( current_theme_supports( 'qtranslate-x' ) && $this -> czr_is_plugin_active('qtranslate-x/qtranslate.php') )
-        $this -> czr_set_qtranslatex_compat();
+      if ( current_theme_supports( 'qtranslate-x' ) && $this -> czr_fn_is_plugin_active('qtranslate-x/qtranslate.php') )
+        $this -> czr_fn_set_qtranslatex_compat();
 
       /*
       * Polylang
       * Credits : Rocco Aliberti
       */
-      if ( current_theme_supports( 'polylang' ) && $this -> czr_is_plugin_active('polylang/polylang.php') )
-        $this -> czr_set_polylang_compat();
+      if ( current_theme_supports( 'polylang' ) && $this -> czr_fn_is_plugin_active('polylang/polylang.php') )
+        $this -> czr_fn_set_polylang_compat();
 
       /*
       * WPML
       */
-      if ( current_theme_supports( 'wpml' ) && $this -> czr_is_plugin_active('sitepress-multilingual-cms/sitepress.php') )
-        $this -> czr_set_wpml_compat();
+      if ( current_theme_supports( 'wpml' ) && $this -> czr_fn_is_plugin_active('sitepress-multilingual-cms/sitepress.php') )
+        $this -> czr_fn_set_wpml_compat();
 
       /* The Events Calendar */
-      if ( current_theme_supports( 'the-events-calendar' ) && $this -> czr_is_plugin_active('the-events-calendar/the-events-calendar.php') )
-        $this -> czr_set_the_events_calendar_compat();
+      if ( current_theme_supports( 'the-events-calendar' ) && $this -> czr_fn_is_plugin_active('the-events-calendar/the-events-calendar.php') )
+        $this -> czr_fn_set_the_events_calendar_compat();
 
       /* Optimize Press */
-      if ( current_theme_supports( 'optimize-press' ) && $this -> czr_is_plugin_active('optimizePressPlugin/optimizepress.php') )
-        $this -> czr_set_optimizepress_compat();
+      if ( current_theme_supports( 'optimize-press' ) && $this -> czr_fn_is_plugin_active('optimizePressPlugin/optimizepress.php') )
+        $this -> czr_fn_set_optimizepress_compat();
 
       /* Woocommerce */
-      if ( current_theme_supports( 'woocommerce' ) && $this -> czr_is_plugin_active('woocommerce/woocommerce.php') )
-        $this -> czr_set_woocomerce_compat();
+      if ( current_theme_supports( 'woocommerce' ) && $this -> czr_fn_is_plugin_active('woocommerce/woocommerce.php') )
+        $this -> czr_fn_set_woocomerce_compat();
 
       /* Sensei woocommerce addon */
-      if ( current_theme_supports( 'sensei') && $this -> czr_is_plugin_active('woothemes-sensei/woothemes-sensei.php') )
-        $this -> czr_set_sensei_compat();
+      if ( current_theme_supports( 'sensei') && $this -> czr_fn_is_plugin_active('woothemes-sensei/woothemes-sensei.php') )
+        $this -> czr_fn_set_sensei_compat();
 
       /* Visual Composer */
-      if ( current_theme_supports( 'visual-composer') && $this -> czr_is_plugin_active('js_composer/js_composer.php') )
-        $this -> czr_set_vc_compat();
+      if ( current_theme_supports( 'visual-composer') && $this -> czr_fn_is_plugin_active('js_composer/js_composer.php') )
+        $this -> czr_fn_set_vc_compat();
 
       /* Disqus Comment System */
-      if ( current_theme_supports( 'disqus') && $this -> czr_is_plugin_active('disqus-comment-system/disqus.php') )
-        $this -> czr_set_disqus_compat();
+      if ( current_theme_supports( 'disqus') && $this -> czr_fn_is_plugin_active('disqus-comment-system/disqus.php') )
+        $this -> czr_fn_set_disqus_compat();
 
       /* Ultimate Responsive Image Slider  */
-      if ( current_theme_supports( 'uris' ) && $this -> czr_is_plugin_active('ultimate-responsive-image-slider/ultimate-responsive-image-slider.php') )
-        $this -> czr_set_uris_compat();
+      if ( current_theme_supports( 'uris' ) && $this -> czr_fn_is_plugin_active('ultimate-responsive-image-slider/ultimate-responsive-image-slider.php') )
+        $this -> czr_fn_set_uris_compat();
     }//end of plugin compatibility function
 
 
@@ -136,7 +136,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    private function czr_set_jetpack_compat() {
+    private function czr_fn_set_jetpack_compat() {
       //jetpack image carousel
       //this filter doesn't exist anymore it has been replaced by
       //tc_is_gallery_enabled
@@ -155,8 +155,8 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       //Anyway to avoid the 1x1 issue we alter the img attribute (data-recalc-dims) which photon adds to the img tag(php) so
       //the width/height will not be erronously recalculated
       if ( class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'photon' ) )
-        add_filter( 'tc_img_smartloaded', 'czr_jp_smartload_img');
-      function czr_jp_smartload_img( $img ) {
+        add_filter( 'tc_img_smartloaded', 'czr_fn_jp_smartload_img');
+      function czr_fn_jp_smartload_img( $img ) {
         return str_replace( 'data-recalc-dims', 'data-tcjp-recalc-dims', $img );
       }
     }//end jetpack compat
@@ -170,44 +170,44 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    private function czr_set_bbpress_compat() {
+    private function czr_fn_set_bbpress_compat() {
       // hide tax archive title
-      add_filter( 'tc_show_tax_archive_title', 'czr_bbpress_disable_tax_archive_title');
-      function czr_bbpress_disable_tax_archive_title( $bool ){
+      add_filter( 'tc_show_tax_archive_title', 'czr_fn_bbpress_disable_tax_archive_title');
+      function czr_fn_bbpress_disable_tax_archive_title( $bool ){
         return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
       }
 
       //disables thumbnails and excerpt for post lists
-      add_filter( 'tc_show_post_list_thumb', 'czr_bbpress_disable_thumbnail' );
-      function czr_bbpress_disable_thumbnail($bool) {
+      add_filter( 'tc_show_post_list_thumb', 'czr_fn_bbpress_disable_thumbnail' );
+      function czr_fn_bbpress_disable_thumbnail($bool) {
          return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
       }
-      add_filter( 'czr_show_excerpt', 'czr_bbpress_disable_excerpt' );
-      function czr_bbpress_disable_excerpt($bool) {
+      add_filter( 'czr_fn_show_excerpt', 'czr_fn_bbpress_disable_excerpt' );
+      function czr_fn_bbpress_disable_excerpt($bool) {
          return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
       }
 
       //disables Customizr author infos on forums
-      add_filter( 'tc_show_author_metas_in_post', 'czr_bbpress_disable_author_meta' );
-      function czr_bbpress_disable_author_meta($bool) {
+      add_filter( 'tc_show_author_metas_in_post', 'czr_fn_bbpress_disable_author_meta' );
+      function czr_fn_bbpress_disable_author_meta($bool) {
         return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
       }
 
       //disables post navigation
-      add_filter( 'tc_show_post_navigation', 'czr_bbpress_disable_post_navigation' );
-      function czr_bbpress_disable_post_navigation($bool) {
+      add_filter( 'tc_show_post_navigation', 'czr_fn_bbpress_disable_post_navigation' );
+      function czr_fn_bbpress_disable_post_navigation($bool) {
          return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
       }
 
       //disables post metas
-      add_filter( 'czr_show_post_metas', 'czr_bbpress_disable_post_metas', 100);
-      function czr_bbpress_disable_post_metas($bool) {
+      add_filter( 'czr_fn_show_post_metas', 'czr_fn_bbpress_disable_post_metas', 100);
+      function czr_fn_bbpress_disable_post_metas($bool) {
          return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
       }
 
       //disable the grid
-      add_filter( 'czr_set_grid_hooks' , 'czr_bbpress_disable_grid', 100 );
-      function czr_bbpress_disable_grid($bool) {
+      add_filter( 'czr_fn_set_grid_hooks' , 'czr_fn_bbpress_disable_grid', 100 );
+      function czr_fn_bbpress_disable_grid($bool) {
          return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
       }
     }
@@ -218,9 +218,9 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    private function czr_set_buddypress_compat() {
-      add_filter( 'czr_are_comments_enabled', 'czr_buddypress_disable_comments' );
-      function czr_buddypress_disable_comments($bool){
+    private function czr_fn_set_buddypress_compat() {
+      add_filter( 'czr_fn_are_comments_enabled', 'czr_fn_buddypress_disable_comments' );
+      function czr_fn_buddypress_disable_comments($bool){
         return ( is_page() && function_exists('is_buddypress') && is_buddypress() ) ? false : $bool;
       }
       //disable smartload in change-avatar buddypress profile page
@@ -234,8 +234,8 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       //2) a cover image, if already set
       //anyways this page is not a regular "front" page as it pertains more to a "backend" side
       //if we can call it that way.
-      add_action( 'xprofile_screen_change_avatar', 'czr_buddypress_maybe_disable_img_smartload' );
-      function czr_buddypress_maybe_disable_img_smartload() {
+      add_action( 'xprofile_screen_change_avatar', 'czr_fn_buddypress_maybe_disable_img_smartload' );
+      function czr_fn_buddypress_maybe_disable_img_smartload() {
         add_filter( 'tc_opt_tc_img_smart_load', '__return_false' );
       }
     }
@@ -246,68 +246,68 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    private function czr_set_qtranslatex_compat() {
-      function czr_url_lang($url) {
+    private function czr_fn_set_qtranslatex_compat() {
+      function czr_fn_url_lang($url) {
         return ( function_exists( 'qtrans_convertURL' ) ) ? qtrans_convertURL($url) : $url;
       }
-      function czr_apply_qtranslate ($text) {
+      function czr_fn_apply_qtranslate ($text) {
         return call_user_func(  '__' , $text );
       }
-      function czr_remove_char_limit() {
+      function czr_fn_remove_char_limit() {
         return 99999;
       }
-      function czr_change_transport( $value , $set ) {
+      function czr_fn_change_transport( $value , $set ) {
         return ('transport' == $set) ? 'refresh' : $value;
       }
 
       //outputs correct urls for current language : in logo, slider
       foreach ( array( 'tc_slide_link_url', 'tc_logo_link_url') as $filter )
-        add_filter( $filter, 'czr_url_lang' );
+        add_filter( $filter, 'czr_fn_url_lang' );
 
       //outputs the qtranslate translation for slider
       foreach ( array( 'tc_slide_title', 'tc_slide_text', 'tc_slide_button_text', 'tc_slide_background_alt' ) as $filter )
-        add_filter( $filter, 'czr_apply_qtranslate' );
+        add_filter( $filter, 'czr_fn_apply_qtranslate' );
       //sets no character limit for slider (title, lead text and button title) => allow users to use qtranslate tags for as many languages they wants ([:en]English text[:de]German text...and so on)
       foreach ( array( 'tc_slide_title_length', 'tc_slide_text_length', 'tc_slide_button_length' ) as $filter )
-        add_filter( $filter  , 'czr_remove_char_limit');
+        add_filter( $filter  , 'czr_fn_remove_char_limit');
 
       //outputs the qtranslate translation for archive titles;
       $tc_archive_titles = array( 'tag_archive', 'category_archive', 'author_archive', 'search_results');
       foreach ( $tc_archive_titles as $title )
-        add_filter("tc_{$title}_title", 'czr_apply_qtranslate' , 20);
+        add_filter("tc_{$title}_title", 'czr_fn_apply_qtranslate' , 20);
 
       // QtranslateX for FP when no FPC or FPU running
       if ( ! class_exists('TC_fpu') && ! class_exists('TC_fpc') ) {
         //outputs correct urls for current language : fp
-        add_filter( 'tc_fp_link_url' , 'czr_url_lang');
+        add_filter( 'tc_fp_link_url' , 'czr_fn_url_lang');
         //outputs the qtranslate translation for featured pages
-        add_filter( 'tc_fp_text', 'czr_apply_qtranslate' );
-        add_filter( 'tc_fp_button_text', 'czr_apply_qtranslate' );
+        add_filter( 'tc_fp_text', 'czr_fn_apply_qtranslate' );
+        add_filter( 'tc_fp_button_text', 'czr_fn_apply_qtranslate' );
 
         /* The following is pretty useless at the momment since we should inhibit preview js code */
         //modify the customizer transport from post message to null for some options
-        add_filter( 'tc_featured_page_button_text_customizer_set' , 'czr_change_transport', 20, 2);
-        add_filter( 'tc_featured_text_one_customizer_set' , 'czr_change_transport', 20, 2);
-        add_filter( 'tc_featured_text_two_customizer_set' , 'czr_change_transport', 20, 2);
-        add_filter( 'tc_featured_text_three_customizer_set', 'czr_change_transport', 20, 2);
+        add_filter( 'tc_featured_page_button_text_customizer_set' , 'czr_fn_change_transport', 20, 2);
+        add_filter( 'tc_featured_text_one_customizer_set' , 'czr_fn_change_transport', 20, 2);
+        add_filter( 'tc_featured_text_two_customizer_set' , 'czr_fn_change_transport', 20, 2);
+        add_filter( 'tc_featured_text_three_customizer_set', 'czr_fn_change_transport', 20, 2);
       }
 
       //posts slider (this filter is not fired in admin )
-      add_filter('tc_posts_slider_pre_model', 'czr_posts_slider_qtranslate');
-      function czr_posts_slider_qtranslate( $pre_slides ){
+      add_filter('tc_posts_slider_pre_model', 'czr_fn_posts_slider_qtranslate');
+      function czr_fn_posts_slider_qtranslate( $pre_slides ){
         if ( empty($pre_slides) )
           return $pre_slides;
 
         // remove useles q-translation of the slider view
         foreach ( array( 'tc_slide_title', 'tc_slide_text', 'tc_slide_button_text', 'tc_slide_background_alt' ) as $filter )
-          remove_filter( $filter, 'czr_apply_qtranslate' );
+          remove_filter( $filter, 'czr_fn_apply_qtranslate' );
 
         // allow q-translation pre trim/sanitize
         foreach ( array( 'tc_posts_slider_button_text_pre_trim', 'tc_post_title_pre_trim', 'tc_post_excerpt_pre_sanitize', 'tc_posts_slide_background' ) as $filter )
-          add_filter( $filter, 'czr_apply_qtranslate' );
+          add_filter( $filter, 'czr_fn_apply_qtranslate' );
 
         //translate button text
-        $pre_slides['common']['button_text'] = $pre_slides['common']['button_text'] ? CZR_slider::$instance -> czr_get_post_slide_button_text( $pre_slides['common']['button_text'] ) : '';
+        $pre_slides['common']['button_text'] = $pre_slides['common']['button_text'] ? CZR_slider::$instance -> czr_fn_get_post_slide_button_text( $pre_slides['common']['button_text'] ) : '';
 
         //translate title and excerpt if needed
         $_posts = &$pre_slides['posts'];
@@ -317,8 +317,8 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
           $_p = get_post( $ID );
           if ( ! $_p ) continue;
 
-          $_post['title'] = $_post['title'] ? CZR_slider::$instance -> czr_get_post_slide_title($_p, $ID) : '';
-          $_post['text']  = $_post['text'] ? CZR_slider::$instance -> czr_get_post_slide_excerpt($_p, $ID) : '';
+          $_post['title'] = $_post['title'] ? CZR_slider::$instance -> czr_fn_get_post_slide_title($_p, $ID) : '';
+          $_post['text']  = $_post['text'] ? CZR_slider::$instance -> czr_fn_get_post_slide_excerpt($_p, $ID) : '';
         }
         return $pre_slides;
       }
@@ -331,25 +331,25 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    private function czr_set_polylang_compat() {
+    private function czr_fn_set_polylang_compat() {
       // Disable posts slider transient caching
       add_filter('tc_posts_slider_use_transient', '__return_false');
 
       // If Polylang is active, hook function on the admin pages
       if ( function_exists( 'pll_register_string' ) )
-        add_action( 'admin_init', 'czr_pll_strings_setup' );
+        add_action( 'admin_init', 'czr_fn_pll_strings_setup' );
 
-      function czr_pll_strings_setup() {
+      function czr_fn_pll_strings_setup() {
         // grab theme options
-        $tc_options = czr__f('__options');
+        $tc_options = czr_fn__f('__options');
         // grab settings map, useful for some options labels
-        $tc_settings_map = CZR_utils_settings_map::$instance -> czr_get_customizer_map( $get_default = true );
+        $tc_settings_map = CZR_utils_settings_map::$instance -> czr_fn_get_customizer_map( $get_default = true );
         $tc_controls_map = $tc_settings_map['add_setting_control'];
         // set $polylang_group;
         $polylang_group = 'customizr-pro' == CZR___::$theme_name ? 'Customizr-Pro' : 'Customizr';
 
         //get options to translate
-        $tc_translatable_raw_options = CZR_plugins_compat::$instance -> czr_get_string_options_to_translate();
+        $tc_translatable_raw_options = CZR_plugins_compat::$instance -> czr_fn_get_string_options_to_translate();
         $tc_pll_options              = array();
 
         //build array if option => array( label (gettext-ed), option )
@@ -379,7 +379,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       if ( function_exists( 'pll_get_post' ) && function_exists( 'pll__' ) && ! is_admin() ) {
         //strings translation
         //get the options to translate
-        $tc_translatable_options = CZR_plugins_compat::$instance -> czr_get_string_options_to_translate();
+        $tc_translatable_options = CZR_plugins_compat::$instance -> czr_fn_get_string_options_to_translate();
         //translate
         foreach ( $tc_translatable_options as $tc_translatable_option )
           add_filter("tc_opt_$tc_translatable_option", 'pll__');
@@ -388,7 +388,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         * Tax filtering (home/blog posts filtered by cat)
         * @param array of term ids
         */
-        function czr_pll_translate_tax( $term_ids ){
+        function czr_fn_pll_translate_tax( $term_ids ){
           if ( ! ( is_array( $term_ids ) && ! empty( $term_ids ) ) )
             return $term_ids;
 
@@ -401,7 +401,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         }
 
         //Translate category ids for the filtered posts in home/blog
-        add_filter('tc_opt_tc_blog_restrict_by_cat', 'czr_pll_translate_tax');
+        add_filter('tc_opt_tc_blog_restrict_by_cat', 'czr_fn_pll_translate_tax');
         /*end tax filtering*/
 
         /* Slider of posts */
@@ -428,8 +428,8 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
         //Featured pages ids "translation"
         // Substitute any page id with the equivalent page in current language (if found)
-        add_filter( 'tc_fp_id', 'czr_pll_page_id', 20 );
-        function czr_pll_page_id( $fp_page_id ) {
+        add_filter( 'tc_fp_id', 'czr_fn_pll_page_id', 20 );
+        function czr_fn_pll_page_id( $fp_page_id ) {
           return is_int( pll_get_post( $fp_page_id ) ) ? pll_get_post( $fp_page_id ) : $fp_page_id;
         }
       }//end Front
@@ -442,7 +442,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    private function czr_set_wpml_compat() {
+    private function czr_fn_set_wpml_compat() {
       //credits : @Srdjan
       $this->default_language = apply_filters( 'wpml_default_language', null );
       $this->current_language = apply_filters( 'wpml_current_language', null );
@@ -461,12 +461,12 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       // This means that
       // 1) We cannot use translated string for the "name" param (which actually they say should be in a readable format ..)
       // 2) We need a way to use the same "name" both when registering the string to translate and retrieving its translations
-      function czr_wpml_get_options_names_config() {
-        $_wp_cache_key     = 'czr_wpml_get_options_names_config';
+      function czr_fn_wpml_get_options_names_config() {
+        $_wp_cache_key     = 'czr_fn_wpml_get_options_names_config';
         $option_name_assoc = wp_cache_get( $_wp_cache_key );
 
         if ( false === $option_name_assoc ) {
-          $options_to_translate = CZR_plugins_compat::$instance -> czr_get_string_options_to_translate();
+          $options_to_translate = CZR_plugins_compat::$instance -> czr_fn_get_string_options_to_translate();
 
           $option_name_assoc = apply_filters( 'tc_wpml_options_names_config', array(
  //           'tc_front_slider'              => 'Front page slider name', //Handled in a different way by Srdjan
@@ -495,16 +495,16 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
           //cache this 'cause is used several times in filter callbacks
           wp_cache_set( $_wp_cache_key, $option_name_assoc );
         }
-        return apply_filters( 'czr_wpml_get_options_names_config', $option_name_assoc );
+        return apply_filters( 'czr_fn_wpml_get_options_names_config', $option_name_assoc );
       }
 
       //Wras wpml_object_id in a more convenient function which recursevely translates array of values
       //$object can be an array or a single value
-      function czr_wpml_object_id( $object_id, $type ) {
+      function czr_fn_wpml_object_id( $object_id, $type ) {
         if ( empty( $object_id ) )
           return $object_id;
         if ( is_array( $object_id ) )
-          return array_map( 'czr_wpml_object_id', $object_id, array_fill( 0, sizeof( $object_id ), $type ) );
+          return array_map( 'czr_fn_wpml_object_id', $object_id, array_fill( 0, sizeof( $object_id ), $type ) );
         return apply_filters( 'wpml_object_id', $object_id, $type, true );
       }
 
@@ -569,16 +569,16 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         return $options;
       }
 
-      add_action( 'admin_init', 'czr_wpml_admin_setup' );
+      add_action( 'admin_init', 'czr_fn_wpml_admin_setup' );
 
-      function czr_wpml_admin_setup() {
+      function czr_fn_wpml_admin_setup() {
         // If wpml-string-translation is active perform admin pages translation
         if ( function_exists( 'icl_register_string' ) ) {
-          $tc_wpml_option_name = czr_wpml_get_options_names_config();
+          $tc_wpml_option_name = czr_fn_wpml_get_options_names_config();
           $tc_wpml_options     = array_keys($tc_wpml_option_name);
 
           // grab theme options
-          $tc_options = czr__f('__options');
+          $tc_options = czr_fn__f('__options');
 
           // build array of options to translate
           foreach ( $tc_wpml_options as $tc_wpml_option )
@@ -595,9 +595,9 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         //In English we have set to filter blog posts for cat A,B and C.
         //In Italian we do not have cat C so there will be displayed transposed cats A and B
         //if we change this option in the Customizer with lang IT removing B, e.g., when we switch to EN we'll have that the array of cats contains just A, as it as been overwritten with the new setting
-        if ( CZR___::$instance -> czr_is_customize_left_panel() )
-          add_filter( 'option_tc_theme_options', 'czr_wpml_customizer_options_transpose' );
-        function czr_wpml_customizer_options_transpose( $options ) {
+        if ( CZR___::$instance -> czr_fn_is_customize_left_panel() )
+          add_filter( 'option_tc_theme_options', 'czr_fn_wpml_customizer_options_transpose' );
+        function czr_fn_wpml_customizer_options_transpose( $options ) {
           $options_to_transpose = apply_filters ( 'tc_wpml_customizer_translate_options', array(
             'page'     => ( ! class_exists('TC_fpu') && ! class_exists('TC_fpc') ) ? array( 'tc_featured_page_one', 'tc_featured_page_two', 'tc_featured_page_three' ) : array(),
             'category' => array( 'tc_blog_restrict_by_cat' )
@@ -606,7 +606,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
           foreach ( $options_to_transpose as $type => $option_to_transpose )
             foreach ( $option_to_transpose as $option )
               if ( isset( $options[$option] ) )
-                $options[$option] = czr_wpml_object_id( $options[$option], $type);
+                $options[$option] = czr_fn_wpml_object_id( $options[$option], $type);
           return $options;
         }
 
@@ -628,32 +628,32 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         if ( function_exists( 'icl_t') ) {
           /*** TC - WPML bind, wrap WPML string translator function into convenient tc functions ***/
           //define our icl_t wrapper for options filtered with tc_opt_{$option}
-          if ( ! function_exists( 'czr_wpml_t_opt' ) ) {
-            function czr_wpml_t_opt( $string ) {
-              return czr_wpml_t( $string, str_replace('tc_opt_', '', current_filter() ) );
+          if ( ! function_exists( 'czr_fn_wpml_t_opt' ) ) {
+            function czr_fn_wpml_t_opt( $string ) {
+              return czr_fn_wpml_t( $string, str_replace('tc_opt_', '', current_filter() ) );
             }
           }
           //special function for the post slider button text pre trim filter
-          if ( ! function_exists( 'czr_wpml_t_ps_button_text' ) ) {
-            function czr_wpml_t_ps_button_text( $string ) {
-              return czr_wpml_t( $string, 'tc_posts_slider_button_text' );
+          if ( ! function_exists( 'czr_fn_wpml_t_ps_button_text' ) ) {
+            function czr_fn_wpml_t_ps_button_text( $string ) {
+              return czr_fn_wpml_t( $string, 'tc_posts_slider_button_text' );
             }
           }
           //define our icl_t wrapper
-          if ( ! function_exists( 'czr_wpml_t' ) ) {
-            function czr_wpml_t( $string, $opt ) {
-              $tc_wpml_options_names = czr_wpml_get_options_names_config();
+          if ( ! function_exists( 'czr_fn_wpml_t' ) ) {
+            function czr_fn_wpml_t( $string, $opt ) {
+              $tc_wpml_options_names = czr_fn_wpml_get_options_names_config();
               return icl_t( TC_WPML_CONTEXT, $tc_wpml_options_names[$opt], $string );
             }
           }
           /*** End TC - WPML bind ***/
 
           //get the options to translate
-          $tc_wpml_options = array_keys( czr_wpml_get_options_names_config() );
+          $tc_wpml_options = array_keys( czr_fn_wpml_get_options_names_config() );
 
           //strings translation
           foreach ( $tc_wpml_options as $tc_wpml_option )
-            add_filter("tc_opt_$tc_wpml_option", 'czr_wpml_t_opt', 20 );
+            add_filter("tc_opt_$tc_wpml_option", 'czr_fn_wpml_t_opt', 20 );
 
           //translates sliders? credits @Srdjan
           add_filter( 'tc_opt_tc_sliders', 'sliders_filter', 99 );
@@ -661,9 +661,9 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         }
         /*A) FP*/
         // Featured pages ids "translation"
-        add_filter( 'tc_fp_id', 'czr_wpml_page_id', 20 );
-        function czr_wpml_page_id( $fp_page_id ) {
-          return czr_wpml_object_id( $fp_page_id, 'page');
+        add_filter( 'tc_fp_id', 'czr_fn_wpml_page_id', 20 );
+        function czr_fn_wpml_page_id( $fp_page_id ) {
+          return czr_fn_wpml_object_id( $fp_page_id, 'page');
         }
 
         /*B) Tax */
@@ -673,13 +673,13 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         * AFAIK wpml needs to exactly know which kind of tax we're looking for, category, tag ecc..
         * @param array of term ids
         */
-        function czr_wpml_translate_cat( $cat_ids ){
+        function czr_fn_wpml_translate_cat( $cat_ids ){
           if ( ! ( is_array( $cat_ids ) && ! empty( $cat_ids ) ) )
             return $cat_ids;
-          return array_unique( czr_wpml_object_id( $cat_ids, 'category' ) );
+          return array_unique( czr_fn_wpml_object_id( $cat_ids, 'category' ) );
         }
         //Translate category ids for the filtered posts in home/blog
-        add_filter('tc_opt_tc_blog_restrict_by_cat', 'czr_wpml_translate_cat');
+        add_filter('tc_opt_tc_blog_restrict_by_cat', 'czr_fn_wpml_translate_cat');
         /*end tax filtering*/
 
         /* Slider of posts */
@@ -717,45 +717,45 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    private function czr_set_the_events_calendar_compat() {
+    private function czr_fn_set_the_events_calendar_compat() {
       /*
       * Are we in the Events list context?
       */
-      if ( ! ( function_exists( 'czr_is_tec_events_list' ) ) ) {
-        function czr_is_tec_events_list() {
+      if ( ! ( function_exists( 'czr_fn_is_tec_events_list' ) ) ) {
+        function czr_fn_is_tec_events_list() {
           return function_exists( 'tribe_is_event_query' ) && tribe_is_event_query() && is_post_type_archive();
         }
       }
       /*
       * Are we in single Event context?
       */
-      if ( ! ( function_exists( 'czr_is_tec_single_event' ) ) ) {
-        function czr_is_tec_single_event() {
+      if ( ! ( function_exists( 'czr_fn_is_tec_single_event' ) ) ) {
+        function czr_fn_is_tec_single_event() {
           return function_exists( 'tribe_is_event_query' ) && tribe_is_event_query() && is_single();
         }
       }
       // hide tax archive title
-      add_filter( 'tc_show_tax_archive_title', 'czr_tec_disable_tax_archive_title');
-      function czr_tec_disable_tax_archive_title( $bool ) {
-        return czr_is_tec_events_list() ? false : $bool;
+      add_filter( 'tc_show_tax_archive_title', 'czr_fn_tec_disable_tax_archive_title');
+      function czr_fn_tec_disable_tax_archive_title( $bool ) {
+        return czr_fn_is_tec_events_list() ? false : $bool;
       }
 
       // Events archive is displayed, wrongly, we our post lists classes, we have to prevent this
-      add_filter( 'czr_post_list_controller', 'czr_tec_disable_post_list');
-      add_filter( 'czr_is_grid_enabled', 'czr_tec_disable_post_list');
-      function czr_tec_disable_post_list( $bool ) {
-        return czr_is_tec_events_list() ? false : $bool;
+      add_filter( 'czr_fn_post_list_controller', 'czr_fn_tec_disable_post_list');
+      add_filter( 'czr_fn_is_grid_enabled', 'czr_fn_tec_disable_post_list');
+      function czr_fn_tec_disable_post_list( $bool ) {
+        return czr_fn_is_tec_events_list() ? false : $bool;
       }
 
       // Now we have to display a post or page content
-      add_filter( 'tc_show_single_post_content', 'czr_tec_show_content' );
-      function czr_tec_show_content( $bool ) {
+      add_filter( 'tc_show_single_post_content', 'czr_fn_tec_show_content' );
+      function czr_fn_tec_show_content( $bool ) {
         //2 cases:
         //1 - in events lists - we force showing single post content
         //2 - in single events we have to prevent showing both page and post content
-        if ( czr_is_tec_events_list() )
+        if ( czr_fn_is_tec_events_list() )
           return true;
-        else if( czr_is_tec_single_event() )
+        else if( czr_fn_is_tec_single_event() )
           return false;
         return $bool;
       }
@@ -764,26 +764,26 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       // The Events Calendar adds a filter on post_type_archive_title with __return_false callback
       // for their own reasons. This impacts on our breadcrumb 'cause we use the function post_type_archive_title() to build up the trail arg in posty_type_archives contexts.
       // What we do here is unhooking their callback before the breadcrumb is built and re-hook it after it has been displayed
-      add_action( 'wp_head', 'czr_tec_allow_display_breadcrumb_in_month_view');
-      function czr_tec_allow_display_breadcrumb_in_month_view() {
-        if ( ! ( czr_is_tec_events_list() && function_exists( 'tribe_is_month' ) && tribe_is_month() ) )
+      add_action( 'wp_head', 'czr_fn_tec_allow_display_breadcrumb_in_month_view');
+      function czr_fn_tec_allow_display_breadcrumb_in_month_view() {
+        if ( ! ( czr_fn_is_tec_events_list() && function_exists( 'tribe_is_month' ) && tribe_is_month() ) )
           return;
 
-        add_filter( 'tc_breadcrumb_trail_args', 'czr_tec_unhook_empty_post_type_archive_title');
-        function czr_tec_unhook_empty_post_type_archive_title( $args = null ) {
+        add_filter( 'tc_breadcrumb_trail_args', 'czr_fn_tec_unhook_empty_post_type_archive_title');
+        function czr_fn_tec_unhook_empty_post_type_archive_title( $args = null ) {
           remove_filter( 'post_type_archive_title', '__return_false', 10 );
           return $args;
         }
-        add_filter( 'tc_breadcrumb_trail_display', 'czr_tec_rehook_empty_post_type_archive_title', PHP_INT_MAX );
-        function czr_tec_rehook_empty_post_type_archive_title( $breadcrumb = null ) {
+        add_filter( 'tc_breadcrumb_trail_display', 'czr_fn_tec_rehook_empty_post_type_archive_title', PHP_INT_MAX );
+        function czr_fn_tec_rehook_empty_post_type_archive_title( $breadcrumb = null ) {
           add_filter( 'post_type_archive_title', '__return_false', 10 );
           return $breadcrumb;
         }
       }
       //disables post navigation in single tec pages
-      add_filter( 'tc_show_post_navigation', 'czr_tec_disable_post_navigation' );
-      function czr_tec_disable_post_navigation($bool) {
-        return ( czr_is_tec_single_event() ) ? false : $bool;
+      add_filter( 'tc_show_post_navigation', 'czr_fn_tec_disable_post_navigation' );
+      function czr_fn_tec_disable_post_navigation($bool) {
+        return ( czr_fn_is_tec_single_event() ) ? false : $bool;
       }
     }//end the-events-calendar compat
 
@@ -795,9 +795,9 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    private function czr_set_optimizepress_compat() {
-      add_action('wp_print_scripts', 'czr_op_dequeue_fancybox_js');
-      function czr_op_dequeue_fancybox_js(){
+    private function czr_fn_set_optimizepress_compat() {
+      add_action('wp_print_scripts', 'czr_fn_op_dequeue_fancybox_js');
+      function czr_fn_op_dequeue_fancybox_js(){
         if ( function_exists('is_le_page') ){
           /* Op Back End: Dequeue tc-scripts */
           if ( is_le_page() || defined('OP_LIVEEDITOR') ) {
@@ -813,8 +813,8 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       }
 
       /* Remove fancybox loading icon*/
-      add_action('wp_footer','czr_op_remove_fancyboxloading');
-      function czr_op_remove_fancyboxloading(){
+      add_action('wp_footer','czr_fn_op_remove_fancyboxloading');
+      function czr_fn_op_remove_fancyboxloading(){
         echo "<script>
                 if (typeof(opjq) !== 'undefined') {
                   opjq(document).ready(function(){
@@ -833,40 +833,40 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    private function czr_set_sensei_compat() {
+    private function czr_fn_set_sensei_compat() {
       //unkooks the default sensei wrappers and add customizr's content wrapper and action hooks
       global $woothemes_sensei;
       remove_action( 'sensei_before_main_content', array( $woothemes_sensei->frontend, 'sensei_output_content_wrapper' ), 10 );
       remove_action( 'sensei_after_main_content', array( $woothemes_sensei->frontend, 'sensei_output_content_wrapper_end' ), 10 );
 
-      add_action('sensei_before_main_content', 'czr_sensei_wrappers', 10);
-      add_action('sensei_after_main_content', 'czr_sensei_wrappers', 10);
+      add_action('sensei_before_main_content', 'czr_fn_sensei_wrappers', 10);
+      add_action('sensei_after_main_content', 'czr_fn_sensei_wrappers', 10);
 
 
-      function czr_sensei_wrappers() {
+      function czr_fn_sensei_wrappers() {
         switch ( current_filter() ) {
-          case 'sensei_before_main_content': CZR_plugins_compat::$instance -> czr_mainwrapper_start();
+          case 'sensei_before_main_content': CZR_plugins_compat::$instance -> czr_fn_mainwrapper_start();
                                              break;
 
-          case 'sensei_after_main_content' : CZR_plugins_compat::$instance -> czr_mainwrapper_end();
+          case 'sensei_after_main_content' : CZR_plugins_compat::$instance -> czr_fn_mainwrapper_end();
                                              break;
         }//end of switch on hook
       }//end of nested function
 
       // hide tax archive title
-      add_filter( 'tc_show_tax_archive_title', 'czr_sensei_disable_tax_archive_title');
-      function czr_sensei_disable_tax_archive_title( $bool ){
+      add_filter( 'tc_show_tax_archive_title', 'czr_fn_sensei_disable_tax_archive_title');
+      function czr_fn_sensei_disable_tax_archive_title( $bool ){
         return ( function_exists('is_sensei') && is_sensei() ) ? false : $bool;
       }
 
       //disables post navigation
-      add_filter( 'tc_show_post_navigation', 'czr_sensei_disable_post_navigation' );
-      function czr_sensei_disable_post_navigation($bool) {
+      add_filter( 'tc_show_post_navigation', 'czr_fn_sensei_disable_post_navigation' );
+      function czr_fn_sensei_disable_post_navigation($bool) {
         return ( function_exists('is_sensei') && is_sensei() ) ? false : $bool;
       }
       //removes post comment action on after_loop hook
-      add_filter( 'czr_are_comments_enabled', 'czr_sensei_disable_comments' );
-      function czr_sensei_disable_comments($bool) {
+      add_filter( 'czr_fn_are_comments_enabled', 'czr_fn_sensei_disable_comments' );
+      function czr_fn_sensei_disable_comments($bool) {
         return ( function_exists('is_sensei') && is_sensei() ) ? false : $bool;
       }
     }//end sensei compat
@@ -880,53 +880,53 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    private function czr_set_woocomerce_compat() {
+    private function czr_fn_set_woocomerce_compat() {
       //unkooks the default woocommerce wrappersv and add customizr's content wrapper and action hooks
       remove_action( 'woocommerce_before_main_content', 'woocommerce_output_content_wrapper', 10);
       remove_action( 'woocommerce_after_main_content', 'woocommerce_output_content_wrapper_end', 10);
-      add_action('woocommerce_before_main_content', 'czr_woocommerce_wrappers', 10);
-      add_action('woocommerce_after_main_content', 'czr_woocommerce_wrappers', 10);
+      add_action('woocommerce_before_main_content', 'czr_fn_woocommerce_wrappers', 10);
+      add_action('woocommerce_after_main_content', 'czr_fn_woocommerce_wrappers', 10);
 
       //disable WooCommerce default breadcrumb
       if ( apply_filters( 'tc_disable_woocommerce_breadcrumb', true ) )
         remove_action( 'woocommerce_before_main_content', 'woocommerce_breadcrumb', 20, 0 );
 
-      function czr_woocommerce_wrappers() {
+      function czr_fn_woocommerce_wrappers() {
         switch ( current_filter() ) {
-          case 'woocommerce_before_main_content': CZR_plugins_compat::$instance -> czr_mainwrapper_start();
+          case 'woocommerce_before_main_content': CZR_plugins_compat::$instance -> czr_fn_mainwrapper_start();
                                                   break;
 
-          case 'woocommerce_after_main_content' : CZR_plugins_compat::$instance -> czr_mainwrapper_end();
+          case 'woocommerce_after_main_content' : CZR_plugins_compat::$instance -> czr_fn_mainwrapper_end();
                                                   break;
         }//end of switch on hook
       }//end of nested function
       //Helper
-      function czr_wc_is_checkout_cart() {
+      function czr_fn_wc_is_checkout_cart() {
         return is_checkout() || is_cart() || defined('WOOCOMMERCE_CHECKOUT') || defined('WOOCOMMERCE_CART');
       }
       // use Customizr title
       // initially used to display the edit button
-      add_filter( 'the_title', 'czr_woocommerce_the_title' );
-      function czr_woocommerce_the_title( $_title ){
+      add_filter( 'the_title', 'czr_fn_woocommerce_the_title' );
+      function czr_fn_woocommerce_the_title( $_title ){
         if ( function_exists('is_woocommerce') && is_woocommerce() && ! is_page() )
             return apply_filters( 'tc_title_text', $_title );
         return $_title;
       }
 
       // hide tax archive title
-      add_filter( 'tc_show_tax_archive_title', 'czr_woocommerce_disable_tax_archive_title');
-      function czr_woocommerce_disable_tax_archive_title( $bool ){
+      add_filter( 'tc_show_tax_archive_title', 'czr_fn_woocommerce_disable_tax_archive_title');
+      function czr_fn_woocommerce_disable_tax_archive_title( $bool ){
         return ( function_exists('is_woocommerce') && is_woocommerce() ) ? false : $bool;
       }
 
       //allow slider in the woocommerce shop page
-      add_filter('tc_show_slider', 'czr_woocommerce_enable_shop_slider');
-      function czr_woocommerce_enable_shop_slider( $bool ){
+      add_filter('tc_show_slider', 'czr_fn_woocommerce_enable_shop_slider');
+      function czr_fn_woocommerce_enable_shop_slider( $bool ){
         return ( function_exists('is_woocommerce') && is_woocommerce() && function_exists('is_shop') && is_shop() ) ? true : $bool;
       }
       //to allow the slider in the woocommerce shop page we need the shop page id
-      add_filter('tc_slider_get_real_id', 'czr_woocommerce_shop_page_id');
-      function czr_woocommerce_shop_page_id( $id ){
+      add_filter('tc_slider_get_real_id', 'czr_fn_woocommerce_shop_page_id');
+      function czr_fn_woocommerce_shop_page_id( $id ){
         return ( function_exists('is_woocommerce') && is_woocommerce() && function_exists('is_shop') && is_shop() && function_exists('wc_get_page_id') ) ? wc_get_page_id('shop') : $id;
       }
 
@@ -937,22 +937,22 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
 
       //disables post navigation
-      add_filter( 'tc_show_post_navigation', 'czr_woocommerce_disable_post_navigation' );
-      function czr_woocommerce_disable_post_navigation($bool) {
+      add_filter( 'tc_show_post_navigation', 'czr_fn_woocommerce_disable_post_navigation' );
+      function czr_fn_woocommerce_disable_post_navigation($bool) {
          return ( function_exists('is_woocommerce') && is_woocommerce() ) ? false : $bool;
       }
 
 
       //removes post comment action on after_loop hook
-      add_filter( 'czr_are_comments_enabled', 'czr_woocommerce_disable_comments' );
-      function czr_woocommerce_disable_comments($bool) {
+      add_filter( 'czr_fn_are_comments_enabled', 'czr_fn_woocommerce_disable_comments' );
+      function czr_fn_woocommerce_disable_comments($bool) {
          return ( function_exists('is_woocommerce') && is_woocommerce() ) ? false : $bool;
       }
 
       //link smooth scroll: exclude woocommerce tabs
-      add_filter( 'tc_anchor_smoothscroll_excl', 'czr_woocommerce_disable_link_scroll' );
-      function czr_woocommerce_disable_link_scroll( $excl ){
-        if ( false == esc_attr( CZR_utils::$inst->czr_opt('tc_link_scroll') ) ) return $excl;
+      add_filter( 'tc_anchor_smoothscroll_excl', 'czr_fn_woocommerce_disable_link_scroll' );
+      function czr_fn_woocommerce_disable_link_scroll( $excl ){
+        if ( false == esc_attr( CZR_utils::$inst->czr_fn_opt('tc_link_scroll') ) ) return $excl;
 
         if ( function_exists('is_woocommerce') && is_woocommerce() ) {
           if ( ! is_array( $excl ) )
@@ -971,30 +971,30 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
 
       //changes customizr meta boxes priority (slider and layout not on top) if displaying woocommerce products in admin
-      add_filter( 'tc_post_meta_boxes_priority', 'czr_woocommerce_change_meta_boxes_priority' , 2 , 10 );
-      function czr_woocommerce_change_meta_boxes_priority($priority , $screen) {
+      add_filter( 'tc_post_meta_boxes_priority', 'czr_fn_woocommerce_change_meta_boxes_priority' , 2 , 10 );
+      function czr_fn_woocommerce_change_meta_boxes_priority($priority , $screen) {
          return ( 'product' == $screen ) ? 'default' : $priority ;
       }
 
 
       // Allow HEADER CART OPTIONS in the customizer
       // Returns a callback function needed by 'active_callback' to enable the options in the customizer
-      add_filter( 'tc_woocommerce_options_enabled', 'czr_woocommerce_options_enabled_cb' );
-      function czr_woocommerce_options_enabled_cb() {
+      add_filter( 'tc_woocommerce_options_enabled', 'czr_fn_woocommerce_options_enabled_cb' );
+      function czr_fn_woocommerce_options_enabled_cb() {
         return '__return_true';
       }
 
       /* rendering the cart icon in the header */
       //narrow the tagline
-      add_filter( 'tc_tagline_class', 'czr_woocommerce_force_tagline_width', 100 );
-      function czr_woocommerce_force_tagline_width( $_class ) {
-        return 1 == esc_attr( CZR_utils::$inst->czr_opt( 'czr_woocommerce_header_cart' ) ) ? 'span6' : $_class ;
+      add_filter( 'tc_tagline_class', 'czr_fn_woocommerce_force_tagline_width', 100 );
+      function czr_fn_woocommerce_force_tagline_width( $_class ) {
+        return 1 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'czr_fn_woocommerce_header_cart' ) ) ? 'span6' : $_class ;
       }
 
       // Ensure cart contents update when products are added to the cart via AJAX (place the following in functions.php)
-      add_filter( 'woocommerce_add_to_cart_fragments', 'czr_woocommerce_add_to_cart_fragment' );
-      function czr_woocommerce_add_to_cart_fragment( $fragments ) {
-        if ( 1 == esc_attr( CZR_utils::$inst->czr_opt( 'czr_woocommerce_header_cart' ) ) ) {
+      add_filter( 'woocommerce_add_to_cart_fragments', 'czr_fn_woocommerce_add_to_cart_fragment' );
+      function czr_fn_woocommerce_add_to_cart_fragment( $fragments ) {
+        if ( 1 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'czr_fn_woocommerce_header_cart' ) ) ) {
           $_cart_count = WC()->cart->get_cart_contents_count();
           $fragments['span.tc-wc-count'] = sprintf( '<span class="count btn-link tc-wc-count">%1$s</span>', $_cart_count ? $_cart_count : '' );
         }
@@ -1002,15 +1002,15 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       }
 
       //print the cart menu in the header
-      add_action( '__navbar', 'czr_woocommerce_header_cart', is_rtl() ? 9 : 19 );
-      function czr_woocommerce_header_cart() {
-        if ( 1 != esc_attr( CZR_utils::$inst->czr_opt( 'czr_woocommerce_header_cart' ) ) )
+      add_action( '__navbar', 'czr_fn_woocommerce_header_cart', is_rtl() ? 9 : 19 );
+      function czr_fn_woocommerce_header_cart() {
+        if ( 1 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'czr_fn_woocommerce_header_cart' ) ) )
           return;
 
         $_main_item_class = '';
         $_cart_count      = WC()->cart->get_cart_contents_count();
         //highlight the cart icon when in the Cart or Ceckout page
-        if ( czr_wc_is_checkout_cart() ) {
+        if ( czr_fn_wc_is_checkout_cart() ) {
           $_main_item_class = 'current-menu-item';
         }
 
@@ -1023,7 +1023,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
             </a>
             <?php
             ?>
-            <?php if ( ! czr_wc_is_checkout_cart() ) : //do not display the dropdown in the cart or checkout page ?>
+            <?php if ( ! czr_fn_wc_is_checkout_cart() ) : //do not display the dropdown in the cart or checkout page ?>
               <ul class="dropdown-menu">
                <li>
                  <?php the_widget( 'WC_Widget_Cart', 'title=' ); ?>
@@ -1037,17 +1037,17 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       }
 
       //add woommerce header cart classes to the header (sticky enabled)
-      add_filter( 'tc_header_classes'   , 'czr_woocommerce_set_header_classes');
-      function czr_woocommerce_set_header_classes( $_classes ) {
-        if ( 1 == esc_attr( CZR_utils::$inst->czr_opt( 'czr_woocommerce_header_cart' ) ) )
-          $_classes[]          = ( 1 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_woocommerce_header_cart_sticky' ) ) ) ? 'tc-wccart-off' : 'tc-wccart-on';
+      add_filter( 'tc_header_classes'   , 'czr_fn_woocommerce_set_header_classes');
+      function czr_fn_woocommerce_set_header_classes( $_classes ) {
+        if ( 1 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'czr_fn_woocommerce_header_cart' ) ) )
+          $_classes[]          = ( 1 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_woocommerce_header_cart_sticky' ) ) ) ? 'tc-wccart-off' : 'tc-wccart-on';
         return $_classes;
       }
 
       //add woocommerce header cart CSS
-      add_filter('tc_user_options_style', 'czr_woocommerce_header_cart_css');
-      function czr_woocommerce_header_cart_css( $_css ) {
-        if ( 1 != esc_attr( CZR_utils::$inst->czr_opt( 'czr_woocommerce_header_cart' ) ) )
+      add_filter('tc_user_options_style', 'czr_fn_woocommerce_header_cart_css');
+      function czr_fn_woocommerce_header_cart_css( $_css ) {
+        if ( 1 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'czr_fn_woocommerce_header_cart' ) ) )
           return $_css;
 
         /* The only real decision I took here is the following:
@@ -1055,7 +1055,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         * so that as it grows it won't break on a new line. This is quite an hack to
         * keep the cart space as small as possible (span1) and do not hurt the tagline too much (from span7 to span6). Also nobody will, allegedly, have more than 10^3 products in its cart
         */
-        $_header_layout      = esc_attr( CZR_utils::$inst->czr_opt( 'tc_header_layout') );
+        $_header_layout      = esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_header_layout') );
         $_resp_pos_css       = 'right' == $_header_layout ? 'float: left;' : '';
         $_wc_t_align         = 'left';
 
@@ -1155,11 +1155,11 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    private function czr_set_vc_compat() {
+    private function czr_fn_set_vc_compat() {
       //link smooth scroll: exclude all anchor links inside vc wrappers (.vc_row)
-      add_filter( 'tc_anchor_smoothscroll_excl', 'czr_vc_disable_link_scroll' );
-      function czr_vc_disable_link_scroll( $excl ){
-        if ( false == esc_attr( CZR_utils::$inst->czr_opt('tc_link_scroll') ) ) return $excl;
+      add_filter( 'tc_anchor_smoothscroll_excl', 'czr_fn_vc_disable_link_scroll' );
+      function czr_fn_vc_disable_link_scroll( $excl ){
+        if ( false == esc_attr( CZR_utils::$inst->czr_fn_opt('tc_link_scroll') ) ) return $excl;
 
         if ( ! is_array( $excl ) )
           $excl = array();
@@ -1183,23 +1183,23 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    private function czr_set_disqus_compat() {
-      if ( ! function_exists( 'czr_disqus_comments_enabled' ) ) {
-        function czr_disqus_comments_enabled() {
+    private function czr_fn_set_disqus_compat() {
+      if ( ! function_exists( 'czr_fn_disqus_comments_enabled' ) ) {
+        function czr_fn_disqus_comments_enabled() {
           return function_exists( 'dsq_is_installed' ) && function_exists( 'dsq_can_replace' )
                  && dsq_is_installed() && dsq_can_replace();
         }
       }
       //replace the default comment link anchor with a more descriptive disqus anchor
-      add_filter( 'tc_bubble_comment_anchor', 'czr_disqus_bubble_comment_anchor' );
-      function czr_disqus_bubble_comment_anchor( $anchor ) {
-        return czr_disqus_comments_enabled() ? '#tc-disqus-comments' : $anchor;
+      add_filter( 'tc_bubble_comment_anchor', 'czr_fn_disqus_bubble_comment_anchor' );
+      function czr_fn_disqus_bubble_comment_anchor( $anchor ) {
+        return czr_fn_disqus_comments_enabled() ? '#tc-disqus-comments' : $anchor;
       }
       //wrap disqus comments template in a convenient div
-      add_action( 'tc_before_comments_template' , 'czr_disqus_comments_wrapper' );
-      add_action( 'tc_after_comments_template'  , 'czr_disqus_comments_wrapper' );
-      function czr_disqus_comments_wrapper() {
-        if ( ! czr_disqus_comments_enabled() )
+      add_action( 'tc_before_comments_template' , 'czr_fn_disqus_comments_wrapper' );
+      add_action( 'tc_after_comments_template'  , 'czr_fn_disqus_comments_wrapper' );
+      function czr_fn_disqus_comments_wrapper() {
+        if ( ! czr_fn_disqus_comments_enabled() )
           return;
 
         switch ( current_filter() ) {
@@ -1217,9 +1217,9 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    private function czr_set_uris_compat() {
-      add_filter ( 'tc_img_smart_load_options', 'czr_uris_disable_img_smartload' ) ;
-      function czr_uris_disable_img_smartload( $options ){
+    private function czr_fn_set_uris_compat() {
+      add_filter ( 'tc_img_smart_load_options', 'czr_fn_uris_disable_img_smartload' ) ;
+      function czr_fn_uris_disable_img_smartload( $options ){
         if ( ! is_array( $options ) )
           $options = array();
 
@@ -1245,7 +1245,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     *
     * originally used for woocommerce compatibility
     */
-    function czr_mainwrapper_start() {
+    function czr_fn_mainwrapper_start() {
       ?>
       <div id="main-wrapper" class="<?php echo implode(' ', apply_filters( 'tc_main_wrapper_classes' , array('container') ) ) ?>">
 
@@ -1256,13 +1256,13 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
             <?php do_action( '__before_article_container'); ##hook of left sidebar?>
 
-              <div id="content" class="<?php echo implode(' ', apply_filters( 'tc_article_container_class' , array( CZR_utils::czr_get_layout( CZR_utils::czr_id() , 'class' ) , 'article-container' ) ) ) ?>">
+              <div id="content" class="<?php echo implode(' ', apply_filters( 'tc_article_container_class' , array( CZR_utils::czr_fn_get_layout( CZR_utils::czr_fn_id() , 'class' ) , 'article-container' ) ) ) ?>">
 
                 <?php do_action ('__before_loop');##hooks the header of the list of post : archive, search... ?>
       <?php
     }
 
-    function czr_mainwrapper_end() {
+    function czr_fn_mainwrapper_end() {
       ?>
                 <?php do_action ('__after_loop');##hook of the comments and the posts navigation with priorities 10 and 20 ?>
 
@@ -1291,8 +1291,8 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @param string $plugin Base plugin path from plugins directory.
     * @return bool True, if in the active plugins list. False, not in the list.
     */
-    function czr_is_plugin_active( $plugin ) {
-      return in_array( $plugin, (array) get_option( 'active_plugins', array() ) ) || $this -> czr_is_plugin_active_for_network( $plugin );
+    function czr_fn_is_plugin_active( $plugin ) {
+      return in_array( $plugin, (array) get_option( 'active_plugins', array() ) ) || $this -> czr_fn_is_plugin_active_for_network( $plugin );
     }
 
 
@@ -1306,7 +1306,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @param string $plugin Base plugin path from plugins directory.
     * @return bool True, if active for the network, otherwise false.
     */
-    function czr_is_plugin_active_for_network( $plugin ) {
+    function czr_fn_is_plugin_active_for_network( $plugin ) {
       if ( ! is_multisite() )
         return false;
 
@@ -1317,7 +1317,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       return false;
     }
 
-    public function czr_get_string_options_to_translate() {
+    public function czr_fn_get_string_options_to_translate() {
       $string_options = array(
         'tc_front_slider',
         'tc_posts_slider_button_text',
@@ -1334,7 +1334,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
         $string_options[] = 'tc_featured_page_button_text';
       }
-      return apply_filters( 'czr_get_string_options_to_translate', $string_options );
+      return apply_filters( 'czr_fn_get_string_options_to_translate', $string_options );
     }
   }//end of class
 endif;

--- a/inc/class-fire-plugins_compat.php
+++ b/inc/class-fire-plugins_compat.php
@@ -397,10 +397,10 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         /* Slider of posts */
         if ( function_exists( 'pll_current_language') ) {
         // Filter the posts query for the current language
-          add_filter( 'tc_query_posts_slider_join'      , 'pll_posts_slider_join' );
-          add_filter( 'tc_query_posts_slider_join_where', 'pll_posts_slider_join' );
+          add_filter( 'tc_query_posts_slider_join'      , 'czr_fn_pll_posts_slider_join' );
+          add_filter( 'tc_query_posts_slider_join_where', 'czr_fn_pll_posts_slider_join' );
         }
-        function pll_posts_slider_join( $join ) {
+        function czr_fn_pll_posts_slider_join( $join ) {
           global $wpdb;
           switch ( current_filter() ){
             case 'tc_query_posts_slider_join'        : $join .= " INNER JOIN $wpdb->term_relationships AS pll_tr";
@@ -675,10 +675,10 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         /* Slider of posts */
         if ( defined( 'ICL_LANGUAGE_CODE') ) {
         // Filter the posts query for the current language
-          add_filter( 'tc_query_posts_slider_join'      , 'wpml_posts_slider_join' );
-          add_filter( 'tc_query_posts_slider_join_where', 'wpml_posts_slider_join' );
+          add_filter( 'tc_query_posts_slider_join'      , 'czr_fn_wpml_posts_slider_join' );
+          add_filter( 'tc_query_posts_slider_join_where', 'czr_fn_wpml_posts_slider_join' );
         }
-        function wpml_posts_slider_join( $join ) {
+        function czr_fn_wpml_posts_slider_join( $join ) {
           global $wpdb;
           switch ( current_filter() ){
             case 'tc_query_posts_slider_join'        : $join .= " INNER JOIN {$wpdb->prefix}icl_translations AS wpml_tr";
@@ -1261,7 +1261,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
           if ( method_exists( 'TC_front_fpu', 'tc_set_fp_hook' ) )
             remove_action( 'template_redirect'         , array( TC_front_fpu::$instance , 'tc_set_fp_hook'), 10 );
           if ( method_exists( 'TC_front_fpu', 'tc_set_colors' ) )
-          remove_action( 'wp_head'                   , array( TC_front_fpu::$instance , 'tc_set_colors'), 10 );
+            remove_action( 'wp_head'                   , array( TC_front_fpu::$instance , 'tc_set_colors'), 10 );
           if ( method_exists( 'TC_front_fpu', 'tc_enqueue_plug_resources' ) )
             remove_action( 'wp_enqueue_scripts'        , array( TC_front_fpu::$instance , 'tc_enqueue_plug_resources') );
         }
@@ -1363,7 +1363,6 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         'tc_social_in_sidebar_title',
       );
       if ( ! apply_filters( 'tc_other_plugins_force_fpu_disable', class_exists('TC_fpu')  ) && ! class_exists('TC_fpc') ) {
-        echo "sono qui";
         $fp_areas = CZR_init::$instance -> fp_ids;
         foreach ( $fp_areas as $fp_area )
           $string_options[] = 'tc_featured_text_' . $fp_area;

--- a/inc/class-fire-plugins_compat.php
+++ b/inc/class-fire-plugins_compat.php
@@ -21,8 +21,8 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
       self::$instance =& $this;
       //add various plugins compatibilty (Jetpack, Bbpress, Qtranslate, Woocommerce, The Event Calendar ...)
-      add_action ('after_setup_theme'          , array( $this , 'tc_set_plugins_supported'), 20 );
-      add_action ('after_setup_theme'          , array( $this , 'tc_plugins_compatibility'), 30 );
+      add_action ('after_setup_theme'          , array( $this , 'czr_set_plugins_supported'), 20 );
+      add_action ('after_setup_theme'          , array( $this , 'czr_plugins_compatibility'), 30 );
       // remove qtranslateX theme options filter
       remove_filter('option_tc_theme_options', 'qtranxf_translate_option', 5);
     }//end of constructor
@@ -155,7 +155,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       //Anyway to avoid the 1x1 issue we alter the img attribute (data-recalc-dims) which photon adds to the img tag(php) so
       //the width/height will not be erronously recalculated
       if ( class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'photon' ) )
-        add_filter( 'tc_img_smartloaded', 'tc_jp_smartload_img');
+        add_filter( 'tc_img_smartloaded', 'czr_jp_smartload_img');
       function czr_jp_smartload_img( $img ) {
         return str_replace( 'data-recalc-dims', 'data-tcjp-recalc-dims', $img );
       }
@@ -172,41 +172,41 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     */
     private function czr_set_bbpress_compat() {
       // hide tax archive title
-      add_filter( 'tc_show_tax_archive_title', 'tc_bbpress_disable_tax_archive_title');
+      add_filter( 'tc_show_tax_archive_title', 'czr_bbpress_disable_tax_archive_title');
       function czr_bbpress_disable_tax_archive_title( $bool ){
         return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
       }
 
       //disables thumbnails and excerpt for post lists
-      add_filter( 'tc_show_post_list_thumb', 'tc_bbpress_disable_thumbnail' );
+      add_filter( 'tc_show_post_list_thumb', 'czr_bbpress_disable_thumbnail' );
       function czr_bbpress_disable_thumbnail($bool) {
          return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
       }
-      add_filter( 'tc_show_excerpt', 'tc_bbpress_disable_excerpt' );
+      add_filter( 'czr_show_excerpt', 'czr_bbpress_disable_excerpt' );
       function czr_bbpress_disable_excerpt($bool) {
          return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
       }
 
       //disables Customizr author infos on forums
-      add_filter( 'tc_show_author_metas_in_post', 'tc_bbpress_disable_author_meta' );
+      add_filter( 'tc_show_author_metas_in_post', 'czr_bbpress_disable_author_meta' );
       function czr_bbpress_disable_author_meta($bool) {
         return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
       }
 
       //disables post navigation
-      add_filter( 'tc_show_post_navigation', 'tc_bbpress_disable_post_navigation' );
+      add_filter( 'tc_show_post_navigation', 'czr_bbpress_disable_post_navigation' );
       function czr_bbpress_disable_post_navigation($bool) {
          return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
       }
 
       //disables post metas
-      add_filter( 'tc_show_post_metas', 'tc_bbpress_disable_post_metas', 100);
+      add_filter( 'czr_show_post_metas', 'czr_bbpress_disable_post_metas', 100);
       function czr_bbpress_disable_post_metas($bool) {
          return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
       }
 
       //disable the grid
-      add_filter( 'tc_set_grid_hooks' , 'tc_bbpress_disable_grid', 100 );
+      add_filter( 'czr_set_grid_hooks' , 'czr_bbpress_disable_grid', 100 );
       function czr_bbpress_disable_grid($bool) {
          return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
       }
@@ -219,7 +219,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @since Customizr 3.3+
     */
     private function czr_set_buddypress_compat() {
-      add_filter( 'tc_are_comments_enabled', 'tc_buddypress_disable_comments' );
+      add_filter( 'czr_are_comments_enabled', 'czr_buddypress_disable_comments' );
       function czr_buddypress_disable_comments($bool){
         return ( is_page() && function_exists('is_buddypress') && is_buddypress() ) ? false : $bool;
       }
@@ -234,7 +234,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       //2) a cover image, if already set
       //anyways this page is not a regular "front" page as it pertains more to a "backend" side
       //if we can call it that way.
-      add_action( 'xprofile_screen_change_avatar', 'tc_buddypress_maybe_disable_img_smartload' );
+      add_action( 'xprofile_screen_change_avatar', 'czr_buddypress_maybe_disable_img_smartload' );
       function czr_buddypress_maybe_disable_img_smartload() {
         add_filter( 'tc_opt_tc_img_smart_load', '__return_false' );
       }
@@ -262,49 +262,49 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
       //outputs correct urls for current language : in logo, slider
       foreach ( array( 'tc_slide_link_url', 'tc_logo_link_url') as $filter )
-        add_filter( $filter, 'tc_url_lang' );
+        add_filter( $filter, 'czr_url_lang' );
 
       //outputs the qtranslate translation for slider
       foreach ( array( 'tc_slide_title', 'tc_slide_text', 'tc_slide_button_text', 'tc_slide_background_alt' ) as $filter )
-        add_filter( $filter, 'tc_apply_qtranslate' );
+        add_filter( $filter, 'czr_apply_qtranslate' );
       //sets no character limit for slider (title, lead text and button title) => allow users to use qtranslate tags for as many languages they wants ([:en]English text[:de]German text...and so on)
       foreach ( array( 'tc_slide_title_length', 'tc_slide_text_length', 'tc_slide_button_length' ) as $filter )
-        add_filter( $filter  , 'tc_remove_char_limit');
+        add_filter( $filter  , 'czr_remove_char_limit');
 
       //outputs the qtranslate translation for archive titles;
       $tc_archive_titles = array( 'tag_archive', 'category_archive', 'author_archive', 'search_results');
       foreach ( $tc_archive_titles as $title )
-        add_filter("tc_{$title}_title", 'tc_apply_qtranslate' , 20);
+        add_filter("tc_{$title}_title", 'czr_apply_qtranslate' , 20);
 
       // QtranslateX for FP when no FPC or FPU running
       if ( ! class_exists('TC_fpu') && ! class_exists('TC_fpc') ) {
         //outputs correct urls for current language : fp
-        add_filter( 'tc_fp_link_url' , 'tc_url_lang');
+        add_filter( 'tc_fp_link_url' , 'czr_url_lang');
         //outputs the qtranslate translation for featured pages
-        add_filter( 'tc_fp_text', 'tc_apply_qtranslate' );
-        add_filter( 'tc_fp_button_text', 'tc_apply_qtranslate' );
+        add_filter( 'tc_fp_text', 'czr_apply_qtranslate' );
+        add_filter( 'tc_fp_button_text', 'czr_apply_qtranslate' );
 
         /* The following is pretty useless at the momment since we should inhibit preview js code */
         //modify the customizer transport from post message to null for some options
-        add_filter( 'tc_featured_page_button_text_customizer_set' , 'tc_change_transport', 20, 2);
-        add_filter( 'tc_featured_text_one_customizer_set' , 'tc_change_transport', 20, 2);
-        add_filter( 'tc_featured_text_two_customizer_set' , 'tc_change_transport', 20, 2);
-        add_filter( 'tc_featured_text_three_customizer_set', 'tc_change_transport', 20, 2);
+        add_filter( 'tc_featured_page_button_text_customizer_set' , 'czr_change_transport', 20, 2);
+        add_filter( 'tc_featured_text_one_customizer_set' , 'czr_change_transport', 20, 2);
+        add_filter( 'tc_featured_text_two_customizer_set' , 'czr_change_transport', 20, 2);
+        add_filter( 'tc_featured_text_three_customizer_set', 'czr_change_transport', 20, 2);
       }
 
       //posts slider (this filter is not fired in admin )
-      add_filter('tc_posts_slider_pre_model', 'tc_posts_slider_qtranslate');
+      add_filter('tc_posts_slider_pre_model', 'czr_posts_slider_qtranslate');
       function czr_posts_slider_qtranslate( $pre_slides ){
         if ( empty($pre_slides) )
           return $pre_slides;
 
         // remove useles q-translation of the slider view
         foreach ( array( 'tc_slide_title', 'tc_slide_text', 'tc_slide_button_text', 'tc_slide_background_alt' ) as $filter )
-          remove_filter( $filter, 'tc_apply_qtranslate' );
+          remove_filter( $filter, 'czr_apply_qtranslate' );
 
         // allow q-translation pre trim/sanitize
         foreach ( array( 'tc_posts_slider_button_text_pre_trim', 'tc_post_title_pre_trim', 'tc_post_excerpt_pre_sanitize', 'tc_posts_slide_background' ) as $filter )
-          add_filter( $filter, 'tc_apply_qtranslate' );
+          add_filter( $filter, 'czr_apply_qtranslate' );
 
         //translate button text
         $pre_slides['common']['button_text'] = $pre_slides['common']['button_text'] ? CZR_slider::$instance -> czr_get_post_slide_button_text( $pre_slides['common']['button_text'] ) : '';
@@ -337,7 +337,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
       // If Polylang is active, hook function on the admin pages
       if ( function_exists( 'pll_register_string' ) )
-        add_action( 'admin_init', 'tc_pll_strings_setup' );
+        add_action( 'admin_init', 'czr_pll_strings_setup' );
 
       function czr_pll_strings_setup() {
         // grab theme options
@@ -401,7 +401,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         }
 
         //Translate category ids for the filtered posts in home/blog
-        add_filter('tc_opt_tc_blog_restrict_by_cat', 'tc_pll_translate_tax');
+        add_filter('tc_opt_tc_blog_restrict_by_cat', 'czr_pll_translate_tax');
         /*end tax filtering*/
 
         /* Slider of posts */
@@ -428,7 +428,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
         //Featured pages ids "translation"
         // Substitute any page id with the equivalent page in current language (if found)
-        add_filter( 'tc_fp_id', 'tc_pll_page_id', 20 );
+        add_filter( 'tc_fp_id', 'czr_pll_page_id', 20 );
         function czr_pll_page_id( $fp_page_id ) {
           return is_int( pll_get_post( $fp_page_id ) ) ? pll_get_post( $fp_page_id ) : $fp_page_id;
         }
@@ -462,7 +462,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       // 1) We cannot use translated string for the "name" param (which actually they say should be in a readable format ..)
       // 2) We need a way to use the same "name" both when registering the string to translate and retrieving its translations
       function czr_wpml_get_options_names_config() {
-        $_wp_cache_key     = 'tc_wpml_get_options_names_config';
+        $_wp_cache_key     = 'czr_wpml_get_options_names_config';
         $option_name_assoc = wp_cache_get( $_wp_cache_key );
 
         if ( false === $option_name_assoc ) {
@@ -495,7 +495,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
           //cache this 'cause is used several times in filter callbacks
           wp_cache_set( $_wp_cache_key, $option_name_assoc );
         }
-        return apply_filters( 'tc_wpml_get_options_names_config', $option_name_assoc );
+        return apply_filters( 'czr_wpml_get_options_names_config', $option_name_assoc );
       }
 
       //Wras wpml_object_id in a more convenient function which recursevely translates array of values
@@ -504,7 +504,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         if ( empty( $object_id ) )
           return $object_id;
         if ( is_array( $object_id ) )
-          return array_map( 'tc_wpml_object_id', $object_id, array_fill( 0, sizeof( $object_id ), $type ) );
+          return array_map( 'czr_wpml_object_id', $object_id, array_fill( 0, sizeof( $object_id ), $type ) );
         return apply_filters( 'wpml_object_id', $object_id, $type, true );
       }
 
@@ -569,7 +569,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         return $options;
       }
 
-      add_action( 'admin_init', 'tc_wpml_admin_setup' );
+      add_action( 'admin_init', 'czr_wpml_admin_setup' );
 
       function czr_wpml_admin_setup() {
         // If wpml-string-translation is active perform admin pages translation
@@ -596,7 +596,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         //In Italian we do not have cat C so there will be displayed transposed cats A and B
         //if we change this option in the Customizer with lang IT removing B, e.g., when we switch to EN we'll have that the array of cats contains just A, as it as been overwritten with the new setting
         if ( CZR___::$instance -> czr_is_customize_left_panel() )
-          add_filter( 'option_tc_theme_options', 'tc_wpml_customizer_options_transpose' );
+          add_filter( 'option_tc_theme_options', 'czr_wpml_customizer_options_transpose' );
         function czr_wpml_customizer_options_transpose( $options ) {
           $options_to_transpose = apply_filters ( 'tc_wpml_customizer_translate_options', array(
             'page'     => ( ! class_exists('TC_fpu') && ! class_exists('TC_fpc') ) ? array( 'tc_featured_page_one', 'tc_featured_page_two', 'tc_featured_page_three' ) : array(),
@@ -653,7 +653,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
           //strings translation
           foreach ( $tc_wpml_options as $tc_wpml_option )
-            add_filter("tc_opt_$tc_wpml_option", 'tc_wpml_t_opt', 20 );
+            add_filter("tc_opt_$tc_wpml_option", 'czr_wpml_t_opt', 20 );
 
           //translates sliders? credits @Srdjan
           add_filter( 'tc_opt_tc_sliders', 'sliders_filter', 99 );
@@ -661,7 +661,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         }
         /*A) FP*/
         // Featured pages ids "translation"
-        add_filter( 'tc_fp_id', 'tc_wpml_page_id', 20 );
+        add_filter( 'tc_fp_id', 'czr_wpml_page_id', 20 );
         function czr_wpml_page_id( $fp_page_id ) {
           return czr_wpml_object_id( $fp_page_id, 'page');
         }
@@ -679,7 +679,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
           return array_unique( czr_wpml_object_id( $cat_ids, 'category' ) );
         }
         //Translate category ids for the filtered posts in home/blog
-        add_filter('tc_opt_tc_blog_restrict_by_cat', 'tc_wpml_translate_cat');
+        add_filter('tc_opt_tc_blog_restrict_by_cat', 'czr_wpml_translate_cat');
         /*end tax filtering*/
 
         /* Slider of posts */
@@ -735,20 +735,20 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         }
       }
       // hide tax archive title
-      add_filter( 'tc_show_tax_archive_title', 'tc_tec_disable_tax_archive_title');
+      add_filter( 'tc_show_tax_archive_title', 'czr_tec_disable_tax_archive_title');
       function czr_tec_disable_tax_archive_title( $bool ) {
         return czr_is_tec_events_list() ? false : $bool;
       }
 
       // Events archive is displayed, wrongly, we our post lists classes, we have to prevent this
-      add_filter( 'tc_post_list_controller', 'tc_tec_disable_post_list');
-      add_filter( 'tc_is_grid_enabled', 'tc_tec_disable_post_list');
+      add_filter( 'czr_post_list_controller', 'czr_tec_disable_post_list');
+      add_filter( 'czr_is_grid_enabled', 'czr_tec_disable_post_list');
       function czr_tec_disable_post_list( $bool ) {
         return czr_is_tec_events_list() ? false : $bool;
       }
 
       // Now we have to display a post or page content
-      add_filter( 'tc_show_single_post_content', 'tc_tec_show_content' );
+      add_filter( 'tc_show_single_post_content', 'czr_tec_show_content' );
       function czr_tec_show_content( $bool ) {
         //2 cases:
         //1 - in events lists - we force showing single post content
@@ -764,24 +764,24 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       // The Events Calendar adds a filter on post_type_archive_title with __return_false callback
       // for their own reasons. This impacts on our breadcrumb 'cause we use the function post_type_archive_title() to build up the trail arg in posty_type_archives contexts.
       // What we do here is unhooking their callback before the breadcrumb is built and re-hook it after it has been displayed
-      add_action( 'wp_head', 'tc_tec_allow_display_breadcrumb_in_month_view');
+      add_action( 'wp_head', 'czr_tec_allow_display_breadcrumb_in_month_view');
       function czr_tec_allow_display_breadcrumb_in_month_view() {
         if ( ! ( czr_is_tec_events_list() && function_exists( 'tribe_is_month' ) && tribe_is_month() ) )
           return;
 
-        add_filter( 'tc_breadcrumb_trail_args', 'tc_tec_unhook_empty_post_type_archive_title');
+        add_filter( 'tc_breadcrumb_trail_args', 'czr_tec_unhook_empty_post_type_archive_title');
         function czr_tec_unhook_empty_post_type_archive_title( $args = null ) {
           remove_filter( 'post_type_archive_title', '__return_false', 10 );
           return $args;
         }
-        add_filter( 'tc_breadcrumb_trail_display', 'tc_tec_rehook_empty_post_type_archive_title', PHP_INT_MAX );
+        add_filter( 'tc_breadcrumb_trail_display', 'czr_tec_rehook_empty_post_type_archive_title', PHP_INT_MAX );
         function czr_tec_rehook_empty_post_type_archive_title( $breadcrumb = null ) {
           add_filter( 'post_type_archive_title', '__return_false', 10 );
           return $breadcrumb;
         }
       }
       //disables post navigation in single tec pages
-      add_filter( 'tc_show_post_navigation', 'tc_tec_disable_post_navigation' );
+      add_filter( 'tc_show_post_navigation', 'czr_tec_disable_post_navigation' );
       function czr_tec_disable_post_navigation($bool) {
         return ( czr_is_tec_single_event() ) ? false : $bool;
       }
@@ -796,7 +796,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @since Customizr 3.3+
     */
     private function czr_set_optimizepress_compat() {
-      add_action('wp_print_scripts', 'tc_op_dequeue_fancybox_js');
+      add_action('wp_print_scripts', 'czr_op_dequeue_fancybox_js');
       function czr_op_dequeue_fancybox_js(){
         if ( function_exists('is_le_page') ){
           /* Op Back End: Dequeue tc-scripts */
@@ -813,7 +813,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       }
 
       /* Remove fancybox loading icon*/
-      add_action('wp_footer','tc_op_remove_fancyboxloading');
+      add_action('wp_footer','czr_op_remove_fancyboxloading');
       function czr_op_remove_fancyboxloading(){
         echo "<script>
                 if (typeof(opjq) !== 'undefined') {
@@ -839,8 +839,8 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       remove_action( 'sensei_before_main_content', array( $woothemes_sensei->frontend, 'sensei_output_content_wrapper' ), 10 );
       remove_action( 'sensei_after_main_content', array( $woothemes_sensei->frontend, 'sensei_output_content_wrapper_end' ), 10 );
 
-      add_action('sensei_before_main_content', 'tc_sensei_wrappers', 10);
-      add_action('sensei_after_main_content', 'tc_sensei_wrappers', 10);
+      add_action('sensei_before_main_content', 'czr_sensei_wrappers', 10);
+      add_action('sensei_after_main_content', 'czr_sensei_wrappers', 10);
 
 
       function czr_sensei_wrappers() {
@@ -854,18 +854,18 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       }//end of nested function
 
       // hide tax archive title
-      add_filter( 'tc_show_tax_archive_title', 'tc_sensei_disable_tax_archive_title');
+      add_filter( 'tc_show_tax_archive_title', 'czr_sensei_disable_tax_archive_title');
       function czr_sensei_disable_tax_archive_title( $bool ){
         return ( function_exists('is_sensei') && is_sensei() ) ? false : $bool;
       }
 
       //disables post navigation
-      add_filter( 'tc_show_post_navigation', 'tc_sensei_disable_post_navigation' );
+      add_filter( 'tc_show_post_navigation', 'czr_sensei_disable_post_navigation' );
       function czr_sensei_disable_post_navigation($bool) {
         return ( function_exists('is_sensei') && is_sensei() ) ? false : $bool;
       }
       //removes post comment action on after_loop hook
-      add_filter( 'tc_are_comments_enabled', 'tc_sensei_disable_comments' );
+      add_filter( 'czr_are_comments_enabled', 'czr_sensei_disable_comments' );
       function czr_sensei_disable_comments($bool) {
         return ( function_exists('is_sensei') && is_sensei() ) ? false : $bool;
       }
@@ -884,8 +884,8 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       //unkooks the default woocommerce wrappersv and add customizr's content wrapper and action hooks
       remove_action( 'woocommerce_before_main_content', 'woocommerce_output_content_wrapper', 10);
       remove_action( 'woocommerce_after_main_content', 'woocommerce_output_content_wrapper_end', 10);
-      add_action('woocommerce_before_main_content', 'tc_woocommerce_wrappers', 10);
-      add_action('woocommerce_after_main_content', 'tc_woocommerce_wrappers', 10);
+      add_action('woocommerce_before_main_content', 'czr_woocommerce_wrappers', 10);
+      add_action('woocommerce_after_main_content', 'czr_woocommerce_wrappers', 10);
 
       //disable WooCommerce default breadcrumb
       if ( apply_filters( 'tc_disable_woocommerce_breadcrumb', true ) )
@@ -906,7 +906,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       }
       // use Customizr title
       // initially used to display the edit button
-      add_filter( 'the_title', 'tc_woocommerce_the_title' );
+      add_filter( 'the_title', 'czr_woocommerce_the_title' );
       function czr_woocommerce_the_title( $_title ){
         if ( function_exists('is_woocommerce') && is_woocommerce() && ! is_page() )
             return apply_filters( 'tc_title_text', $_title );
@@ -914,18 +914,18 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       }
 
       // hide tax archive title
-      add_filter( 'tc_show_tax_archive_title', 'tc_woocommerce_disable_tax_archive_title');
+      add_filter( 'tc_show_tax_archive_title', 'czr_woocommerce_disable_tax_archive_title');
       function czr_woocommerce_disable_tax_archive_title( $bool ){
         return ( function_exists('is_woocommerce') && is_woocommerce() ) ? false : $bool;
       }
 
       //allow slider in the woocommerce shop page
-      add_filter('tc_show_slider', 'tc_woocommerce_enable_shop_slider');
+      add_filter('tc_show_slider', 'czr_woocommerce_enable_shop_slider');
       function czr_woocommerce_enable_shop_slider( $bool ){
         return ( function_exists('is_woocommerce') && is_woocommerce() && function_exists('is_shop') && is_shop() ) ? true : $bool;
       }
       //to allow the slider in the woocommerce shop page we need the shop page id
-      add_filter('tc_slider_get_real_id', 'tc_woocommerce_shop_page_id');
+      add_filter('tc_slider_get_real_id', 'czr_woocommerce_shop_page_id');
       function czr_woocommerce_shop_page_id( $id ){
         return ( function_exists('is_woocommerce') && is_woocommerce() && function_exists('is_shop') && is_shop() && function_exists('wc_get_page_id') ) ? wc_get_page_id('shop') : $id;
       }
@@ -937,20 +937,20 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
 
       //disables post navigation
-      add_filter( 'tc_show_post_navigation', 'tc_woocommerce_disable_post_navigation' );
+      add_filter( 'tc_show_post_navigation', 'czr_woocommerce_disable_post_navigation' );
       function czr_woocommerce_disable_post_navigation($bool) {
          return ( function_exists('is_woocommerce') && is_woocommerce() ) ? false : $bool;
       }
 
 
       //removes post comment action on after_loop hook
-      add_filter( 'tc_are_comments_enabled', 'tc_woocommerce_disable_comments' );
+      add_filter( 'czr_are_comments_enabled', 'czr_woocommerce_disable_comments' );
       function czr_woocommerce_disable_comments($bool) {
          return ( function_exists('is_woocommerce') && is_woocommerce() ) ? false : $bool;
       }
 
       //link smooth scroll: exclude woocommerce tabs
-      add_filter( 'tc_anchor_smoothscroll_excl', 'tc_woocommerce_disable_link_scroll' );
+      add_filter( 'tc_anchor_smoothscroll_excl', 'czr_woocommerce_disable_link_scroll' );
       function czr_woocommerce_disable_link_scroll( $excl ){
         if ( false == esc_attr( CZR_utils::$inst->czr_opt('tc_link_scroll') ) ) return $excl;
 
@@ -971,7 +971,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
 
       //changes customizr meta boxes priority (slider and layout not on top) if displaying woocommerce products in admin
-      add_filter( 'tc_post_meta_boxes_priority', 'tc_woocommerce_change_meta_boxes_priority' , 2 , 10 );
+      add_filter( 'tc_post_meta_boxes_priority', 'czr_woocommerce_change_meta_boxes_priority' , 2 , 10 );
       function czr_woocommerce_change_meta_boxes_priority($priority , $screen) {
          return ( 'product' == $screen ) ? 'default' : $priority ;
       }
@@ -979,22 +979,22 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
       // Allow HEADER CART OPTIONS in the customizer
       // Returns a callback function needed by 'active_callback' to enable the options in the customizer
-      add_filter( 'tc_woocommerce_options_enabled', 'tc_woocommerce_options_enabled_cb' );
+      add_filter( 'tc_woocommerce_options_enabled', 'czr_woocommerce_options_enabled_cb' );
       function czr_woocommerce_options_enabled_cb() {
         return '__return_true';
       }
 
       /* rendering the cart icon in the header */
       //narrow the tagline
-      add_filter( 'tc_tagline_class', 'tc_woocommerce_force_tagline_width', 100 );
+      add_filter( 'tc_tagline_class', 'czr_woocommerce_force_tagline_width', 100 );
       function czr_woocommerce_force_tagline_width( $_class ) {
-        return 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_woocommerce_header_cart' ) ) ? 'span6' : $_class ;
+        return 1 == esc_attr( CZR_utils::$inst->czr_opt( 'czr_woocommerce_header_cart' ) ) ? 'span6' : $_class ;
       }
 
       // Ensure cart contents update when products are added to the cart via AJAX (place the following in functions.php)
-      add_filter( 'woocommerce_add_to_cart_fragments', 'tc_woocommerce_add_to_cart_fragment' );
+      add_filter( 'woocommerce_add_to_cart_fragments', 'czr_woocommerce_add_to_cart_fragment' );
       function czr_woocommerce_add_to_cart_fragment( $fragments ) {
-        if ( 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_woocommerce_header_cart' ) ) ) {
+        if ( 1 == esc_attr( CZR_utils::$inst->czr_opt( 'czr_woocommerce_header_cart' ) ) ) {
           $_cart_count = WC()->cart->get_cart_contents_count();
           $fragments['span.tc-wc-count'] = sprintf( '<span class="count btn-link tc-wc-count">%1$s</span>', $_cart_count ? $_cart_count : '' );
         }
@@ -1002,9 +1002,9 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       }
 
       //print the cart menu in the header
-      add_action( '__navbar', 'tc_woocommerce_header_cart', is_rtl() ? 9 : 19 );
+      add_action( '__navbar', 'czr_woocommerce_header_cart', is_rtl() ? 9 : 19 );
       function czr_woocommerce_header_cart() {
-        if ( 1 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_woocommerce_header_cart' ) ) )
+        if ( 1 != esc_attr( CZR_utils::$inst->czr_opt( 'czr_woocommerce_header_cart' ) ) )
           return;
 
         $_main_item_class = '';
@@ -1037,17 +1037,17 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       }
 
       //add woommerce header cart classes to the header (sticky enabled)
-      add_filter( 'tc_header_classes'   , 'tc_woocommerce_set_header_classes');
+      add_filter( 'tc_header_classes'   , 'czr_woocommerce_set_header_classes');
       function czr_woocommerce_set_header_classes( $_classes ) {
-        if ( 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_woocommerce_header_cart' ) ) )
+        if ( 1 == esc_attr( CZR_utils::$inst->czr_opt( 'czr_woocommerce_header_cart' ) ) )
           $_classes[]          = ( 1 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_woocommerce_header_cart_sticky' ) ) ) ? 'tc-wccart-off' : 'tc-wccart-on';
         return $_classes;
       }
 
       //add woocommerce header cart CSS
-      add_filter('tc_user_options_style', 'tc_woocommerce_header_cart_css');
+      add_filter('tc_user_options_style', 'czr_woocommerce_header_cart_css');
       function czr_woocommerce_header_cart_css( $_css ) {
-        if ( 1 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_woocommerce_header_cart' ) ) )
+        if ( 1 != esc_attr( CZR_utils::$inst->czr_opt( 'czr_woocommerce_header_cart' ) ) )
           return $_css;
 
         /* The only real decision I took here is the following:
@@ -1157,7 +1157,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     */
     private function czr_set_vc_compat() {
       //link smooth scroll: exclude all anchor links inside vc wrappers (.vc_row)
-      add_filter( 'tc_anchor_smoothscroll_excl', 'tc_vc_disable_link_scroll' );
+      add_filter( 'tc_anchor_smoothscroll_excl', 'czr_vc_disable_link_scroll' );
       function czr_vc_disable_link_scroll( $excl ){
         if ( false == esc_attr( CZR_utils::$inst->czr_opt('tc_link_scroll') ) ) return $excl;
 
@@ -1191,13 +1191,13 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         }
       }
       //replace the default comment link anchor with a more descriptive disqus anchor
-      add_filter( 'tc_bubble_comment_anchor', 'tc_disqus_bubble_comment_anchor' );
+      add_filter( 'tc_bubble_comment_anchor', 'czr_disqus_bubble_comment_anchor' );
       function czr_disqus_bubble_comment_anchor( $anchor ) {
         return czr_disqus_comments_enabled() ? '#tc-disqus-comments' : $anchor;
       }
       //wrap disqus comments template in a convenient div
-      add_action( 'tc_before_comments_template' , 'tc_disqus_comments_wrapper' );
-      add_action( 'tc_after_comments_template'  , 'tc_disqus_comments_wrapper' );
+      add_action( 'tc_before_comments_template' , 'czr_disqus_comments_wrapper' );
+      add_action( 'tc_after_comments_template'  , 'czr_disqus_comments_wrapper' );
       function czr_disqus_comments_wrapper() {
         if ( ! czr_disqus_comments_enabled() )
           return;
@@ -1218,7 +1218,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @since Customizr 3.4+
     */
     private function czr_set_uris_compat() {
-      add_filter ( 'tc_img_smart_load_options', 'tc_uris_disable_img_smartload' ) ;
+      add_filter ( 'tc_img_smart_load_options', 'czr_uris_disable_img_smartload' ) ;
       function czr_uris_disable_img_smartload( $options ){
         if ( ! is_array( $options ) )
           $options = array();
@@ -1334,7 +1334,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
         $string_options[] = 'tc_featured_page_button_text';
       }
-      return apply_filters( 'tc_get_string_options_to_translate', $string_options );
+      return apply_filters( 'czr_get_string_options_to_translate', $string_options );
     }
   }//end of class
 endif;

--- a/inc/class-fire-plugins_compat.php
+++ b/inc/class-fire-plugins_compat.php
@@ -65,67 +65,67 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     function czr_plugins_compatibility() {
       /* JETPACK */
       //adds compatibilty with the jetpack image carousel and photon
-      if ( current_theme_supports( 'jetpack' ) && $this -> tc_is_plugin_active('jetpack/jetpack.php') )
-        $this -> tc_set_jetpack_compat();
+      if ( current_theme_supports( 'jetpack' ) && $this -> czr_is_plugin_active('jetpack/jetpack.php') )
+        $this -> czr_set_jetpack_compat();
 
       /* BBPRESS */
       //if bbpress is installed and activated, we can check the existence of the contextual boolean function is_bbpress() to execute some code
-      if ( current_theme_supports( 'bbpress' ) && $this -> tc_is_plugin_active('bbpress/bbpress.php') )
-        $this -> tc_set_bbpress_compat();
+      if ( current_theme_supports( 'bbpress' ) && $this -> czr_is_plugin_active('bbpress/bbpress.php') )
+        $this -> czr_set_bbpress_compat();
 
       /* BUDDYPRESS */
       //if buddypress is installed and activated, we can check the existence of the contextual boolean function is_buddypress() to execute some code
       // we have to use buddy-press instead of buddypress as string for theme support as buddypress makes some checks on current_theme_supports('buddypress') which result in not using its templates
-      if ( current_theme_supports( 'buddy-press' ) && $this -> tc_is_plugin_active('buddypress/bp-loader.php') )
-        $this -> tc_set_buddypress_compat();
+      if ( current_theme_supports( 'buddy-press' ) && $this -> czr_is_plugin_active('buddypress/bp-loader.php') )
+        $this -> czr_set_buddypress_compat();
 
       /*
       * QTranslatex
       * Credits : @acub, http://websiter.ro
       */
-      if ( current_theme_supports( 'qtranslate-x' ) && $this -> tc_is_plugin_active('qtranslate-x/qtranslate.php') )
-        $this -> tc_set_qtranslatex_compat();
+      if ( current_theme_supports( 'qtranslate-x' ) && $this -> czr_is_plugin_active('qtranslate-x/qtranslate.php') )
+        $this -> czr_set_qtranslatex_compat();
 
       /*
       * Polylang
       * Credits : Rocco Aliberti
       */
-      if ( current_theme_supports( 'polylang' ) && $this -> tc_is_plugin_active('polylang/polylang.php') )
-        $this -> tc_set_polylang_compat();
+      if ( current_theme_supports( 'polylang' ) && $this -> czr_is_plugin_active('polylang/polylang.php') )
+        $this -> czr_set_polylang_compat();
 
       /*
       * WPML
       */
-      if ( current_theme_supports( 'wpml' ) && $this -> tc_is_plugin_active('sitepress-multilingual-cms/sitepress.php') )
-        $this -> tc_set_wpml_compat();
+      if ( current_theme_supports( 'wpml' ) && $this -> czr_is_plugin_active('sitepress-multilingual-cms/sitepress.php') )
+        $this -> czr_set_wpml_compat();
 
       /* The Events Calendar */
-      if ( current_theme_supports( 'the-events-calendar' ) && $this -> tc_is_plugin_active('the-events-calendar/the-events-calendar.php') )
-        $this -> tc_set_the_events_calendar_compat();
+      if ( current_theme_supports( 'the-events-calendar' ) && $this -> czr_is_plugin_active('the-events-calendar/the-events-calendar.php') )
+        $this -> czr_set_the_events_calendar_compat();
 
       /* Optimize Press */
-      if ( current_theme_supports( 'optimize-press' ) && $this -> tc_is_plugin_active('optimizePressPlugin/optimizepress.php') )
-        $this -> tc_set_optimizepress_compat();
+      if ( current_theme_supports( 'optimize-press' ) && $this -> czr_is_plugin_active('optimizePressPlugin/optimizepress.php') )
+        $this -> czr_set_optimizepress_compat();
 
       /* Woocommerce */
-      if ( current_theme_supports( 'woocommerce' ) && $this -> tc_is_plugin_active('woocommerce/woocommerce.php') )
-        $this -> tc_set_woocomerce_compat();
+      if ( current_theme_supports( 'woocommerce' ) && $this -> czr_is_plugin_active('woocommerce/woocommerce.php') )
+        $this -> czr_set_woocomerce_compat();
 
       /* Sensei woocommerce addon */
-      if ( current_theme_supports( 'sensei') && $this -> tc_is_plugin_active('woothemes-sensei/woothemes-sensei.php') )
-        $this -> tc_set_sensei_compat();
+      if ( current_theme_supports( 'sensei') && $this -> czr_is_plugin_active('woothemes-sensei/woothemes-sensei.php') )
+        $this -> czr_set_sensei_compat();
 
       /* Visual Composer */
-      if ( current_theme_supports( 'visual-composer') && $this -> tc_is_plugin_active('js_composer/js_composer.php') )
-        $this -> tc_set_vc_compat();
+      if ( current_theme_supports( 'visual-composer') && $this -> czr_is_plugin_active('js_composer/js_composer.php') )
+        $this -> czr_set_vc_compat();
 
       /* Disqus Comment System */
-      if ( current_theme_supports( 'disqus') && $this -> tc_is_plugin_active('disqus-comment-system/disqus.php') )
-        $this -> tc_set_disqus_compat();
+      if ( current_theme_supports( 'disqus') && $this -> czr_is_plugin_active('disqus-comment-system/disqus.php') )
+        $this -> czr_set_disqus_compat();
 
       /* Ultimate Responsive Image Slider  */
-      if ( current_theme_supports( 'uris' ) && $this -> tc_is_plugin_active('ultimate-responsive-image-slider/ultimate-responsive-image-slider.php') )
-        $this -> tc_set_uris_compat();
+      if ( current_theme_supports( 'uris' ) && $this -> czr_is_plugin_active('ultimate-responsive-image-slider/ultimate-responsive-image-slider.php') )
+        $this -> czr_set_uris_compat();
     }//end of plugin compatibility function
 
 
@@ -307,7 +307,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
           add_filter( $filter, 'tc_apply_qtranslate' );
 
         //translate button text
-        $pre_slides['common']['button_text'] = $pre_slides['common']['button_text'] ? CZR_slider::$instance -> tc_get_post_slide_button_text( $pre_slides['common']['button_text'] ) : '';
+        $pre_slides['common']['button_text'] = $pre_slides['common']['button_text'] ? CZR_slider::$instance -> czr_get_post_slide_button_text( $pre_slides['common']['button_text'] ) : '';
 
         //translate title and excerpt if needed
         $_posts = &$pre_slides['posts'];
@@ -317,8 +317,8 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
           $_p = get_post( $ID );
           if ( ! $_p ) continue;
 
-          $_post['title'] = $_post['title'] ? CZR_slider::$instance -> tc_get_post_slide_title($_p, $ID) : '';
-          $_post['text']  = $_post['text'] ? CZR_slider::$instance -> tc_get_post_slide_excerpt($_p, $ID) : '';
+          $_post['title'] = $_post['title'] ? CZR_slider::$instance -> czr_get_post_slide_title($_p, $ID) : '';
+          $_post['text']  = $_post['text'] ? CZR_slider::$instance -> czr_get_post_slide_excerpt($_p, $ID) : '';
         }
         return $pre_slides;
       }
@@ -341,15 +341,15 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
       function czr_pll_strings_setup() {
         // grab theme options
-        $tc_options = tc__f('__options');
+        $tc_options = czr__f('__options');
         // grab settings map, useful for some options labels
-        $tc_settings_map = CZR_utils_settings_map::$instance -> tc_get_customizer_map( $get_default = true );
+        $tc_settings_map = CZR_utils_settings_map::$instance -> czr_get_customizer_map( $get_default = true );
         $tc_controls_map = $tc_settings_map['add_setting_control'];
         // set $polylang_group;
         $polylang_group = 'customizr-pro' == CZR___::$theme_name ? 'Customizr-Pro' : 'Customizr';
 
         //get options to translate
-        $tc_translatable_raw_options = CZR_plugins_compat::$instance -> tc_get_string_options_to_translate();
+        $tc_translatable_raw_options = CZR_plugins_compat::$instance -> czr_get_string_options_to_translate();
         $tc_pll_options              = array();
 
         //build array if option => array( label (gettext-ed), option )
@@ -379,7 +379,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       if ( function_exists( 'pll_get_post' ) && function_exists( 'pll__' ) && ! is_admin() ) {
         //strings translation
         //get the options to translate
-        $tc_translatable_options = CZR_plugins_compat::$instance -> tc_get_string_options_to_translate();
+        $tc_translatable_options = CZR_plugins_compat::$instance -> czr_get_string_options_to_translate();
         //translate
         foreach ( $tc_translatable_options as $tc_translatable_option )
           add_filter("tc_opt_$tc_translatable_option", 'pll__');
@@ -466,7 +466,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         $option_name_assoc = wp_cache_get( $_wp_cache_key );
 
         if ( false === $option_name_assoc ) {
-          $options_to_translate = CZR_plugins_compat::$instance -> tc_get_string_options_to_translate();
+          $options_to_translate = CZR_plugins_compat::$instance -> czr_get_string_options_to_translate();
 
           $option_name_assoc = apply_filters( 'tc_wpml_options_names_config', array(
  //           'tc_front_slider'              => 'Front page slider name', //Handled in a different way by Srdjan
@@ -574,11 +574,11 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       function czr_wpml_admin_setup() {
         // If wpml-string-translation is active perform admin pages translation
         if ( function_exists( 'icl_register_string' ) ) {
-          $tc_wpml_option_name = tc_wpml_get_options_names_config();
+          $tc_wpml_option_name = czr_wpml_get_options_names_config();
           $tc_wpml_options     = array_keys($tc_wpml_option_name);
 
           // grab theme options
-          $tc_options = tc__f('__options');
+          $tc_options = czr__f('__options');
 
           // build array of options to translate
           foreach ( $tc_wpml_options as $tc_wpml_option )
@@ -595,7 +595,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         //In English we have set to filter blog posts for cat A,B and C.
         //In Italian we do not have cat C so there will be displayed transposed cats A and B
         //if we change this option in the Customizer with lang IT removing B, e.g., when we switch to EN we'll have that the array of cats contains just A, as it as been overwritten with the new setting
-        if ( CZR___::$instance -> tc_is_customize_left_panel() )
+        if ( CZR___::$instance -> czr_is_customize_left_panel() )
           add_filter( 'option_tc_theme_options', 'tc_wpml_customizer_options_transpose' );
         function czr_wpml_customizer_options_transpose( $options ) {
           $options_to_transpose = apply_filters ( 'tc_wpml_customizer_translate_options', array(
@@ -606,7 +606,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
           foreach ( $options_to_transpose as $type => $option_to_transpose )
             foreach ( $option_to_transpose as $option )
               if ( isset( $options[$option] ) )
-                $options[$option] = tc_wpml_object_id( $options[$option], $type);
+                $options[$option] = czr_wpml_object_id( $options[$option], $type);
           return $options;
         }
 
@@ -630,26 +630,26 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
           //define our icl_t wrapper for options filtered with tc_opt_{$option}
           if ( ! function_exists( 'czr_wpml_t_opt' ) ) {
             function czr_wpml_t_opt( $string ) {
-              return tc_wpml_t( $string, str_replace('tc_opt_', '', current_filter() ) );
+              return czr_wpml_t( $string, str_replace('tc_opt_', '', current_filter() ) );
             }
           }
           //special function for the post slider button text pre trim filter
           if ( ! function_exists( 'czr_wpml_t_ps_button_text' ) ) {
             function czr_wpml_t_ps_button_text( $string ) {
-              return tc_wpml_t( $string, 'tc_posts_slider_button_text' );
+              return czr_wpml_t( $string, 'tc_posts_slider_button_text' );
             }
           }
           //define our icl_t wrapper
           if ( ! function_exists( 'czr_wpml_t' ) ) {
             function czr_wpml_t( $string, $opt ) {
-              $tc_wpml_options_names = tc_wpml_get_options_names_config();
+              $tc_wpml_options_names = czr_wpml_get_options_names_config();
               return icl_t( TC_WPML_CONTEXT, $tc_wpml_options_names[$opt], $string );
             }
           }
           /*** End TC - WPML bind ***/
 
           //get the options to translate
-          $tc_wpml_options = array_keys( tc_wpml_get_options_names_config() );
+          $tc_wpml_options = array_keys( czr_wpml_get_options_names_config() );
 
           //strings translation
           foreach ( $tc_wpml_options as $tc_wpml_option )
@@ -663,7 +663,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         // Featured pages ids "translation"
         add_filter( 'tc_fp_id', 'tc_wpml_page_id', 20 );
         function czr_wpml_page_id( $fp_page_id ) {
-          return tc_wpml_object_id( $fp_page_id, 'page');
+          return czr_wpml_object_id( $fp_page_id, 'page');
         }
 
         /*B) Tax */
@@ -676,7 +676,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         function czr_wpml_translate_cat( $cat_ids ){
           if ( ! ( is_array( $cat_ids ) && ! empty( $cat_ids ) ) )
             return $cat_ids;
-          return array_unique( tc_wpml_object_id( $cat_ids, 'category' ) );
+          return array_unique( czr_wpml_object_id( $cat_ids, 'category' ) );
         }
         //Translate category ids for the filtered posts in home/blog
         add_filter('tc_opt_tc_blog_restrict_by_cat', 'tc_wpml_translate_cat');
@@ -737,14 +737,14 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       // hide tax archive title
       add_filter( 'tc_show_tax_archive_title', 'tc_tec_disable_tax_archive_title');
       function czr_tec_disable_tax_archive_title( $bool ) {
-        return tc_is_tec_events_list() ? false : $bool;
+        return czr_is_tec_events_list() ? false : $bool;
       }
 
       // Events archive is displayed, wrongly, we our post lists classes, we have to prevent this
       add_filter( 'tc_post_list_controller', 'tc_tec_disable_post_list');
       add_filter( 'tc_is_grid_enabled', 'tc_tec_disable_post_list');
       function czr_tec_disable_post_list( $bool ) {
-        return tc_is_tec_events_list() ? false : $bool;
+        return czr_is_tec_events_list() ? false : $bool;
       }
 
       // Now we have to display a post or page content
@@ -753,9 +753,9 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         //2 cases:
         //1 - in events lists - we force showing single post content
         //2 - in single events we have to prevent showing both page and post content
-        if ( tc_is_tec_events_list() )
+        if ( czr_is_tec_events_list() )
           return true;
-        else if( tc_is_tec_single_event() )
+        else if( czr_is_tec_single_event() )
           return false;
         return $bool;
       }
@@ -766,7 +766,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       // What we do here is unhooking their callback before the breadcrumb is built and re-hook it after it has been displayed
       add_action( 'wp_head', 'tc_tec_allow_display_breadcrumb_in_month_view');
       function czr_tec_allow_display_breadcrumb_in_month_view() {
-        if ( ! ( tc_is_tec_events_list() && function_exists( 'tribe_is_month' ) && tribe_is_month() ) )
+        if ( ! ( czr_is_tec_events_list() && function_exists( 'tribe_is_month' ) && tribe_is_month() ) )
           return;
 
         add_filter( 'tc_breadcrumb_trail_args', 'tc_tec_unhook_empty_post_type_archive_title');
@@ -783,7 +783,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       //disables post navigation in single tec pages
       add_filter( 'tc_show_post_navigation', 'tc_tec_disable_post_navigation' );
       function czr_tec_disable_post_navigation($bool) {
-        return ( tc_is_tec_single_event() ) ? false : $bool;
+        return ( czr_is_tec_single_event() ) ? false : $bool;
       }
     }//end the-events-calendar compat
 
@@ -845,10 +845,10 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
       function czr_sensei_wrappers() {
         switch ( current_filter() ) {
-          case 'sensei_before_main_content': CZR_plugins_compat::$instance -> tc_mainwrapper_start();
+          case 'sensei_before_main_content': CZR_plugins_compat::$instance -> czr_mainwrapper_start();
                                              break;
 
-          case 'sensei_after_main_content' : CZR_plugins_compat::$instance -> tc_mainwrapper_end();
+          case 'sensei_after_main_content' : CZR_plugins_compat::$instance -> czr_mainwrapper_end();
                                              break;
         }//end of switch on hook
       }//end of nested function
@@ -893,10 +893,10 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
       function czr_woocommerce_wrappers() {
         switch ( current_filter() ) {
-          case 'woocommerce_before_main_content': CZR_plugins_compat::$instance -> tc_mainwrapper_start();
+          case 'woocommerce_before_main_content': CZR_plugins_compat::$instance -> czr_mainwrapper_start();
                                                   break;
 
-          case 'woocommerce_after_main_content' : CZR_plugins_compat::$instance -> tc_mainwrapper_end();
+          case 'woocommerce_after_main_content' : CZR_plugins_compat::$instance -> czr_mainwrapper_end();
                                                   break;
         }//end of switch on hook
       }//end of nested function
@@ -952,7 +952,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       //link smooth scroll: exclude woocommerce tabs
       add_filter( 'tc_anchor_smoothscroll_excl', 'tc_woocommerce_disable_link_scroll' );
       function czr_woocommerce_disable_link_scroll( $excl ){
-        if ( false == esc_attr( CZR_utils::$inst->tc_opt('tc_link_scroll') ) ) return $excl;
+        if ( false == esc_attr( CZR_utils::$inst->czr_opt('tc_link_scroll') ) ) return $excl;
 
         if ( function_exists('is_woocommerce') && is_woocommerce() ) {
           if ( ! is_array( $excl ) )
@@ -988,13 +988,13 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       //narrow the tagline
       add_filter( 'tc_tagline_class', 'tc_woocommerce_force_tagline_width', 100 );
       function czr_woocommerce_force_tagline_width( $_class ) {
-        return 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_woocommerce_header_cart' ) ) ? 'span6' : $_class ;
+        return 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_woocommerce_header_cart' ) ) ? 'span6' : $_class ;
       }
 
       // Ensure cart contents update when products are added to the cart via AJAX (place the following in functions.php)
       add_filter( 'woocommerce_add_to_cart_fragments', 'tc_woocommerce_add_to_cart_fragment' );
       function czr_woocommerce_add_to_cart_fragment( $fragments ) {
-        if ( 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_woocommerce_header_cart' ) ) ) {
+        if ( 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_woocommerce_header_cart' ) ) ) {
           $_cart_count = WC()->cart->get_cart_contents_count();
           $fragments['span.tc-wc-count'] = sprintf( '<span class="count btn-link tc-wc-count">%1$s</span>', $_cart_count ? $_cart_count : '' );
         }
@@ -1004,13 +1004,13 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       //print the cart menu in the header
       add_action( '__navbar', 'tc_woocommerce_header_cart', is_rtl() ? 9 : 19 );
       function czr_woocommerce_header_cart() {
-        if ( 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_woocommerce_header_cart' ) ) )
+        if ( 1 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_woocommerce_header_cart' ) ) )
           return;
 
         $_main_item_class = '';
         $_cart_count      = WC()->cart->get_cart_contents_count();
         //highlight the cart icon when in the Cart or Ceckout page
-        if ( tc_wc_is_checkout_cart() ) {
+        if ( czr_wc_is_checkout_cart() ) {
           $_main_item_class = 'current-menu-item';
         }
 
@@ -1023,7 +1023,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
             </a>
             <?php
             ?>
-            <?php if ( ! tc_wc_is_checkout_cart() ) : //do not display the dropdown in the cart or checkout page ?>
+            <?php if ( ! czr_wc_is_checkout_cart() ) : //do not display the dropdown in the cart or checkout page ?>
               <ul class="dropdown-menu">
                <li>
                  <?php the_widget( 'WC_Widget_Cart', 'title=' ); ?>
@@ -1039,15 +1039,15 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       //add woommerce header cart classes to the header (sticky enabled)
       add_filter( 'tc_header_classes'   , 'tc_woocommerce_set_header_classes');
       function czr_woocommerce_set_header_classes( $_classes ) {
-        if ( 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_woocommerce_header_cart' ) ) )
-          $_classes[]          = ( 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_woocommerce_header_cart_sticky' ) ) ) ? 'tc-wccart-off' : 'tc-wccart-on';
+        if ( 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_woocommerce_header_cart' ) ) )
+          $_classes[]          = ( 1 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_woocommerce_header_cart_sticky' ) ) ) ? 'tc-wccart-off' : 'tc-wccart-on';
         return $_classes;
       }
 
       //add woocommerce header cart CSS
       add_filter('tc_user_options_style', 'tc_woocommerce_header_cart_css');
       function czr_woocommerce_header_cart_css( $_css ) {
-        if ( 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_woocommerce_header_cart' ) ) )
+        if ( 1 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_woocommerce_header_cart' ) ) )
           return $_css;
 
         /* The only real decision I took here is the following:
@@ -1055,7 +1055,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         * so that as it grows it won't break on a new line. This is quite an hack to
         * keep the cart space as small as possible (span1) and do not hurt the tagline too much (from span7 to span6). Also nobody will, allegedly, have more than 10^3 products in its cart
         */
-        $_header_layout      = esc_attr( CZR_utils::$inst->tc_opt( 'tc_header_layout') );
+        $_header_layout      = esc_attr( CZR_utils::$inst->czr_opt( 'tc_header_layout') );
         $_resp_pos_css       = 'right' == $_header_layout ? 'float: left;' : '';
         $_wc_t_align         = 'left';
 
@@ -1159,7 +1159,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       //link smooth scroll: exclude all anchor links inside vc wrappers (.vc_row)
       add_filter( 'tc_anchor_smoothscroll_excl', 'tc_vc_disable_link_scroll' );
       function czr_vc_disable_link_scroll( $excl ){
-        if ( false == esc_attr( CZR_utils::$inst->tc_opt('tc_link_scroll') ) ) return $excl;
+        if ( false == esc_attr( CZR_utils::$inst->czr_opt('tc_link_scroll') ) ) return $excl;
 
         if ( ! is_array( $excl ) )
           $excl = array();
@@ -1193,13 +1193,13 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       //replace the default comment link anchor with a more descriptive disqus anchor
       add_filter( 'tc_bubble_comment_anchor', 'tc_disqus_bubble_comment_anchor' );
       function czr_disqus_bubble_comment_anchor( $anchor ) {
-        return tc_disqus_comments_enabled() ? '#tc-disqus-comments' : $anchor;
+        return czr_disqus_comments_enabled() ? '#tc-disqus-comments' : $anchor;
       }
       //wrap disqus comments template in a convenient div
       add_action( 'tc_before_comments_template' , 'tc_disqus_comments_wrapper' );
       add_action( 'tc_after_comments_template'  , 'tc_disqus_comments_wrapper' );
       function czr_disqus_comments_wrapper() {
-        if ( ! tc_disqus_comments_enabled() )
+        if ( ! czr_disqus_comments_enabled() )
           return;
 
         switch ( current_filter() ) {
@@ -1256,7 +1256,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
             <?php do_action( '__before_article_container'); ##hook of left sidebar?>
 
-              <div id="content" class="<?php echo implode(' ', apply_filters( 'tc_article_container_class' , array( CZR_utils::tc_get_layout( CZR_utils::tc_id() , 'class' ) , 'article-container' ) ) ) ?>">
+              <div id="content" class="<?php echo implode(' ', apply_filters( 'tc_article_container_class' , array( CZR_utils::czr_get_layout( CZR_utils::czr_id() , 'class' ) , 'article-container' ) ) ) ?>">
 
                 <?php do_action ('__before_loop');##hooks the header of the list of post : archive, search... ?>
       <?php
@@ -1292,7 +1292,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @return bool True, if in the active plugins list. False, not in the list.
     */
     function czr_is_plugin_active( $plugin ) {
-      return in_array( $plugin, (array) get_option( 'active_plugins', array() ) ) || $this -> tc_is_plugin_active_for_network( $plugin );
+      return in_array( $plugin, (array) get_option( 'active_plugins', array() ) ) || $this -> czr_is_plugin_active_for_network( $plugin );
     }
 
 

--- a/inc/class-fire-plugins_compat.php
+++ b/inc/class-fire-plugins_compat.php
@@ -10,8 +10,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_plugins_compat' ) ) :
-  class TC_plugins_compat {
+if ( ! class_exists( 'CZR_plugins_compat' ) ) :
+  class CZR_plugins_compat {
     //Access any method or var of the class with classname::$instance -> var or method():
     static $instance;
     //credits @Srdjan
@@ -307,7 +307,7 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
           add_filter( $filter, 'tc_apply_qtranslate' );
 
         //translate button text
-        $pre_slides['common']['button_text'] = $pre_slides['common']['button_text'] ? TC_slider::$instance -> tc_get_post_slide_button_text( $pre_slides['common']['button_text'] ) : '';
+        $pre_slides['common']['button_text'] = $pre_slides['common']['button_text'] ? CZR_slider::$instance -> tc_get_post_slide_button_text( $pre_slides['common']['button_text'] ) : '';
 
         //translate title and excerpt if needed
         $_posts = &$pre_slides['posts'];
@@ -317,8 +317,8 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
           $_p = get_post( $ID );
           if ( ! $_p ) continue;
 
-          $_post['title'] = $_post['title'] ? TC_slider::$instance -> tc_get_post_slide_title($_p, $ID) : '';
-          $_post['text']  = $_post['text'] ? TC_slider::$instance -> tc_get_post_slide_excerpt($_p, $ID) : '';
+          $_post['title'] = $_post['title'] ? CZR_slider::$instance -> tc_get_post_slide_title($_p, $ID) : '';
+          $_post['text']  = $_post['text'] ? CZR_slider::$instance -> tc_get_post_slide_excerpt($_p, $ID) : '';
         }
         return $pre_slides;
       }
@@ -343,13 +343,13 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
         // grab theme options
         $tc_options = tc__f('__options');
         // grab settings map, useful for some options labels
-        $tc_settings_map = TC_utils_settings_map::$instance -> tc_get_customizer_map( $get_default = true );
+        $tc_settings_map = CZR_utils_settings_map::$instance -> tc_get_customizer_map( $get_default = true );
         $tc_controls_map = $tc_settings_map['add_setting_control'];
         // set $polylang_group;
-        $polylang_group = 'customizr-pro' == TC___::$theme_name ? 'Customizr-Pro' : 'Customizr';
+        $polylang_group = 'customizr-pro' == CZR___::$theme_name ? 'Customizr-Pro' : 'Customizr';
 
         //get options to translate
-        $tc_translatable_raw_options = TC_plugins_compat::$instance -> tc_get_string_options_to_translate();
+        $tc_translatable_raw_options = CZR_plugins_compat::$instance -> tc_get_string_options_to_translate();
         $tc_pll_options              = array();
 
         //build array if option => array( label (gettext-ed), option )
@@ -379,7 +379,7 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
       if ( function_exists( 'pll_get_post' ) && function_exists( 'pll__' ) && ! is_admin() ) {
         //strings translation
         //get the options to translate
-        $tc_translatable_options = TC_plugins_compat::$instance -> tc_get_string_options_to_translate();
+        $tc_translatable_options = CZR_plugins_compat::$instance -> tc_get_string_options_to_translate();
         //translate
         foreach ( $tc_translatable_options as $tc_translatable_option )
           add_filter("tc_opt_$tc_translatable_option", 'pll__');
@@ -466,7 +466,7 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
         $option_name_assoc = wp_cache_get( $_wp_cache_key );
 
         if ( false === $option_name_assoc ) {
-          $options_to_translate = TC_plugins_compat::$instance -> tc_get_string_options_to_translate();
+          $options_to_translate = CZR_plugins_compat::$instance -> tc_get_string_options_to_translate();
 
           $option_name_assoc = apply_filters( 'tc_wpml_options_names_config', array(
  //           'tc_front_slider'              => 'Front page slider name', //Handled in a different way by Srdjan
@@ -517,7 +517,7 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
               $slide_language = apply_filters( 'wpml_element_language_code',
                             null, array('element_id' => $attachment_id,
                                 'element_type' => 'attachment') );
-              if ( TC_plugins_compat::$instance->current_language != $slide_language ) {
+              if ( CZR_plugins_compat::$instance->current_language != $slide_language ) {
                 // Replace with translated slide
                 $translated_slide_id = apply_filters( 'wpml_object_id',
                                 $attachment_id, 'attachment', false );
@@ -561,10 +561,10 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
       function pre_update_option_filter( $options ) {
         if ( isset( $options['tc_sliders'] ) ) {
             // Force default language
-            $current_language = TC_plugins_compat::$instance->current_language;
-            TC_plugins_compat::$instance->current_language = TC_plugins_compat::$instance->default_language;
+            $current_language = CZR_plugins_compat::$instance->current_language;
+            CZR_plugins_compat::$instance->current_language = CZR_plugins_compat::$instance->default_language;
             $options['tc_sliders'] = sliders_filter( $options['tc_sliders'] );
-            TC_plugins_compat::$instance->current_language = $current_language;
+            CZR_plugins_compat::$instance->current_language = $current_language;
         }
         return $options;
       }
@@ -595,7 +595,7 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
         //In English we have set to filter blog posts for cat A,B and C.
         //In Italian we do not have cat C so there will be displayed transposed cats A and B
         //if we change this option in the Customizer with lang IT removing B, e.g., when we switch to EN we'll have that the array of cats contains just A, as it as been overwritten with the new setting
-        if ( TC___::$instance -> tc_is_customize_left_panel() )
+        if ( CZR___::$instance -> tc_is_customize_left_panel() )
           add_filter( 'option_tc_theme_options', 'tc_wpml_customizer_options_transpose' );
         function tc_wpml_customizer_options_transpose( $options ) {
           $options_to_transpose = apply_filters ( 'tc_wpml_customizer_translate_options', array(
@@ -845,10 +845,10 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
 
       function tc_sensei_wrappers() {
         switch ( current_filter() ) {
-          case 'sensei_before_main_content': TC_plugins_compat::$instance -> tc_mainwrapper_start();
+          case 'sensei_before_main_content': CZR_plugins_compat::$instance -> tc_mainwrapper_start();
                                              break;
 
-          case 'sensei_after_main_content' : TC_plugins_compat::$instance -> tc_mainwrapper_end();
+          case 'sensei_after_main_content' : CZR_plugins_compat::$instance -> tc_mainwrapper_end();
                                              break;
         }//end of switch on hook
       }//end of nested function
@@ -893,10 +893,10 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
 
       function tc_woocommerce_wrappers() {
         switch ( current_filter() ) {
-          case 'woocommerce_before_main_content': TC_plugins_compat::$instance -> tc_mainwrapper_start();
+          case 'woocommerce_before_main_content': CZR_plugins_compat::$instance -> tc_mainwrapper_start();
                                                   break;
 
-          case 'woocommerce_after_main_content' : TC_plugins_compat::$instance -> tc_mainwrapper_end();
+          case 'woocommerce_after_main_content' : CZR_plugins_compat::$instance -> tc_mainwrapper_end();
                                                   break;
         }//end of switch on hook
       }//end of nested function
@@ -952,7 +952,7 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
       //link smooth scroll: exclude woocommerce tabs
       add_filter( 'tc_anchor_smoothscroll_excl', 'tc_woocommerce_disable_link_scroll' );
       function tc_woocommerce_disable_link_scroll( $excl ){
-        if ( false == esc_attr( TC_utils::$inst->tc_opt('tc_link_scroll') ) ) return $excl;
+        if ( false == esc_attr( CZR_utils::$inst->tc_opt('tc_link_scroll') ) ) return $excl;
 
         if ( function_exists('is_woocommerce') && is_woocommerce() ) {
           if ( ! is_array( $excl ) )
@@ -988,13 +988,13 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
       //narrow the tagline
       add_filter( 'tc_tagline_class', 'tc_woocommerce_force_tagline_width', 100 );
       function tc_woocommerce_force_tagline_width( $_class ) {
-        return 1 == esc_attr( TC_utils::$inst->tc_opt( 'tc_woocommerce_header_cart' ) ) ? 'span6' : $_class ;
+        return 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_woocommerce_header_cart' ) ) ? 'span6' : $_class ;
       }
 
       // Ensure cart contents update when products are added to the cart via AJAX (place the following in functions.php)
       add_filter( 'woocommerce_add_to_cart_fragments', 'tc_woocommerce_add_to_cart_fragment' );
       function tc_woocommerce_add_to_cart_fragment( $fragments ) {
-        if ( 1 == esc_attr( TC_utils::$inst->tc_opt( 'tc_woocommerce_header_cart' ) ) ) {
+        if ( 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_woocommerce_header_cart' ) ) ) {
           $_cart_count = WC()->cart->get_cart_contents_count();
           $fragments['span.tc-wc-count'] = sprintf( '<span class="count btn-link tc-wc-count">%1$s</span>', $_cart_count ? $_cart_count : '' );
         }
@@ -1004,7 +1004,7 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
       //print the cart menu in the header
       add_action( '__navbar', 'tc_woocommerce_header_cart', is_rtl() ? 9 : 19 );
       function tc_woocommerce_header_cart() {
-        if ( 1 != esc_attr( TC_utils::$inst->tc_opt( 'tc_woocommerce_header_cart' ) ) )
+        if ( 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_woocommerce_header_cart' ) ) )
           return;
 
         $_main_item_class = '';
@@ -1039,15 +1039,15 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
       //add woommerce header cart classes to the header (sticky enabled)
       add_filter( 'tc_header_classes'   , 'tc_woocommerce_set_header_classes');
       function tc_woocommerce_set_header_classes( $_classes ) {
-        if ( 1 == esc_attr( TC_utils::$inst->tc_opt( 'tc_woocommerce_header_cart' ) ) )
-          $_classes[]          = ( 1 != esc_attr( TC_utils::$inst->tc_opt( 'tc_woocommerce_header_cart_sticky' ) ) ) ? 'tc-wccart-off' : 'tc-wccart-on';
+        if ( 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_woocommerce_header_cart' ) ) )
+          $_classes[]          = ( 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_woocommerce_header_cart_sticky' ) ) ) ? 'tc-wccart-off' : 'tc-wccart-on';
         return $_classes;
       }
 
       //add woocommerce header cart CSS
       add_filter('tc_user_options_style', 'tc_woocommerce_header_cart_css');
       function tc_woocommerce_header_cart_css( $_css ) {
-        if ( 1 != esc_attr( TC_utils::$inst->tc_opt( 'tc_woocommerce_header_cart' ) ) )
+        if ( 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_woocommerce_header_cart' ) ) )
           return $_css;
 
         /* The only real decision I took here is the following:
@@ -1055,7 +1055,7 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
         * so that as it grows it won't break on a new line. This is quite an hack to
         * keep the cart space as small as possible (span1) and do not hurt the tagline too much (from span7 to span6). Also nobody will, allegedly, have more than 10^3 products in its cart
         */
-        $_header_layout      = esc_attr( TC_utils::$inst->tc_opt( 'tc_header_layout') );
+        $_header_layout      = esc_attr( CZR_utils::$inst->tc_opt( 'tc_header_layout') );
         $_resp_pos_css       = 'right' == $_header_layout ? 'float: left;' : '';
         $_wc_t_align         = 'left';
 
@@ -1159,7 +1159,7 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
       //link smooth scroll: exclude all anchor links inside vc wrappers (.vc_row)
       add_filter( 'tc_anchor_smoothscroll_excl', 'tc_vc_disable_link_scroll' );
       function tc_vc_disable_link_scroll( $excl ){
-        if ( false == esc_attr( TC_utils::$inst->tc_opt('tc_link_scroll') ) ) return $excl;
+        if ( false == esc_attr( CZR_utils::$inst->tc_opt('tc_link_scroll') ) ) return $excl;
 
         if ( ! is_array( $excl ) )
           $excl = array();
@@ -1256,7 +1256,7 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
 
             <?php do_action( '__before_article_container'); ##hook of left sidebar?>
 
-              <div id="content" class="<?php echo implode(' ', apply_filters( 'tc_article_container_class' , array( TC_utils::tc_get_layout( TC_utils::tc_id() , 'class' ) , 'article-container' ) ) ) ?>">
+              <div id="content" class="<?php echo implode(' ', apply_filters( 'tc_article_container_class' , array( CZR_utils::tc_get_layout( CZR_utils::tc_id() , 'class' ) , 'article-container' ) ) ) ?>">
 
                 <?php do_action ('__before_loop');##hooks the header of the list of post : archive, search... ?>
       <?php
@@ -1328,7 +1328,7 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
         'tc_social_in_sidebar_title',
       );
       if ( ! class_exists('TC_fpu') && ! class_exists('TC_fpc') ) {
-        $fp_areas = TC_init::$instance -> fp_ids;
+        $fp_areas = CZR_init::$instance -> fp_ids;
         foreach ( $fp_areas as $fp_area )
           $string_options[] = 'tc_featured_text_' . $fp_area;
 

--- a/inc/class-fire-plugins_compat.php
+++ b/inc/class-fire-plugins_compat.php
@@ -182,7 +182,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       function czr_fn_bbpress_disable_thumbnail($bool) {
          return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
       }
-      add_filter( 'czr_fn_show_excerpt', 'czr_fn_bbpress_disable_excerpt' );
+      add_filter( 'tc_show_excerpt', 'czr_fn_bbpress_disable_excerpt' );
       function czr_fn_bbpress_disable_excerpt($bool) {
          return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
       }
@@ -200,13 +200,13 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       }
 
       //disables post metas
-      add_filter( 'czr_fn_show_post_metas', 'czr_fn_bbpress_disable_post_metas', 100);
+      add_filter( 'tc_show_post_metas', 'czr_fn_bbpress_disable_post_metas', 100);
       function czr_fn_bbpress_disable_post_metas($bool) {
          return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
       }
 
       //disable the grid
-      add_filter( 'czr_fn_set_grid_hooks' , 'czr_fn_bbpress_disable_grid', 100 );
+      add_filter( 'tc_set_grid_hooks' , 'czr_fn_bbpress_disable_grid', 100 );
       function czr_fn_bbpress_disable_grid($bool) {
          return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
       }
@@ -219,7 +219,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @since Customizr 3.3+
     */
     private function czr_fn_set_buddypress_compat() {
-      add_filter( 'czr_fn_are_comments_enabled', 'czr_fn_buddypress_disable_comments' );
+      add_filter( 'tc_are_comments_enabled', 'czr_fn_buddypress_disable_comments' );
       function czr_fn_buddypress_disable_comments($bool){
         return ( is_page() && function_exists('is_buddypress') && is_buddypress() ) ? false : $bool;
       }
@@ -495,7 +495,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
           //cache this 'cause is used several times in filter callbacks
           wp_cache_set( $_wp_cache_key, $option_name_assoc );
         }
-        return apply_filters( 'czr_fn_wpml_get_options_names_config', $option_name_assoc );
+        return apply_filters( 'tc_wpml_get_options_names_config', $option_name_assoc );
       }
 
       //Wras wpml_object_id in a more convenient function which recursevely translates array of values
@@ -741,8 +741,8 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       }
 
       // Events archive is displayed, wrongly, we our post lists classes, we have to prevent this
-      add_filter( 'czr_fn_post_list_controller', 'czr_fn_tec_disable_post_list');
-      add_filter( 'czr_fn_is_grid_enabled', 'czr_fn_tec_disable_post_list');
+      add_filter( 'tc_post_list_controller', 'czr_fn_tec_disable_post_list');
+      add_filter( 'tc_is_grid_enabled', 'czr_fn_tec_disable_post_list');
       function czr_fn_tec_disable_post_list( $bool ) {
         return czr_fn_is_tec_events_list() ? false : $bool;
       }
@@ -865,7 +865,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         return ( function_exists('is_sensei') && is_sensei() ) ? false : $bool;
       }
       //removes post comment action on after_loop hook
-      add_filter( 'czr_fn_are_comments_enabled', 'czr_fn_sensei_disable_comments' );
+      add_filter( 'tc_are_comments_enabled', 'czr_fn_sensei_disable_comments' );
       function czr_fn_sensei_disable_comments($bool) {
         return ( function_exists('is_sensei') && is_sensei() ) ? false : $bool;
       }
@@ -944,7 +944,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
 
       //removes post comment action on after_loop hook
-      add_filter( 'czr_fn_are_comments_enabled', 'czr_fn_woocommerce_disable_comments' );
+      add_filter( 'tc_are_comments_enabled', 'czr_fn_woocommerce_disable_comments' );
       function czr_fn_woocommerce_disable_comments($bool) {
          return ( function_exists('is_woocommerce') && is_woocommerce() ) ? false : $bool;
       }
@@ -988,13 +988,13 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       //narrow the tagline
       add_filter( 'tc_tagline_class', 'czr_fn_woocommerce_force_tagline_width', 100 );
       function czr_fn_woocommerce_force_tagline_width( $_class ) {
-        return 1 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'czr_fn_woocommerce_header_cart' ) ) ? 'span6' : $_class ;
+        return 1 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_woocommerce_header_cart' ) ) ? 'span6' : $_class ;
       }
 
       // Ensure cart contents update when products are added to the cart via AJAX (place the following in functions.php)
       add_filter( 'woocommerce_add_to_cart_fragments', 'czr_fn_woocommerce_add_to_cart_fragment' );
       function czr_fn_woocommerce_add_to_cart_fragment( $fragments ) {
-        if ( 1 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'czr_fn_woocommerce_header_cart' ) ) ) {
+        if ( 1 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_woocommerce_header_cart' ) ) ) {
           $_cart_count = WC()->cart->get_cart_contents_count();
           $fragments['span.tc-wc-count'] = sprintf( '<span class="count btn-link tc-wc-count">%1$s</span>', $_cart_count ? $_cart_count : '' );
         }
@@ -1004,7 +1004,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       //print the cart menu in the header
       add_action( '__navbar', 'czr_fn_woocommerce_header_cart', is_rtl() ? 9 : 19 );
       function czr_fn_woocommerce_header_cart() {
-        if ( 1 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'czr_fn_woocommerce_header_cart' ) ) )
+        if ( 1 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_woocommerce_header_cart' ) ) )
           return;
 
         $_main_item_class = '';
@@ -1039,7 +1039,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       //add woommerce header cart classes to the header (sticky enabled)
       add_filter( 'tc_header_classes'   , 'czr_fn_woocommerce_set_header_classes');
       function czr_fn_woocommerce_set_header_classes( $_classes ) {
-        if ( 1 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'czr_fn_woocommerce_header_cart' ) ) )
+        if ( 1 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_woocommerce_header_cart' ) ) )
           $_classes[]          = ( 1 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_woocommerce_header_cart_sticky' ) ) ) ? 'tc-wccart-off' : 'tc-wccart-on';
         return $_classes;
       }
@@ -1047,7 +1047,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       //add woocommerce header cart CSS
       add_filter('tc_user_options_style', 'czr_fn_woocommerce_header_cart_css');
       function czr_fn_woocommerce_header_cart_css( $_css ) {
-        if ( 1 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'czr_fn_woocommerce_header_cart' ) ) )
+        if ( 1 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_woocommerce_header_cart' ) ) )
           return $_css;
 
         /* The only real decision I took here is the following:
@@ -1334,7 +1334,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
 
         $string_options[] = 'tc_featured_page_button_text';
       }
-      return apply_filters( 'czr_fn_get_string_options_to_translate', $string_options );
+      return apply_filters( 'tc_get_string_options_to_translate', $string_options );
     }
   }//end of class
 endif;

--- a/inc/class-fire-plugins_compat.php
+++ b/inc/class-fire-plugins_compat.php
@@ -628,19 +628,19 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
         if ( function_exists( 'icl_t') ) {
           /*** TC - WPML bind, wrap WPML string translator function into convenient tc functions ***/
           //define our icl_t wrapper for options filtered with tc_opt_{$option}
-          if ( ! function_exists( 'tc_wpml_t_opt' ) ) {
+          if ( ! function_exists( 'czr_wpml_t_opt' ) ) {
             function czr_wpml_t_opt( $string ) {
               return tc_wpml_t( $string, str_replace('tc_opt_', '', current_filter() ) );
             }
           }
           //special function for the post slider button text pre trim filter
-          if ( ! function_exists( 'tc_wpml_t_ps_button_text' ) ) {
+          if ( ! function_exists( 'czr_wpml_t_ps_button_text' ) ) {
             function czr_wpml_t_ps_button_text( $string ) {
               return tc_wpml_t( $string, 'tc_posts_slider_button_text' );
             }
           }
           //define our icl_t wrapper
-          if ( ! function_exists( 'tc_wpml_t' ) ) {
+          if ( ! function_exists( 'czr_wpml_t' ) ) {
             function czr_wpml_t( $string, $opt ) {
               $tc_wpml_options_names = tc_wpml_get_options_names_config();
               return icl_t( TC_WPML_CONTEXT, $tc_wpml_options_names[$opt], $string );
@@ -721,7 +721,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       /*
       * Are we in the Events list context?
       */
-      if ( ! ( function_exists( 'tc_is_tec_events_list' ) ) ) {
+      if ( ! ( function_exists( 'czr_is_tec_events_list' ) ) ) {
         function czr_is_tec_events_list() {
           return function_exists( 'tribe_is_event_query' ) && tribe_is_event_query() && is_post_type_archive();
         }
@@ -729,7 +729,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
       /*
       * Are we in single Event context?
       */
-      if ( ! ( function_exists( 'tc_is_tec_single_event' ) ) ) {
+      if ( ! ( function_exists( 'czr_is_tec_single_event' ) ) ) {
         function czr_is_tec_single_event() {
           return function_exists( 'tribe_is_event_query' ) && tribe_is_event_query() && is_single();
         }
@@ -1184,7 +1184,7 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @since Customizr 3.4+
     */
     private function czr_set_disqus_compat() {
-      if ( ! function_exists( 'tc_disqus_comments_enabled' ) ) {
+      if ( ! function_exists( 'czr_disqus_comments_enabled' ) ) {
         function czr_disqus_comments_enabled() {
           return function_exists( 'dsq_is_installed' ) && function_exists( 'dsq_can_replace' )
                  && dsq_is_installed() && dsq_can_replace();

--- a/inc/class-fire-plugins_compat.php
+++ b/inc/class-fire-plugins_compat.php
@@ -171,45 +171,28 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     * @since Customizr 3.3+
     */
     private function czr_fn_set_bbpress_compat() {
+      if ( ! function_exists( 'czr_fn_bbpress_disable_feature' ) ) {
+        function czr_fn_bbpress_disable_feature( $bool ) {
+          return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
+        }
+      }
+
       // hide tax archive title
-      add_filter( 'tc_show_tax_archive_title', 'czr_fn_bbpress_disable_tax_archive_title');
-      function czr_fn_bbpress_disable_tax_archive_title( $bool ){
-        return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
-      }
-
+      add_filter( 'tc_show_tax_archive_title', 'czr_fn_bbpress_disable_feature');
       //disables thumbnails and excerpt for post lists
-      add_filter( 'tc_show_post_list_thumb', 'czr_fn_bbpress_disable_thumbnail' );
-      function czr_fn_bbpress_disable_thumbnail($bool) {
-         return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
-      }
-      add_filter( 'tc_show_excerpt', 'czr_fn_bbpress_disable_excerpt' );
-      function czr_fn_bbpress_disable_excerpt($bool) {
-         return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
-      }
-
+      add_filter( 'tc_show_post_list_thumb', 'czr_fn_bbpress_disable_feature' );
+      //show full content in post lists
+      add_filter( 'tc_show_excerpt', 'czr_fn_bbpress_disable_feature' );
       //disables Customizr author infos on forums
-      add_filter( 'tc_show_author_metas_in_post', 'czr_fn_bbpress_disable_author_meta' );
-      function czr_fn_bbpress_disable_author_meta($bool) {
-        return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
-      }
-
+      add_filter( 'tc_show_author_metas_in_post', 'czr_fn_bbpress_disable_feature' );
       //disables post navigation
-      add_filter( 'tc_show_post_navigation', 'czr_fn_bbpress_disable_post_navigation' );
-      function czr_fn_bbpress_disable_post_navigation($bool) {
-         return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
-      }
-
+      add_filter( 'tc_show_post_navigation', 'czr_fn_bbpress_disable_feature' );
       //disables post metas
-      add_filter( 'tc_show_post_metas', 'czr_fn_bbpress_disable_post_metas', 100);
-      function czr_fn_bbpress_disable_post_metas($bool) {
-         return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
-      }
-
+      add_filter( 'tc_show_post_metas', 'czr_fn_bbpress_disable_feature', 100);
       //disable the grid
-      add_filter( 'tc_set_grid_hooks' , 'czr_fn_bbpress_disable_grid', 100 );
-      function czr_fn_bbpress_disable_grid($bool) {
-         return ( function_exists('is_bbpress') && is_bbpress() ) ? false : $bool;
-      }
+      add_filter( 'tc_set_grid_hooks' , 'czr_fn_bbpress_disable_feature', 100 );
+      //disable the smartload help block
+      add_filter( 'tc_is_img_smartload_help_on', 'czr_fn_bbpress_disable_feature' );
     }
 
     /**

--- a/inc/class-fire-resources.php
+++ b/inc/class-fire-resources.php
@@ -48,7 +48,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
 		* @package Customizr
 		* @since Customizr 1.1
 		*/
-        function tc_enqueue_front_styles() {
+        function czr_enqueue_front_styles() {
           //Enqueue FontAwesome CSS
           if ( true == CZR_utils::$inst -> tc_opt( 'tc_font_awesome_css' ) ) {
             $_path = apply_filters( 'tc_font_icons_path' , TC_BASE_URL . 'inc/assets/css' );
@@ -77,7 +77,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    private function tc_get_script_map( $_handles = array() ) {
+    private function czr_get_script_map( $_handles = array() ) {
       $_map = array(
         'tc-js-params' => array(
           'path' => 'inc/assets/js/parts/',
@@ -174,7 +174,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
 		* @package Customizr
 		* @since Customizr 1.0
 		*/
-		function tc_enqueue_front_scripts() {
+		function czr_enqueue_front_scripts() {
 	    //wp scripts
 	  	if ( is_singular() && get_option( 'thread_comments' ) )
 		    wp_enqueue_script( 'comment-reply' );
@@ -329,7 +329,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since Customizr 3.2.3
     */
-		function tc_write_inline_font_icons_css( $_css = null ) {
+		function czr_write_inline_font_icons_css( $_css = null ) {
       $_css               = isset($_css) ? $_css : '';
       return apply_filters( 'tc_write_inline_font_icons',
         $this -> tc_get_inline_font_icons_css() . "\n" . $_css,
@@ -345,7 +345,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since Customizr 3.3.2
     */
-    public function tc_get_inline_font_icons_css() {
+    public function czr_get_inline_font_icons_css() {
       if ( false == CZR_utils::$inst -> tc_opt( 'tc_font_awesome_icons' ) )
         return;
 
@@ -374,7 +374,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since Customizr 2.0.7
     */
-    function tc_write_custom_css( $_css = null ) {
+    function czr_write_custom_css( $_css = null ) {
       $_css               = isset($_css) ? $_css : '';
       $tc_custom_css      = esc_html( CZR_utils::$inst->tc_opt( 'tc_custom_css') );
       if ( ! isset($tc_custom_css) || empty($tc_custom_css) )
@@ -389,7 +389,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
 
 
     /* See: https://github.com/presscustomizr/customizr/issues/605 */
-    function tc_apply_media_upload_front_patch( $_css ) {
+    function czr_apply_media_upload_front_patch( $_css ) {
       global $wp_version;
       if ( version_compare( '4.5', $wp_version, '<=' ) )
         $_css = sprintf("%s%s",
@@ -409,7 +409,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since Customizr 3.2.9
     */
-    function tc_enqueue_gfonts() {
+    function czr_enqueue_gfonts() {
       $_font_pair         = esc_attr( CZR_utils::$inst->tc_opt( 'tc_fonts' ) );
       $_all_font_pairs    = CZR_init::$instance -> font_pairs;
       if ( ! $this -> tc_is_gfont( $_font_pair , '_g_') )
@@ -433,7 +433,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since Customizr 3.2.9
     */
-    function tc_write_fonts_inline_css( $_css = null , $_context = null ) {
+    function czr_write_fonts_inline_css( $_css = null , $_context = null ) {
       $_css               = isset($_css) ? $_css : '';
       $_font_pair         = esc_attr( CZR_utils::$inst->tc_opt( 'tc_fonts' ) );
       $_body_font_size    = esc_attr( CZR_utils::$inst->tc_opt( 'tc_body_font_size' ) );
@@ -503,7 +503,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since Customizr 3.3.2
     */
-    private function tc_is_gfont($_font , $_gfont_id = null ) {
+    private function czr_is_gfont($_font , $_gfont_id = null ) {
       $_gfont_id = $_gfont_id ? $_gfont_id : '_g_';
       return false !== strpos( $_font , $_gfont_id );
     }
@@ -516,7 +516,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since Customizr 3.2.11
     */
-    function tc_write_dropcap_inline_css( $_css = null , $_context = null ) {
+    function czr_write_dropcap_inline_css( $_css = null , $_context = null ) {
       $_css               = isset($_css) ? $_css : '';
       if ( ! esc_attr( CZR_utils::$inst->tc_opt( 'tc_enable_dropcap' ) ) )
         return $_css;
@@ -553,7 +553,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    function tc_set_random_skin ( $_skin ) {
+    function czr_set_random_skin ( $_skin ) {
       if ( false == esc_attr( CZR_utils::$inst -> tc_opt( 'tc_skin_random' ) ) )
         return $_skin;
 
@@ -581,7 +581,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since Customizr 3.3.2
     */
-    private function tc_get_font_css_prop( $_raw_font , $is_gfont = false ) {
+    private function czr_get_font_css_prop( $_raw_font , $is_gfont = false ) {
       $_css_exp = explode(':', $_raw_font);
       $_weight  = isset( $_css_exp[1] ) ? $_css_exp[1] : 'inherit';
       $_family  = '';
@@ -604,7 +604,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    function tc_enqueue_script( $_handles = array() ) {
+    function czr_enqueue_script( $_handles = array() ) {
       if ( empty($_handles) )
         return;
 
@@ -638,7 +638,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    private function tc_normalize_script_args( $_handle, $_params ) {
+    private function czr_normalize_script_args( $_handle, $_params ) {
       //Do we load the minified version if available ?
       if ( count( $_params['files'] ) > 1 )
         $_filename = ( defined('WP_DEBUG') && true === WP_DEBUG ) ? $_params['files'][0] : $_params['files'][1];
@@ -661,7 +661,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since v3.3+
     */
-    function tc_load_concatenated_front_scripts() {
+    function czr_load_concatenated_front_scripts() {
       return apply_filters( 'tc_load_concatenated_front_scripts' , ! defined('CZR_DEV')  || ( defined('CZR_DEV') && false == CZR_DEV ) );
     }
 
@@ -672,7 +672,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since v3.3+
     */
-    private function tc_is_fancyboxjs_required() {
+    private function czr_is_fancyboxjs_required() {
       return CZR_utils::$inst -> tc_opt( 'tc_fancybox' ) || CZR_utils::$inst -> tc_opt( 'tc_gallery_fancybox');
     }
 
@@ -683,7 +683,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since v3.3+
     */
-    function tc_maybe_is_holder_js_required(){
+    function czr_maybe_is_holder_js_required(){
       $bool = false;
 
       if ( ! ( class_exists('CZR_featured_pages') && CZR_featured_pages::$instance -> tc_show_featured_pages_img() ) )

--- a/inc/class-fire-resources.php
+++ b/inc/class-fire-resources.php
@@ -160,7 +160,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
         )
       );//end of scripts map
 
-      return apply_filters('czr_fn_get_script_map' , $_map, $_handles );
+      return apply_filters('tc_get_script_map' , $_map, $_handles );
     }
 
 
@@ -558,7 +558,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
         return $_skin;
 
       //allow custom skins to be taken in account
-      $_skins = apply_filters( 'czr_fn_get_skin_color', CZR_init::$instance -> skin_color_map, 'all' );
+      $_skins = apply_filters( 'tc_get_skin_color', CZR_init::$instance -> skin_color_map, 'all' );
 
       //allow users to filter the list of skins they want to randomize
       $_skins = apply_filters( 'tc_skins_to_randomize', $_skins );
@@ -662,7 +662,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @since v3.3+
     */
     function czr_fn_load_concatenated_front_scripts() {
-      return apply_filters( 'czr_fn_load_concatenated_front_scripts' , ! defined('CZR_DEV')  || ( defined('CZR_DEV') && false == CZR_DEV ) );
+      return apply_filters( 'tc_load_concatenated_front_scripts' , ! defined('CZR_DEV')  || ( defined('CZR_DEV') && false == CZR_DEV ) );
     }
 
     /**

--- a/inc/class-fire-resources.php
+++ b/inc/class-fire-resources.php
@@ -38,7 +38,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
           add_filter ('tc_opt_tc_skin'                , array( $this, 'tc_set_random_skin' ) );
 
           //stores the front scripts map in a property
-          $this -> tc_script_map = $this -> tc_get_script_map();
+          $this -> tc_script_map = $this -> czr_get_script_map();
 	    }
 
 
@@ -50,16 +50,16 @@ if ( ! class_exists( 'CZR_resources' ) ) :
 		*/
         function czr_enqueue_front_styles() {
           //Enqueue FontAwesome CSS
-          if ( true == CZR_utils::$inst -> tc_opt( 'tc_font_awesome_css' ) ) {
+          if ( true == CZR_utils::$inst -> czr_opt( 'tc_font_awesome_css' ) ) {
             $_path = apply_filters( 'tc_font_icons_path' , TC_BASE_URL . 'inc/assets/css' );
             wp_enqueue_style( 'customizr-fa',
-                $_path . '/fonts/' . CZR_init::$instance -> tc_maybe_use_min_style( 'font-awesome.css' ),
+                $_path . '/fonts/' . CZR_init::$instance -> czr_maybe_use_min_style( 'font-awesome.css' ),
                 array() , CUSTOMIZR_VER, 'all' );
           }
 
-	      wp_enqueue_style( 'customizr-common', CZR_init::$instance -> tc_get_style_src( 'common') , array() , CUSTOMIZR_VER, 'all' );
+	      wp_enqueue_style( 'customizr-common', CZR_init::$instance -> czr_get_style_src( 'common') , array() , CUSTOMIZR_VER, 'all' );
           //Customizr active skin
-	      wp_register_style( 'customizr-skin', CZR_init::$instance -> tc_get_style_src( 'skin'), array('customizr-common'), CUSTOMIZR_VER, 'all' );
+	      wp_register_style( 'customizr-skin', CZR_init::$instance -> czr_get_style_src( 'skin'), array('customizr-common'), CUSTOMIZR_VER, 'all' );
 	      wp_enqueue_style( 'customizr-skin' );
 	      //Customizr stylesheet (style.css)
 	      wp_enqueue_style( 'customizr-style', get_stylesheet_uri(), array( 'customizr-skin' ), CUSTOMIZR_VER , 'all' );
@@ -144,19 +144,19 @@ if ( ! class_exists( 'CZR_resources' ) ) :
         'tc-main-front' => array(
           'path' => 'inc/assets/js/parts/',
           'files' => array( 'main.js' , 'main.min.js' ),
-          'dependencies' => $this -> tc_is_fancyboxjs_required() ? array( 'tc-js-arraymap-proto', 'jquery' , 'tc-js-params', 'tc-img-original-sizes', 'tc-bootstrap', 'tc-fancybox' , 'underscore' ) : array( 'jquery' , 'tc-js-params', 'tc-img-original-sizes', 'tc-bootstrap' , 'underscore' )
+          'dependencies' => $this -> czr_is_fancyboxjs_required() ? array( 'tc-js-arraymap-proto', 'jquery' , 'tc-js-params', 'tc-img-original-sizes', 'tc-bootstrap', 'tc-fancybox' , 'underscore' ) : array( 'jquery' , 'tc-js-params', 'tc-img-original-sizes', 'tc-bootstrap' , 'underscore' )
         ),
         //loaded separately => not included in tc-script.js
         'tc-fancybox' => array(
           'path' => 'inc/assets/js/fancybox/',
           'files' => array( 'jquery.fancybox-1.3.4.min.js' ),
-          'dependencies' => $this -> tc_load_concatenated_front_scripts() ? array( 'jquery' ) : array( 'tc-js-arraymap-proto', 'jquery' , 'tc-js-params', 'tc-bootstrap' )
+          'dependencies' => $this -> czr_load_concatenated_front_scripts() ? array( 'jquery' ) : array( 'tc-js-arraymap-proto', 'jquery' , 'tc-js-params', 'tc-bootstrap' )
         ),
         //concats all scripts except fancybox
         'tc-scripts' => array(
           'path' => 'inc/assets/js/',
           'files' => array( 'tc-scripts.js' , 'tc-scripts.min.js' ),
-          'dependencies' =>  $this -> tc_is_fancyboxjs_required() ? array( 'jquery', 'tc-fancybox' ) : array( 'jquery' )
+          'dependencies' =>  $this -> czr_is_fancyboxjs_required() ? array( 'jquery', 'tc-fancybox' ) : array( 'jquery' )
         )
       );//end of scripts map
 
@@ -193,35 +193,35 @@ if ( ! class_exists( 'CZR_resources' ) ) :
       );
 
       //customizr scripts and libs
-	   	if ( $this -> tc_load_concatenated_front_scripts() )	{
-        if ( $this -> tc_is_fancyboxjs_required() )
-          $this -> tc_enqueue_script( 'tc-fancybox' );
+	   	if ( $this -> czr_load_concatenated_front_scripts() )	{
+        if ( $this -> czr_is_fancyboxjs_required() )
+          $this -> czr_enqueue_script( 'tc-fancybox' );
         //!!tc-scripts includes underscore, tc-js-arraymap-proto
-        $this -> tc_enqueue_script( 'tc-scripts' );
+        $this -> czr_enqueue_script( 'tc-scripts' );
 			}
 			else {
         wp_enqueue_script( 'underscore' );
         //!!mind the dependencies
-        $this -> tc_enqueue_script( array( 'tc-js-params', 'tc-js-arraymap-proto', 'tc-img-original-sizes', 'tc-bootstrap', 'tc-smoothscroll', 'tc-outline', 'tc-waypoints' ) );
+        $this -> czr_enqueue_script( array( 'tc-js-params', 'tc-js-arraymap-proto', 'tc-img-original-sizes', 'tc-bootstrap', 'tc-smoothscroll', 'tc-outline', 'tc-waypoints' ) );
 
-        if ( $this -> tc_is_fancyboxjs_required() )
-          $this -> tc_enqueue_script( 'tc-fancybox' );
+        if ( $this -> czr_is_fancyboxjs_required() )
+          $this -> czr_enqueue_script( 'tc-fancybox' );
 
-        $this -> tc_enqueue_script( array( 'tc-dropcap' , 'tc-img-smartload', 'tc-ext-links', 'tc-center-images', 'tc-parallax', 'tc-main-front' ) );
+        $this -> czr_enqueue_script( array( 'tc-dropcap' , 'tc-img-smartload', 'tc-ext-links', 'tc-center-images', 'tc-parallax', 'tc-main-front' ) );
 			}//end of load concatenate script if
 
       //carousel options
       //gets slider options if any for home/front page or for others posts/pages
-      $js_slidername      = tc__f('__is_home') ? CZR_utils::$inst->tc_opt( 'tc_front_slider' ) : get_post_meta( CZR_utils::tc_id() , $key = 'post_slider_key' , $single = true );
-      $js_sliderdelay     = tc__f('__is_home') ? CZR_utils::$inst->tc_opt( 'tc_slider_delay' ) : get_post_meta( CZR_utils::tc_id() , $key = 'slider_delay_key' , $single = true );
+      $js_slidername      = czr__f('__is_home') ? CZR_utils::$inst->czr_opt( 'tc_front_slider' ) : get_post_meta( CZR_utils::czr_id() , $key = 'post_slider_key' , $single = true );
+      $js_sliderdelay     = czr__f('__is_home') ? CZR_utils::$inst->czr_opt( 'tc_slider_delay' ) : get_post_meta( CZR_utils::czr_id() , $key = 'slider_delay_key' , $single = true );
 
 			//has the post comments ? adds a boolean parameter in js
 			global $wp_query;
 			$has_post_comments 	= ( 0 != $wp_query -> post_count && comments_open() && get_comments_number() != 0 ) ? true : false;
 
 			//adds the jquery effect library if smooth scroll is enabled => easeOutExpo effect
-			$anchor_smooth_scroll 		  = ( false != esc_attr( CZR_utils::$inst->tc_opt( 'tc_link_scroll') ) ) ? 'easeOutExpo' : 'linear';
-			if ( false != esc_attr( CZR_utils::$inst->tc_opt( 'tc_link_scroll') ) )
+			$anchor_smooth_scroll 		  = ( false != esc_attr( CZR_utils::$inst->czr_opt( 'tc_link_scroll') ) ) ? 'easeOutExpo' : 'linear';
+			if ( false != esc_attr( CZR_utils::$inst->czr_opt( 'tc_link_scroll') ) )
 				wp_enqueue_script('jquery-effects-core');
             $anchor_smooth_scroll_exclude =  apply_filters( 'tc_anchor_smoothscroll_excl' , array(
                 'simple' => array( '[class*=edd]' , '.tc-carousel-control', '.carousel-control', '[data-toggle="modal"]', '[data-toggle="dropdown"]', '[data-toggle="tooltip"]', '[data-toggle="popover"]', '[data-toggle="collapse"]', '[data-toggle="tab"]', '[class*=upme]', '[class*=um-]' ),
@@ -231,11 +231,11 @@ if ( ! class_exists( 'CZR_resources' ) ) :
                 )
             ));
 
-      $smooth_scroll_enabled = apply_filters('tc_enable_smoothscroll', ! wp_is_mobile() && 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_smoothscroll') ) );
+      $smooth_scroll_enabled = apply_filters('tc_enable_smoothscroll', ! wp_is_mobile() && 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_smoothscroll') ) );
       $smooth_scroll_options = apply_filters('tc_smoothscroll_options', array( 'touchpadSupport' => false ) );
 
       //smart load
-      $smart_load_enabled   = esc_attr( CZR_utils::$inst->tc_opt( 'tc_img_smart_load' ) );
+      $smart_load_enabled   = esc_attr( CZR_utils::$inst->czr_opt( 'tc_img_smart_load' ) );
       $smart_load_opts      = apply_filters( 'tc_img_smart_load_options' , array(
             'parentSelectors' => array(
                 '.article-container', '.__before_main_wrapper', '.widget-front',
@@ -245,7 +245,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
             )
       ));
 			//gets current screen layout
-    	$screen_layout      = CZR_utils::tc_get_layout( CZR_utils::tc_id() , 'sidebar'  );
+    	$screen_layout      = CZR_utils::czr_get_layout( CZR_utils::czr_id() , 'sidebar'  );
     	//gets the global layout settings
     	$global_layout      = apply_filters( 'tc_global_layout' , CZR_init::$instance -> global_layout );
     	$sidebar_layout     = isset($global_layout[$screen_layout]['sidebar']) ? $global_layout[$screen_layout]['sidebar'] : false;
@@ -254,54 +254,54 @@ if ( ! class_exists( 'CZR_resources' ) ) :
 	    $right_sb_class     = sprintf( '.%1$s.right.tc-sidebar', (false != $sidebar_layout) ? $sidebar_layout : 'span3' );
 
 			wp_localize_script(
-	        $this -> tc_load_concatenated_front_scripts() ? 'tc-scripts' : 'tc-js-params',
+	        $this -> czr_load_concatenated_front_scripts() ? 'tc-scripts' : 'tc-js-params',
 	        'TCParams',
 	        apply_filters( 'tc_customizr_script_params' , array(
 	          	'_disabled'          => apply_filters( 'tc_disabled_front_js_parts', array() ),
-              'FancyBoxState' 		=> $this -> tc_is_fancyboxjs_required(),
-	          	'FancyBoxAutoscale' => ( 1 == CZR_utils::$inst->tc_opt( 'tc_fancybox_autoscale') ) ? true : false,
+              'FancyBoxState' 		=> $this -> czr_is_fancyboxjs_required(),
+	          	'FancyBoxAutoscale' => ( 1 == CZR_utils::$inst->czr_opt( 'tc_fancybox_autoscale') ) ? true : false,
 	          	'SliderName' 			  => $js_slidername,
 	          	'SliderDelay' 			=> $js_sliderdelay,
 	          	'SliderHover'			  => apply_filters( 'tc_stop_slider_hover', true ),
-	          	'centerSliderImg'   => esc_attr( CZR_utils::$inst->tc_opt( 'tc_center_slider_img') ),
+	          	'centerSliderImg'   => esc_attr( CZR_utils::$inst->czr_opt( 'tc_center_slider_img') ),
               'SmoothScroll'      => array( 'Enabled' => $smooth_scroll_enabled, 'Options' => $smooth_scroll_options ),
               'anchorSmoothScroll'			=> $anchor_smooth_scroll,
               'anchorSmoothScrollExclude' => $anchor_smooth_scroll_exclude,
-	          	'ReorderBlocks' 		=> esc_attr( CZR_utils::$inst->tc_opt( 'tc_block_reorder') ),
-	          	'centerAllImg' 			=> esc_attr( CZR_utils::$inst->tc_opt( 'tc_center_img') ),
+	          	'ReorderBlocks' 		=> esc_attr( CZR_utils::$inst->czr_opt( 'tc_block_reorder') ),
+	          	'centerAllImg' 			=> esc_attr( CZR_utils::$inst->czr_opt( 'tc_center_img') ),
 	          	'HasComments' 			=> $has_post_comments,
 	          	'LeftSidebarClass' 		=> $left_sb_class,
 	          	'RightSidebarClass' 	=> $right_sb_class,
 	          	'LoadModernizr' 		=> apply_filters( 'tc_load_modernizr' , true ),
 	          	'stickyCustomOffset' 	=> apply_filters( 'tc_sticky_custom_offset' , array( "_initial" => 0, "_scrolling" => 0, "options" => array( "_static" => true, "_element" => "" ) ) ),
-	          	'stickyHeader' 			=> esc_attr( CZR_utils::$inst->tc_opt( 'tc_sticky_header' ) ),
-	          	'dropdowntoViewport' 	=> esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_resp_dropdown_limit_to_viewport') ),
+	          	'stickyHeader' 			=> esc_attr( CZR_utils::$inst->czr_opt( 'tc_sticky_header' ) ),
+	          	'dropdowntoViewport' 	=> esc_attr( CZR_utils::$inst->czr_opt( 'tc_menu_resp_dropdown_limit_to_viewport') ),
 	          	'timerOnScrollAllBrowsers' => apply_filters( 'tc_timer_on_scroll_for_all_browser' , true), //<= if false, for ie only
-              'extLinksStyle'       => esc_attr( CZR_utils::$inst->tc_opt( 'tc_ext_link_style' ) ),
-              'extLinksTargetExt'   => esc_attr( CZR_utils::$inst->tc_opt( 'tc_ext_link_target' ) ),
+              'extLinksStyle'       => esc_attr( CZR_utils::$inst->czr_opt( 'tc_ext_link_style' ) ),
+              'extLinksTargetExt'   => esc_attr( CZR_utils::$inst->czr_opt( 'tc_ext_link_target' ) ),
               'extLinksSkipSelectors'   => apply_filters( 'tc_ext_links_skip_selectors' , array( 'classes' => array('btn', 'button') , 'ids' => array() ) ),
-              'dropcapEnabled'      => esc_attr( CZR_utils::$inst->tc_opt( 'tc_enable_dropcap' ) ),
-              'dropcapWhere'      => array( 'post' => esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_dropcap' ) ) , 'page' => esc_attr( CZR_utils::$inst->tc_opt( 'tc_page_dropcap' ) ) ),
-              'dropcapMinWords'     => esc_attr( CZR_utils::$inst->tc_opt( 'tc_dropcap_minwords' ) ),
+              'dropcapEnabled'      => esc_attr( CZR_utils::$inst->czr_opt( 'tc_enable_dropcap' ) ),
+              'dropcapWhere'      => array( 'post' => esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_dropcap' ) ) , 'page' => esc_attr( CZR_utils::$inst->czr_opt( 'tc_page_dropcap' ) ) ),
+              'dropcapMinWords'     => esc_attr( CZR_utils::$inst->czr_opt( 'tc_dropcap_minwords' ) ),
               'dropcapSkipSelectors'  => apply_filters( 'tc_dropcap_skip_selectors' , array( 'tags' => array('IMG' , 'IFRAME', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'BLOCKQUOTE', 'UL', 'OL'), 'classes' => array('btn') , 'id' => array() ) ),
               'imgSmartLoadEnabled' => $smart_load_enabled,
               'imgSmartLoadOpts'    => $smart_load_opts,
               'goldenRatio'         => apply_filters( 'tc_grid_golden_ratio' , 1.618 ),
-              'gridGoldenRatioLimit' => esc_attr( CZR_utils::$inst->tc_opt( 'tc_grid_thumb_height' ) ),
-              'isSecondMenuEnabled'  => CZR_utils::$inst->tc_is_secondary_menu_enabled(),
-              'secondMenuRespSet'   => esc_attr( CZR_utils::$inst->tc_opt( 'tc_second_menu_resp_setting' ) )
+              'gridGoldenRatioLimit' => esc_attr( CZR_utils::$inst->czr_opt( 'tc_grid_thumb_height' ) ),
+              'isSecondMenuEnabled'  => CZR_utils::$inst->czr_is_secondary_menu_enabled(),
+              'secondMenuRespSet'   => esc_attr( CZR_utils::$inst->czr_opt( 'tc_second_menu_resp_setting' ) )
 	        	),
-	        	CZR_utils::tc_id()
+	        	CZR_utils::czr_id()
 		    )//end of filter
 	     );
 
 	    //fancybox style
-	    if ( $this -> tc_is_fancyboxjs_required() )
+	    if ( $this -> czr_is_fancyboxjs_required() )
 	      wp_enqueue_style( 'fancyboxcss' , TC_BASE_URL . 'inc/assets/js/fancybox/jquery.fancybox-1.3.4.min.css' );
 
 	    //holder.js is loaded when featured pages are enabled AND FP are set to show images and at least one holder should be displayed.
-      $tc_show_featured_pages 	         = class_exists('CZR_featured_pages') && CZR_featured_pages::$instance -> tc_show_featured_pages();
-    	if ( 0 != $tc_show_featured_pages && $this -> tc_maybe_is_holder_js_required() ) {
+      $tc_show_featured_pages 	         = class_exists('CZR_featured_pages') && CZR_featured_pages::$instance -> czr_show_featured_pages();
+    	if ( 0 != $tc_show_featured_pages && $this -> czr_maybe_is_holder_js_required() ) {
 	    	wp_enqueue_script(
 	    		'holder',
 	    		sprintf( '%1$sinc/assets/js/holder.min.js' , TC_BASE_URL ),
@@ -312,7 +312,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
 	    }
 
 	    //load retina.js in footer if enabled
-	    if ( apply_filters('tc_load_retinajs', 1 == CZR_utils::$inst->tc_opt( 'tc_retina_support' ) ) )
+	    if ( apply_filters('tc_load_retinajs', 1 == CZR_utils::$inst->czr_opt( 'tc_retina_support' ) ) )
 	    	wp_enqueue_script( 'retinajs' ,TC_BASE_URL . 'inc/assets/js/retina.min.js', array(), CUSTOMIZR_VER, $in_footer = true);
 
 	    //Load hammer.js for mobile
@@ -332,7 +332,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
 		function czr_write_inline_font_icons_css( $_css = null ) {
       $_css               = isset($_css) ? $_css : '';
       return apply_filters( 'tc_write_inline_font_icons',
-        $this -> tc_get_inline_font_icons_css() . "\n" . $_css,
+        $this -> czr_get_inline_font_icons_css() . "\n" . $_css,
         $_css
       );
     }//end of function
@@ -346,7 +346,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @since Customizr 3.3.2
     */
     public function czr_get_inline_font_icons_css() {
-      if ( false == CZR_utils::$inst -> tc_opt( 'tc_font_awesome_icons' ) )
+      if ( false == CZR_utils::$inst -> czr_opt( 'tc_font_awesome_icons' ) )
         return;
 
       $_path = apply_filters( 'tc_font_icons_path' , TC_BASE_URL . 'inc/assets/css' );
@@ -376,14 +376,14 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     */
     function czr_write_custom_css( $_css = null ) {
       $_css               = isset($_css) ? $_css : '';
-      $tc_custom_css      = esc_html( CZR_utils::$inst->tc_opt( 'tc_custom_css') );
+      $tc_custom_css      = esc_html( CZR_utils::$inst->czr_opt( 'tc_custom_css') );
       if ( ! isset($tc_custom_css) || empty($tc_custom_css) )
         return $_css;
 
       return apply_filters( 'tc_write_custom_css',
         $_css . "\n" . html_entity_decode( $tc_custom_css ),
         $_css,
-        CZR_utils::$inst->tc_opt( 'tc_custom_css')
+        CZR_utils::$inst->czr_opt( 'tc_custom_css')
       );
     }//end of function
 
@@ -410,14 +410,14 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @since Customizr 3.2.9
     */
     function czr_enqueue_gfonts() {
-      $_font_pair         = esc_attr( CZR_utils::$inst->tc_opt( 'tc_fonts' ) );
+      $_font_pair         = esc_attr( CZR_utils::$inst->czr_opt( 'tc_fonts' ) );
       $_all_font_pairs    = CZR_init::$instance -> font_pairs;
-      if ( ! $this -> tc_is_gfont( $_font_pair , '_g_') )
+      if ( ! $this -> czr_is_gfont( $_font_pair , '_g_') )
         return;
 
       wp_enqueue_style(
         'tc-gfonts',
-        sprintf( '//fonts.googleapis.com/css?family=%s', CZR_utils::$inst -> tc_get_font( 'single' , $_font_pair ) ),
+        sprintf( '//fonts.googleapis.com/css?family=%s', CZR_utils::$inst -> czr_get_font( 'single' , $_font_pair ) ),
         array(),
         null,
         'all'
@@ -435,8 +435,8 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     */
     function czr_write_fonts_inline_css( $_css = null , $_context = null ) {
       $_css               = isset($_css) ? $_css : '';
-      $_font_pair         = esc_attr( CZR_utils::$inst->tc_opt( 'tc_fonts' ) );
-      $_body_font_size    = esc_attr( CZR_utils::$inst->tc_opt( 'tc_body_font_size' ) );
+      $_font_pair         = esc_attr( CZR_utils::$inst->czr_opt( 'tc_fonts' ) );
+      $_body_font_size    = esc_attr( CZR_utils::$inst->czr_opt( 'tc_body_font_size' ) );
       $_font_selectors    = CZR_init::$instance -> font_selectors;
 
       //create the $body and $titles vars
@@ -455,13 +455,13 @@ if ( ! class_exists( 'CZR_resources' ) ) :
       $body   = apply_filters('tc_body_fonts_selectors' , $body );
 
       if ( 'helvetica_arial' != $_font_pair ) {//check if not default
-        $_selector_fonts  = explode( '|', CZR_utils::$inst -> tc_get_font( 'single' , $_font_pair ) );
+        $_selector_fonts  = explode( '|', CZR_utils::$inst -> czr_get_font( 'single' , $_font_pair ) );
         if ( ! is_array($_selector_fonts) )
           return $_css;
 
         foreach ($_selector_fonts as $_key => $_raw_font) {
           //create the $_family and $_weight vars
-          extract( $this -> tc_get_font_css_prop( $_raw_font , $this -> tc_is_gfont( $_font_pair ) ) );
+          extract( $this -> czr_get_font_css_prop( $_raw_font , $this -> czr_is_gfont( $_font_pair ) ) );
 
           switch ($_key) {
             case 0 : //titles font
@@ -518,13 +518,13 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     */
     function czr_write_dropcap_inline_css( $_css = null , $_context = null ) {
       $_css               = isset($_css) ? $_css : '';
-      if ( ! esc_attr( CZR_utils::$inst->tc_opt( 'tc_enable_dropcap' ) ) )
+      if ( ! esc_attr( CZR_utils::$inst->czr_opt( 'tc_enable_dropcap' ) ) )
         return $_css;
 
-      $_main_color_pair = CZR_utils::$inst -> tc_get_skin_color( 'pair' );
+      $_main_color_pair = CZR_utils::$inst -> czr_get_skin_color( 'pair' );
       $_color           = $_main_color_pair[0];
       $_shad_color      = $_main_color_pair[1];
-      $_pad_right       = false !== strpos( esc_attr( CZR_utils::$inst->tc_opt( 'tc_fonts' ) ), 'lobster' ) ? 26 : 8;
+      $_pad_right       = false !== strpos( esc_attr( CZR_utils::$inst->czr_opt( 'tc_fonts' ) ), 'lobster' ) ? 26 : 8;
       $_css .= "
         .tc-dropcap {
           color: {$_color};
@@ -554,7 +554,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @since Customizr 3.3+
     */
     function czr_set_random_skin ( $_skin ) {
-      if ( false == esc_attr( CZR_utils::$inst -> tc_opt( 'tc_skin_random' ) ) )
+      if ( false == esc_attr( CZR_utils::$inst -> czr_opt( 'tc_skin_random' ) ) )
         return $_skin;
 
       //allow custom skins to be taken in account
@@ -624,7 +624,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
 
       //Enqueue the scripts with normalizes args
       foreach ( $_scripts as $_hand => $_params )
-        call_user_func_array( 'wp_enqueue_script',  $this -> tc_normalize_script_args( $_hand, $_params ) );
+        call_user_func_array( 'wp_enqueue_script',  $this -> czr_normalize_script_args( $_hand, $_params ) );
 
     }//end of fn
 
@@ -673,7 +673,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @since v3.3+
     */
     private function czr_is_fancyboxjs_required() {
-      return CZR_utils::$inst -> tc_opt( 'tc_fancybox' ) || CZR_utils::$inst -> tc_opt( 'tc_gallery_fancybox');
+      return CZR_utils::$inst -> czr_opt( 'tc_fancybox' ) || CZR_utils::$inst -> czr_opt( 'tc_gallery_fancybox');
     }
 
     /**
@@ -686,14 +686,14 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     function czr_maybe_is_holder_js_required(){
       $bool = false;
 
-      if ( ! ( class_exists('CZR_featured_pages') && CZR_featured_pages::$instance -> tc_show_featured_pages_img() ) )
+      if ( ! ( class_exists('CZR_featured_pages') && CZR_featured_pages::$instance -> czr_show_featured_pages_img() ) )
         return $bool;
 
       $fp_ids = apply_filters( 'tc_featured_pages_ids' , CZR_init::$instance -> fp_ids);
 
       foreach ( $fp_ids as $fp_single_id ){
-        $featured_page_id = CZR_utils::$inst->tc_opt( 'tc_featured_page_'.$fp_single_id );
-        if ( null == $featured_page_id || ! $featured_page_id || ! CZR_featured_pages::$instance -> tc_get_fp_img( null, $featured_page_id, null ) ) {
+        $featured_page_id = CZR_utils::$inst->czr_opt( 'tc_featured_page_'.$fp_single_id );
+        if ( null == $featured_page_id || ! $featured_page_id || ! CZR_featured_pages::$instance -> czr_get_fp_img( null, $featured_page_id, null ) ) {
           $bool = true;
           break;
         }

--- a/inc/class-fire-resources.php
+++ b/inc/class-fire-resources.php
@@ -380,7 +380,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
       if ( ! isset($tc_custom_css) || empty($tc_custom_css) )
         return $_css;
 
-      return apply_filters( 'czr_fn_write_custom_css',
+      return apply_filters( 'tc_write_custom_css',
         $_css . "\n" . html_entity_decode( $tc_custom_css ),
         $_css,
         CZR_utils::$inst->czr_fn_opt( 'tc_custom_css')

--- a/inc/class-fire-resources.php
+++ b/inc/class-fire-resources.php
@@ -20,25 +20,25 @@ if ( ! class_exists( 'CZR_resources' ) ) :
 
 	    function __construct () {
 	        self::$instance =& $this;
-          add_action( 'wp_enqueue_scripts'            , array( $this , 'czr_enqueue_gfonts' ) , 0 );
-	        add_action( 'wp_enqueue_scripts'						, array( $this , 'czr_enqueue_front_styles' ) );
-          add_action( 'wp_enqueue_scripts'						, array( $this , 'czr_enqueue_front_scripts' ) );
+          add_action( 'wp_enqueue_scripts'            , array( $this , 'czr_fn_enqueue_gfonts' ) , 0 );
+	        add_action( 'wp_enqueue_scripts'						, array( $this , 'czr_fn_enqueue_front_styles' ) );
+          add_action( 'wp_enqueue_scripts'						, array( $this , 'czr_fn_enqueue_front_scripts' ) );
           //Custom Stylesheets
           //Write font icon
-          add_filter('tc_user_options_style'          , array( $this , 'czr_write_inline_font_icons_css') , apply_filters( 'tc_font_icon_priority', 999 ) );
+          add_filter('tc_user_options_style'          , array( $this , 'czr_fn_write_inline_font_icons_css') , apply_filters( 'tc_font_icon_priority', 999 ) );
 	        //Custom CSS
-          add_filter('tc_user_options_style'          , array( $this , 'czr_write_custom_css') , apply_filters( 'tc_custom_css_priority', 9999 ) );
-          add_filter('tc_user_options_style'          , array( $this , 'czr_write_fonts_inline_css') );
-          add_filter('tc_user_options_style'          , array( $this , 'czr_write_dropcap_inline_css') );
+          add_filter('tc_user_options_style'          , array( $this , 'czr_fn_write_custom_css') , apply_filters( 'tc_custom_css_priority', 9999 ) );
+          add_filter('tc_user_options_style'          , array( $this , 'czr_fn_write_fonts_inline_css') );
+          add_filter('tc_user_options_style'          , array( $this , 'czr_fn_write_dropcap_inline_css') );
 
           /* See: https://github.com/presscustomizr/customizr/issues/605 */
-          add_filter('tc_user_options_style'          , array( $this , 'czr_apply_media_upload_front_patch' ) );
+          add_filter('tc_user_options_style'          , array( $this , 'czr_fn_apply_media_upload_front_patch' ) );
 
           //set random skin
-          add_filter ('tc_opt_tc_skin'                , array( $this, 'czr_set_random_skin' ) );
+          add_filter ('tc_opt_tc_skin'                , array( $this, 'czr_fn_set_random_skin' ) );
 
           //stores the front scripts map in a property
-          $this -> tc_script_map = $this -> czr_get_script_map();
+          $this -> tc_script_map = $this -> czr_fn_get_script_map();
 	    }
 
 
@@ -48,18 +48,18 @@ if ( ! class_exists( 'CZR_resources' ) ) :
 		* @package Customizr
 		* @since Customizr 1.1
 		*/
-        function czr_enqueue_front_styles() {
+        function czr_fn_enqueue_front_styles() {
           //Enqueue FontAwesome CSS
-          if ( true == CZR_utils::$inst -> czr_opt( 'tc_font_awesome_css' ) ) {
+          if ( true == CZR_utils::$inst -> czr_fn_opt( 'tc_font_awesome_css' ) ) {
             $_path = apply_filters( 'tc_font_icons_path' , TC_BASE_URL . 'inc/assets/css' );
             wp_enqueue_style( 'customizr-fa',
-                $_path . '/fonts/' . CZR_init::$instance -> czr_maybe_use_min_style( 'font-awesome.css' ),
+                $_path . '/fonts/' . CZR_init::$instance -> czr_fn_maybe_use_min_style( 'font-awesome.css' ),
                 array() , CUSTOMIZR_VER, 'all' );
           }
 
-	      wp_enqueue_style( 'customizr-common', CZR_init::$instance -> czr_get_style_src( 'common') , array() , CUSTOMIZR_VER, 'all' );
+	      wp_enqueue_style( 'customizr-common', CZR_init::$instance -> czr_fn_get_style_src( 'common') , array() , CUSTOMIZR_VER, 'all' );
           //Customizr active skin
-	      wp_register_style( 'customizr-skin', CZR_init::$instance -> czr_get_style_src( 'skin'), array('customizr-common'), CUSTOMIZR_VER, 'all' );
+	      wp_register_style( 'customizr-skin', CZR_init::$instance -> czr_fn_get_style_src( 'skin'), array('customizr-common'), CUSTOMIZR_VER, 'all' );
 	      wp_enqueue_style( 'customizr-skin' );
 	      //Customizr stylesheet (style.css)
 	      wp_enqueue_style( 'customizr-style', get_stylesheet_uri(), array( 'customizr-skin' ), CUSTOMIZR_VER , 'all' );
@@ -77,7 +77,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    private function czr_get_script_map( $_handles = array() ) {
+    private function czr_fn_get_script_map( $_handles = array() ) {
       $_map = array(
         'tc-js-params' => array(
           'path' => 'inc/assets/js/parts/',
@@ -144,23 +144,23 @@ if ( ! class_exists( 'CZR_resources' ) ) :
         'tc-main-front' => array(
           'path' => 'inc/assets/js/parts/',
           'files' => array( 'main.js' , 'main.min.js' ),
-          'dependencies' => $this -> czr_is_fancyboxjs_required() ? array( 'tc-js-arraymap-proto', 'jquery' , 'tc-js-params', 'tc-img-original-sizes', 'tc-bootstrap', 'tc-fancybox' , 'underscore' ) : array( 'jquery' , 'tc-js-params', 'tc-img-original-sizes', 'tc-bootstrap' , 'underscore' )
+          'dependencies' => $this -> czr_fn_is_fancyboxjs_required() ? array( 'tc-js-arraymap-proto', 'jquery' , 'tc-js-params', 'tc-img-original-sizes', 'tc-bootstrap', 'tc-fancybox' , 'underscore' ) : array( 'jquery' , 'tc-js-params', 'tc-img-original-sizes', 'tc-bootstrap' , 'underscore' )
         ),
         //loaded separately => not included in tc-script.js
         'tc-fancybox' => array(
           'path' => 'inc/assets/js/fancybox/',
           'files' => array( 'jquery.fancybox-1.3.4.min.js' ),
-          'dependencies' => $this -> czr_load_concatenated_front_scripts() ? array( 'jquery' ) : array( 'tc-js-arraymap-proto', 'jquery' , 'tc-js-params', 'tc-bootstrap' )
+          'dependencies' => $this -> czr_fn_load_concatenated_front_scripts() ? array( 'jquery' ) : array( 'tc-js-arraymap-proto', 'jquery' , 'tc-js-params', 'tc-bootstrap' )
         ),
         //concats all scripts except fancybox
         'tc-scripts' => array(
           'path' => 'inc/assets/js/',
           'files' => array( 'tc-scripts.js' , 'tc-scripts.min.js' ),
-          'dependencies' =>  $this -> czr_is_fancyboxjs_required() ? array( 'jquery', 'tc-fancybox' ) : array( 'jquery' )
+          'dependencies' =>  $this -> czr_fn_is_fancyboxjs_required() ? array( 'jquery', 'tc-fancybox' ) : array( 'jquery' )
         )
       );//end of scripts map
 
-      return apply_filters('czr_get_script_map' , $_map, $_handles );
+      return apply_filters('czr_fn_get_script_map' , $_map, $_handles );
     }
 
 
@@ -174,7 +174,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
 		* @package Customizr
 		* @since Customizr 1.0
 		*/
-		function czr_enqueue_front_scripts() {
+		function czr_fn_enqueue_front_scripts() {
 	    //wp scripts
 	  	if ( is_singular() && get_option( 'thread_comments' ) )
 		    wp_enqueue_script( 'comment-reply' );
@@ -193,35 +193,35 @@ if ( ! class_exists( 'CZR_resources' ) ) :
       );
 
       //customizr scripts and libs
-	   	if ( $this -> czr_load_concatenated_front_scripts() )	{
-        if ( $this -> czr_is_fancyboxjs_required() )
-          $this -> czr_enqueue_script( 'tc-fancybox' );
+	   	if ( $this -> czr_fn_load_concatenated_front_scripts() )	{
+        if ( $this -> czr_fn_is_fancyboxjs_required() )
+          $this -> czr_fn_enqueue_script( 'tc-fancybox' );
         //!!tc-scripts includes underscore, tc-js-arraymap-proto
-        $this -> czr_enqueue_script( 'tc-scripts' );
+        $this -> czr_fn_enqueue_script( 'tc-scripts' );
 			}
 			else {
         wp_enqueue_script( 'underscore' );
         //!!mind the dependencies
-        $this -> czr_enqueue_script( array( 'tc-js-params', 'tc-js-arraymap-proto', 'tc-img-original-sizes', 'tc-bootstrap', 'tc-smoothscroll', 'tc-outline', 'tc-waypoints' ) );
+        $this -> czr_fn_enqueue_script( array( 'tc-js-params', 'tc-js-arraymap-proto', 'tc-img-original-sizes', 'tc-bootstrap', 'tc-smoothscroll', 'tc-outline', 'tc-waypoints' ) );
 
-        if ( $this -> czr_is_fancyboxjs_required() )
-          $this -> czr_enqueue_script( 'tc-fancybox' );
+        if ( $this -> czr_fn_is_fancyboxjs_required() )
+          $this -> czr_fn_enqueue_script( 'tc-fancybox' );
 
-        $this -> czr_enqueue_script( array( 'tc-dropcap' , 'tc-img-smartload', 'tc-ext-links', 'tc-center-images', 'tc-parallax', 'tc-main-front' ) );
+        $this -> czr_fn_enqueue_script( array( 'tc-dropcap' , 'tc-img-smartload', 'tc-ext-links', 'tc-center-images', 'tc-parallax', 'tc-main-front' ) );
 			}//end of load concatenate script if
 
       //carousel options
       //gets slider options if any for home/front page or for others posts/pages
-      $js_slidername      = czr__f('__is_home') ? CZR_utils::$inst->czr_opt( 'tc_front_slider' ) : get_post_meta( CZR_utils::czr_id() , $key = 'post_slider_key' , $single = true );
-      $js_sliderdelay     = czr__f('__is_home') ? CZR_utils::$inst->czr_opt( 'tc_slider_delay' ) : get_post_meta( CZR_utils::czr_id() , $key = 'slider_delay_key' , $single = true );
+      $js_slidername      = czr_fn__f('__is_home') ? CZR_utils::$inst->czr_fn_opt( 'tc_front_slider' ) : get_post_meta( CZR_utils::czr_fn_id() , $key = 'post_slider_key' , $single = true );
+      $js_sliderdelay     = czr_fn__f('__is_home') ? CZR_utils::$inst->czr_fn_opt( 'tc_slider_delay' ) : get_post_meta( CZR_utils::czr_fn_id() , $key = 'slider_delay_key' , $single = true );
 
 			//has the post comments ? adds a boolean parameter in js
 			global $wp_query;
 			$has_post_comments 	= ( 0 != $wp_query -> post_count && comments_open() && get_comments_number() != 0 ) ? true : false;
 
 			//adds the jquery effect library if smooth scroll is enabled => easeOutExpo effect
-			$anchor_smooth_scroll 		  = ( false != esc_attr( CZR_utils::$inst->czr_opt( 'tc_link_scroll') ) ) ? 'easeOutExpo' : 'linear';
-			if ( false != esc_attr( CZR_utils::$inst->czr_opt( 'tc_link_scroll') ) )
+			$anchor_smooth_scroll 		  = ( false != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_link_scroll') ) ) ? 'easeOutExpo' : 'linear';
+			if ( false != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_link_scroll') ) )
 				wp_enqueue_script('jquery-effects-core');
             $anchor_smooth_scroll_exclude =  apply_filters( 'tc_anchor_smoothscroll_excl' , array(
                 'simple' => array( '[class*=edd]' , '.tc-carousel-control', '.carousel-control', '[data-toggle="modal"]', '[data-toggle="dropdown"]', '[data-toggle="tooltip"]', '[data-toggle="popover"]', '[data-toggle="collapse"]', '[data-toggle="tab"]', '[class*=upme]', '[class*=um-]' ),
@@ -231,11 +231,11 @@ if ( ! class_exists( 'CZR_resources' ) ) :
                 )
             ));
 
-      $smooth_scroll_enabled = apply_filters('tc_enable_smoothscroll', ! wp_is_mobile() && 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_smoothscroll') ) );
+      $smooth_scroll_enabled = apply_filters('tc_enable_smoothscroll', ! wp_is_mobile() && 1 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_smoothscroll') ) );
       $smooth_scroll_options = apply_filters('tc_smoothscroll_options', array( 'touchpadSupport' => false ) );
 
       //smart load
-      $smart_load_enabled   = esc_attr( CZR_utils::$inst->czr_opt( 'tc_img_smart_load' ) );
+      $smart_load_enabled   = esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_img_smart_load' ) );
       $smart_load_opts      = apply_filters( 'tc_img_smart_load_options' , array(
             'parentSelectors' => array(
                 '.article-container', '.__before_main_wrapper', '.widget-front',
@@ -245,7 +245,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
             )
       ));
 			//gets current screen layout
-    	$screen_layout      = CZR_utils::czr_get_layout( CZR_utils::czr_id() , 'sidebar'  );
+    	$screen_layout      = CZR_utils::czr_fn_get_layout( CZR_utils::czr_fn_id() , 'sidebar'  );
     	//gets the global layout settings
     	$global_layout      = apply_filters( 'tc_global_layout' , CZR_init::$instance -> global_layout );
     	$sidebar_layout     = isset($global_layout[$screen_layout]['sidebar']) ? $global_layout[$screen_layout]['sidebar'] : false;
@@ -254,54 +254,54 @@ if ( ! class_exists( 'CZR_resources' ) ) :
 	    $right_sb_class     = sprintf( '.%1$s.right.tc-sidebar', (false != $sidebar_layout) ? $sidebar_layout : 'span3' );
 
 			wp_localize_script(
-	        $this -> czr_load_concatenated_front_scripts() ? 'tc-scripts' : 'tc-js-params',
+	        $this -> czr_fn_load_concatenated_front_scripts() ? 'tc-scripts' : 'tc-js-params',
 	        'TCParams',
 	        apply_filters( 'tc_customizr_script_params' , array(
 	          	'_disabled'          => apply_filters( 'tc_disabled_front_js_parts', array() ),
-              'FancyBoxState' 		=> $this -> czr_is_fancyboxjs_required(),
-	          	'FancyBoxAutoscale' => ( 1 == CZR_utils::$inst->czr_opt( 'tc_fancybox_autoscale') ) ? true : false,
+              'FancyBoxState' 		=> $this -> czr_fn_is_fancyboxjs_required(),
+	          	'FancyBoxAutoscale' => ( 1 == CZR_utils::$inst->czr_fn_opt( 'tc_fancybox_autoscale') ) ? true : false,
 	          	'SliderName' 			  => $js_slidername,
 	          	'SliderDelay' 			=> $js_sliderdelay,
 	          	'SliderHover'			  => apply_filters( 'tc_stop_slider_hover', true ),
-	          	'centerSliderImg'   => esc_attr( CZR_utils::$inst->czr_opt( 'tc_center_slider_img') ),
+	          	'centerSliderImg'   => esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_center_slider_img') ),
               'SmoothScroll'      => array( 'Enabled' => $smooth_scroll_enabled, 'Options' => $smooth_scroll_options ),
               'anchorSmoothScroll'			=> $anchor_smooth_scroll,
               'anchorSmoothScrollExclude' => $anchor_smooth_scroll_exclude,
-	          	'ReorderBlocks' 		=> esc_attr( CZR_utils::$inst->czr_opt( 'tc_block_reorder') ),
-	          	'centerAllImg' 			=> esc_attr( CZR_utils::$inst->czr_opt( 'tc_center_img') ),
+	          	'ReorderBlocks' 		=> esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_block_reorder') ),
+	          	'centerAllImg' 			=> esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_center_img') ),
 	          	'HasComments' 			=> $has_post_comments,
 	          	'LeftSidebarClass' 		=> $left_sb_class,
 	          	'RightSidebarClass' 	=> $right_sb_class,
 	          	'LoadModernizr' 		=> apply_filters( 'tc_load_modernizr' , true ),
 	          	'stickyCustomOffset' 	=> apply_filters( 'tc_sticky_custom_offset' , array( "_initial" => 0, "_scrolling" => 0, "options" => array( "_static" => true, "_element" => "" ) ) ),
-	          	'stickyHeader' 			=> esc_attr( CZR_utils::$inst->czr_opt( 'tc_sticky_header' ) ),
-	          	'dropdowntoViewport' 	=> esc_attr( CZR_utils::$inst->czr_opt( 'tc_menu_resp_dropdown_limit_to_viewport') ),
+	          	'stickyHeader' 			=> esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_sticky_header' ) ),
+	          	'dropdowntoViewport' 	=> esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_menu_resp_dropdown_limit_to_viewport') ),
 	          	'timerOnScrollAllBrowsers' => apply_filters( 'tc_timer_on_scroll_for_all_browser' , true), //<= if false, for ie only
-              'extLinksStyle'       => esc_attr( CZR_utils::$inst->czr_opt( 'tc_ext_link_style' ) ),
-              'extLinksTargetExt'   => esc_attr( CZR_utils::$inst->czr_opt( 'tc_ext_link_target' ) ),
+              'extLinksStyle'       => esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_ext_link_style' ) ),
+              'extLinksTargetExt'   => esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_ext_link_target' ) ),
               'extLinksSkipSelectors'   => apply_filters( 'tc_ext_links_skip_selectors' , array( 'classes' => array('btn', 'button') , 'ids' => array() ) ),
-              'dropcapEnabled'      => esc_attr( CZR_utils::$inst->czr_opt( 'tc_enable_dropcap' ) ),
-              'dropcapWhere'      => array( 'post' => esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_dropcap' ) ) , 'page' => esc_attr( CZR_utils::$inst->czr_opt( 'tc_page_dropcap' ) ) ),
-              'dropcapMinWords'     => esc_attr( CZR_utils::$inst->czr_opt( 'tc_dropcap_minwords' ) ),
+              'dropcapEnabled'      => esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_enable_dropcap' ) ),
+              'dropcapWhere'      => array( 'post' => esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_post_dropcap' ) ) , 'page' => esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_page_dropcap' ) ) ),
+              'dropcapMinWords'     => esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_dropcap_minwords' ) ),
               'dropcapSkipSelectors'  => apply_filters( 'tc_dropcap_skip_selectors' , array( 'tags' => array('IMG' , 'IFRAME', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'BLOCKQUOTE', 'UL', 'OL'), 'classes' => array('btn') , 'id' => array() ) ),
               'imgSmartLoadEnabled' => $smart_load_enabled,
               'imgSmartLoadOpts'    => $smart_load_opts,
               'goldenRatio'         => apply_filters( 'tc_grid_golden_ratio' , 1.618 ),
-              'gridGoldenRatioLimit' => esc_attr( CZR_utils::$inst->czr_opt( 'tc_grid_thumb_height' ) ),
-              'isSecondMenuEnabled'  => CZR_utils::$inst->czr_is_secondary_menu_enabled(),
-              'secondMenuRespSet'   => esc_attr( CZR_utils::$inst->czr_opt( 'tc_second_menu_resp_setting' ) )
+              'gridGoldenRatioLimit' => esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_grid_thumb_height' ) ),
+              'isSecondMenuEnabled'  => CZR_utils::$inst->czr_fn_is_secondary_menu_enabled(),
+              'secondMenuRespSet'   => esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_second_menu_resp_setting' ) )
 	        	),
-	        	CZR_utils::czr_id()
+	        	CZR_utils::czr_fn_id()
 		    )//end of filter
 	     );
 
 	    //fancybox style
-	    if ( $this -> czr_is_fancyboxjs_required() )
+	    if ( $this -> czr_fn_is_fancyboxjs_required() )
 	      wp_enqueue_style( 'fancyboxcss' , TC_BASE_URL . 'inc/assets/js/fancybox/jquery.fancybox-1.3.4.min.css' );
 
 	    //holder.js is loaded when featured pages are enabled AND FP are set to show images and at least one holder should be displayed.
-      $tc_show_featured_pages 	         = class_exists('CZR_featured_pages') && CZR_featured_pages::$instance -> czr_show_featured_pages();
-    	if ( 0 != $tc_show_featured_pages && $this -> czr_maybe_is_holder_js_required() ) {
+      $tc_show_featured_pages 	         = class_exists('CZR_featured_pages') && CZR_featured_pages::$instance -> czr_fn_show_featured_pages();
+    	if ( 0 != $tc_show_featured_pages && $this -> czr_fn_maybe_is_holder_js_required() ) {
 	    	wp_enqueue_script(
 	    		'holder',
 	    		sprintf( '%1$sinc/assets/js/holder.min.js' , TC_BASE_URL ),
@@ -312,7 +312,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
 	    }
 
 	    //load retina.js in footer if enabled
-	    if ( apply_filters('tc_load_retinajs', 1 == CZR_utils::$inst->czr_opt( 'tc_retina_support' ) ) )
+	    if ( apply_filters('tc_load_retinajs', 1 == CZR_utils::$inst->czr_fn_opt( 'tc_retina_support' ) ) )
 	    	wp_enqueue_script( 'retinajs' ,TC_BASE_URL . 'inc/assets/js/retina.min.js', array(), CUSTOMIZR_VER, $in_footer = true);
 
 	    //Load hammer.js for mobile
@@ -329,10 +329,10 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since Customizr 3.2.3
     */
-		function czr_write_inline_font_icons_css( $_css = null ) {
+		function czr_fn_write_inline_font_icons_css( $_css = null ) {
       $_css               = isset($_css) ? $_css : '';
       return apply_filters( 'tc_write_inline_font_icons',
-        $this -> czr_get_inline_font_icons_css() . "\n" . $_css,
+        $this -> czr_fn_get_inline_font_icons_css() . "\n" . $_css,
         $_css
       );
     }//end of function
@@ -345,8 +345,8 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since Customizr 3.3.2
     */
-    public function czr_get_inline_font_icons_css() {
-      if ( false == CZR_utils::$inst -> czr_opt( 'tc_font_awesome_icons' ) )
+    public function czr_fn_get_inline_font_icons_css() {
+      if ( false == CZR_utils::$inst -> czr_fn_opt( 'tc_font_awesome_icons' ) )
         return;
 
       $_path = apply_filters( 'tc_font_icons_path' , TC_BASE_URL . 'inc/assets/css' );
@@ -374,22 +374,22 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since Customizr 2.0.7
     */
-    function czr_write_custom_css( $_css = null ) {
+    function czr_fn_write_custom_css( $_css = null ) {
       $_css               = isset($_css) ? $_css : '';
-      $tc_custom_css      = esc_html( CZR_utils::$inst->czr_opt( 'tc_custom_css') );
+      $tc_custom_css      = esc_html( CZR_utils::$inst->czr_fn_opt( 'tc_custom_css') );
       if ( ! isset($tc_custom_css) || empty($tc_custom_css) )
         return $_css;
 
-      return apply_filters( 'czr_write_custom_css',
+      return apply_filters( 'czr_fn_write_custom_css',
         $_css . "\n" . html_entity_decode( $tc_custom_css ),
         $_css,
-        CZR_utils::$inst->czr_opt( 'tc_custom_css')
+        CZR_utils::$inst->czr_fn_opt( 'tc_custom_css')
       );
     }//end of function
 
 
     /* See: https://github.com/presscustomizr/customizr/issues/605 */
-    function czr_apply_media_upload_front_patch( $_css ) {
+    function czr_fn_apply_media_upload_front_patch( $_css ) {
       global $wp_version;
       if ( version_compare( '4.5', $wp_version, '<=' ) )
         $_css = sprintf("%s%s",
@@ -409,15 +409,15 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since Customizr 3.2.9
     */
-    function czr_enqueue_gfonts() {
-      $_font_pair         = esc_attr( CZR_utils::$inst->czr_opt( 'tc_fonts' ) );
+    function czr_fn_enqueue_gfonts() {
+      $_font_pair         = esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_fonts' ) );
       $_all_font_pairs    = CZR_init::$instance -> font_pairs;
-      if ( ! $this -> czr_is_gfont( $_font_pair , '_g_') )
+      if ( ! $this -> czr_fn_is_gfont( $_font_pair , '_g_') )
         return;
 
       wp_enqueue_style(
         'tc-gfonts',
-        sprintf( '//fonts.googleapis.com/css?family=%s', CZR_utils::$inst -> czr_get_font( 'single' , $_font_pair ) ),
+        sprintf( '//fonts.googleapis.com/css?family=%s', CZR_utils::$inst -> czr_fn_get_font( 'single' , $_font_pair ) ),
         array(),
         null,
         'all'
@@ -433,10 +433,10 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since Customizr 3.2.9
     */
-    function czr_write_fonts_inline_css( $_css = null , $_context = null ) {
+    function czr_fn_write_fonts_inline_css( $_css = null , $_context = null ) {
       $_css               = isset($_css) ? $_css : '';
-      $_font_pair         = esc_attr( CZR_utils::$inst->czr_opt( 'tc_fonts' ) );
-      $_body_font_size    = esc_attr( CZR_utils::$inst->czr_opt( 'tc_body_font_size' ) );
+      $_font_pair         = esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_fonts' ) );
+      $_body_font_size    = esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_body_font_size' ) );
       $_font_selectors    = CZR_init::$instance -> font_selectors;
 
       //create the $body and $titles vars
@@ -455,13 +455,13 @@ if ( ! class_exists( 'CZR_resources' ) ) :
       $body   = apply_filters('tc_body_fonts_selectors' , $body );
 
       if ( 'helvetica_arial' != $_font_pair ) {//check if not default
-        $_selector_fonts  = explode( '|', CZR_utils::$inst -> czr_get_font( 'single' , $_font_pair ) );
+        $_selector_fonts  = explode( '|', CZR_utils::$inst -> czr_fn_get_font( 'single' , $_font_pair ) );
         if ( ! is_array($_selector_fonts) )
           return $_css;
 
         foreach ($_selector_fonts as $_key => $_raw_font) {
           //create the $_family and $_weight vars
-          extract( $this -> czr_get_font_css_prop( $_raw_font , $this -> czr_is_gfont( $_font_pair ) ) );
+          extract( $this -> czr_fn_get_font_css_prop( $_raw_font , $this -> czr_fn_is_gfont( $_font_pair ) ) );
 
           switch ($_key) {
             case 0 : //titles font
@@ -503,7 +503,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since Customizr 3.3.2
     */
-    private function czr_is_gfont($_font , $_gfont_id = null ) {
+    private function czr_fn_is_gfont($_font , $_gfont_id = null ) {
       $_gfont_id = $_gfont_id ? $_gfont_id : '_g_';
       return false !== strpos( $_font , $_gfont_id );
     }
@@ -516,15 +516,15 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since Customizr 3.2.11
     */
-    function czr_write_dropcap_inline_css( $_css = null , $_context = null ) {
+    function czr_fn_write_dropcap_inline_css( $_css = null , $_context = null ) {
       $_css               = isset($_css) ? $_css : '';
-      if ( ! esc_attr( CZR_utils::$inst->czr_opt( 'tc_enable_dropcap' ) ) )
+      if ( ! esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_enable_dropcap' ) ) )
         return $_css;
 
-      $_main_color_pair = CZR_utils::$inst -> czr_get_skin_color( 'pair' );
+      $_main_color_pair = CZR_utils::$inst -> czr_fn_get_skin_color( 'pair' );
       $_color           = $_main_color_pair[0];
       $_shad_color      = $_main_color_pair[1];
-      $_pad_right       = false !== strpos( esc_attr( CZR_utils::$inst->czr_opt( 'tc_fonts' ) ), 'lobster' ) ? 26 : 8;
+      $_pad_right       = false !== strpos( esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_fonts' ) ), 'lobster' ) ? 26 : 8;
       $_css .= "
         .tc-dropcap {
           color: {$_color};
@@ -553,12 +553,12 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    function czr_set_random_skin ( $_skin ) {
-      if ( false == esc_attr( CZR_utils::$inst -> czr_opt( 'tc_skin_random' ) ) )
+    function czr_fn_set_random_skin ( $_skin ) {
+      if ( false == esc_attr( CZR_utils::$inst -> czr_fn_opt( 'tc_skin_random' ) ) )
         return $_skin;
 
       //allow custom skins to be taken in account
-      $_skins = apply_filters( 'czr_get_skin_color', CZR_init::$instance -> skin_color_map, 'all' );
+      $_skins = apply_filters( 'czr_fn_get_skin_color', CZR_init::$instance -> skin_color_map, 'all' );
 
       //allow users to filter the list of skins they want to randomize
       $_skins = apply_filters( 'tc_skins_to_randomize', $_skins );
@@ -581,7 +581,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since Customizr 3.3.2
     */
-    private function czr_get_font_css_prop( $_raw_font , $is_gfont = false ) {
+    private function czr_fn_get_font_css_prop( $_raw_font , $is_gfont = false ) {
       $_css_exp = explode(':', $_raw_font);
       $_weight  = isset( $_css_exp[1] ) ? $_css_exp[1] : 'inherit';
       $_family  = '';
@@ -604,7 +604,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    function czr_enqueue_script( $_handles = array() ) {
+    function czr_fn_enqueue_script( $_handles = array() ) {
       if ( empty($_handles) )
         return;
 
@@ -624,7 +624,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
 
       //Enqueue the scripts with normalizes args
       foreach ( $_scripts as $_hand => $_params )
-        call_user_func_array( 'wp_enqueue_script',  $this -> czr_normalize_script_args( $_hand, $_params ) );
+        call_user_func_array( 'wp_enqueue_script',  $this -> czr_fn_normalize_script_args( $_hand, $_params ) );
 
     }//end of fn
 
@@ -638,7 +638,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    private function czr_normalize_script_args( $_handle, $_params ) {
+    private function czr_fn_normalize_script_args( $_handle, $_params ) {
       //Do we load the minified version if available ?
       if ( count( $_params['files'] ) > 1 )
         $_filename = ( defined('WP_DEBUG') && true === WP_DEBUG ) ? $_params['files'][0] : $_params['files'][1];
@@ -661,8 +661,8 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since v3.3+
     */
-    function czr_load_concatenated_front_scripts() {
-      return apply_filters( 'czr_load_concatenated_front_scripts' , ! defined('CZR_DEV')  || ( defined('CZR_DEV') && false == CZR_DEV ) );
+    function czr_fn_load_concatenated_front_scripts() {
+      return apply_filters( 'czr_fn_load_concatenated_front_scripts' , ! defined('CZR_DEV')  || ( defined('CZR_DEV') && false == CZR_DEV ) );
     }
 
     /**
@@ -672,8 +672,8 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since v3.3+
     */
-    private function czr_is_fancyboxjs_required() {
-      return CZR_utils::$inst -> czr_opt( 'tc_fancybox' ) || CZR_utils::$inst -> czr_opt( 'tc_gallery_fancybox');
+    private function czr_fn_is_fancyboxjs_required() {
+      return CZR_utils::$inst -> czr_fn_opt( 'tc_fancybox' ) || CZR_utils::$inst -> czr_fn_opt( 'tc_gallery_fancybox');
     }
 
     /**
@@ -683,17 +683,17 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @package Customizr
     * @since v3.3+
     */
-    function czr_maybe_is_holder_js_required(){
+    function czr_fn_maybe_is_holder_js_required(){
       $bool = false;
 
-      if ( ! ( class_exists('CZR_featured_pages') && CZR_featured_pages::$instance -> czr_show_featured_pages_img() ) )
+      if ( ! ( class_exists('CZR_featured_pages') && CZR_featured_pages::$instance -> czr_fn_show_featured_pages_img() ) )
         return $bool;
 
       $fp_ids = apply_filters( 'tc_featured_pages_ids' , CZR_init::$instance -> fp_ids);
 
       foreach ( $fp_ids as $fp_single_id ){
-        $featured_page_id = CZR_utils::$inst->czr_opt( 'tc_featured_page_'.$fp_single_id );
-        if ( null == $featured_page_id || ! $featured_page_id || ! CZR_featured_pages::$instance -> czr_get_fp_img( null, $featured_page_id, null ) ) {
+        $featured_page_id = CZR_utils::$inst->czr_fn_opt( 'tc_featured_page_'.$fp_single_id );
+        if ( null == $featured_page_id || ! $featured_page_id || ! CZR_featured_pages::$instance -> czr_fn_get_fp_img( null, $featured_page_id, null ) ) {
           $bool = true;
           break;
         }

--- a/inc/class-fire-resources.php
+++ b/inc/class-fire-resources.php
@@ -20,22 +20,22 @@ if ( ! class_exists( 'CZR_resources' ) ) :
 
 	    function __construct () {
 	        self::$instance =& $this;
-          add_action( 'wp_enqueue_scripts'            , array( $this , 'tc_enqueue_gfonts' ) , 0 );
-	        add_action( 'wp_enqueue_scripts'						, array( $this , 'tc_enqueue_front_styles' ) );
-          add_action( 'wp_enqueue_scripts'						, array( $this , 'tc_enqueue_front_scripts' ) );
+          add_action( 'wp_enqueue_scripts'            , array( $this , 'czr_enqueue_gfonts' ) , 0 );
+	        add_action( 'wp_enqueue_scripts'						, array( $this , 'czr_enqueue_front_styles' ) );
+          add_action( 'wp_enqueue_scripts'						, array( $this , 'czr_enqueue_front_scripts' ) );
           //Custom Stylesheets
           //Write font icon
-          add_filter('tc_user_options_style'          , array( $this , 'tc_write_inline_font_icons_css') , apply_filters( 'tc_font_icon_priority', 999 ) );
+          add_filter('tc_user_options_style'          , array( $this , 'czr_write_inline_font_icons_css') , apply_filters( 'tc_font_icon_priority', 999 ) );
 	        //Custom CSS
-          add_filter('tc_user_options_style'          , array( $this , 'tc_write_custom_css') , apply_filters( 'tc_custom_css_priority', 9999 ) );
-          add_filter('tc_user_options_style'          , array( $this , 'tc_write_fonts_inline_css') );
-          add_filter('tc_user_options_style'          , array( $this , 'tc_write_dropcap_inline_css') );
+          add_filter('tc_user_options_style'          , array( $this , 'czr_write_custom_css') , apply_filters( 'tc_custom_css_priority', 9999 ) );
+          add_filter('tc_user_options_style'          , array( $this , 'czr_write_fonts_inline_css') );
+          add_filter('tc_user_options_style'          , array( $this , 'czr_write_dropcap_inline_css') );
 
           /* See: https://github.com/presscustomizr/customizr/issues/605 */
-          add_filter('tc_user_options_style'          , array( $this , 'tc_apply_media_upload_front_patch' ) );
+          add_filter('tc_user_options_style'          , array( $this , 'czr_apply_media_upload_front_patch' ) );
 
           //set random skin
-          add_filter ('tc_opt_tc_skin'                , array( $this, 'tc_set_random_skin' ) );
+          add_filter ('tc_opt_tc_skin'                , array( $this, 'czr_set_random_skin' ) );
 
           //stores the front scripts map in a property
           $this -> tc_script_map = $this -> czr_get_script_map();
@@ -160,7 +160,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
         )
       );//end of scripts map
 
-      return apply_filters('tc_get_script_map' , $_map, $_handles );
+      return apply_filters('czr_get_script_map' , $_map, $_handles );
     }
 
 
@@ -380,7 +380,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
       if ( ! isset($tc_custom_css) || empty($tc_custom_css) )
         return $_css;
 
-      return apply_filters( 'tc_write_custom_css',
+      return apply_filters( 'czr_write_custom_css',
         $_css . "\n" . html_entity_decode( $tc_custom_css ),
         $_css,
         CZR_utils::$inst->czr_opt( 'tc_custom_css')
@@ -558,7 +558,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
         return $_skin;
 
       //allow custom skins to be taken in account
-      $_skins = apply_filters( 'tc_get_skin_color', CZR_init::$instance -> skin_color_map, 'all' );
+      $_skins = apply_filters( 'czr_get_skin_color', CZR_init::$instance -> skin_color_map, 'all' );
 
       //allow users to filter the list of skins they want to randomize
       $_skins = apply_filters( 'tc_skins_to_randomize', $_skins );
@@ -662,7 +662,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
     * @since v3.3+
     */
     function czr_load_concatenated_front_scripts() {
-      return apply_filters( 'tc_load_concatenated_front_scripts' , ! defined('CZR_DEV')  || ( defined('CZR_DEV') && false == CZR_DEV ) );
+      return apply_filters( 'czr_load_concatenated_front_scripts' , ! defined('CZR_DEV')  || ( defined('CZR_DEV') && false == CZR_DEV ) );
     }
 
     /**

--- a/inc/class-fire-resources.php
+++ b/inc/class-fire-resources.php
@@ -11,8 +11,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_resources' ) ) :
-	class TC_resources {
+if ( ! class_exists( 'CZR_resources' ) ) :
+	class CZR_resources {
 	    //Access any method or var of the class with classname::$instance -> var or method():
 	    static $instance;
       public $tc_script_map;
@@ -22,7 +22,7 @@ if ( ! class_exists( 'TC_resources' ) ) :
 	        self::$instance =& $this;
           add_action( 'wp_enqueue_scripts'            , array( $this , 'tc_enqueue_gfonts' ) , 0 );
 	        add_action( 'wp_enqueue_scripts'						, array( $this , 'tc_enqueue_front_styles' ) );
-            add_action( 'wp_enqueue_scripts'						, array( $this , 'tc_enqueue_front_scripts' ) );
+          add_action( 'wp_enqueue_scripts'						, array( $this , 'tc_enqueue_front_scripts' ) );
           //Custom Stylesheets
           //Write font icon
           add_filter('tc_user_options_style'          , array( $this , 'tc_write_inline_font_icons_css') , apply_filters( 'tc_font_icon_priority', 999 ) );
@@ -50,16 +50,16 @@ if ( ! class_exists( 'TC_resources' ) ) :
 		*/
         function tc_enqueue_front_styles() {
           //Enqueue FontAwesome CSS
-          if ( true == TC_utils::$inst -> tc_opt( 'tc_font_awesome_css' ) ) {
+          if ( true == CZR_utils::$inst -> tc_opt( 'tc_font_awesome_css' ) ) {
             $_path = apply_filters( 'tc_font_icons_path' , TC_BASE_URL . 'inc/assets/css' );
             wp_enqueue_style( 'customizr-fa',
-                $_path . '/fonts/' . TC_init::$instance -> tc_maybe_use_min_style( 'font-awesome.css' ),
+                $_path . '/fonts/' . CZR_init::$instance -> tc_maybe_use_min_style( 'font-awesome.css' ),
                 array() , CUSTOMIZR_VER, 'all' );
           }
 
-	      wp_enqueue_style( 'customizr-common', TC_init::$instance -> tc_get_style_src( 'common') , array() , CUSTOMIZR_VER, 'all' );
+	      wp_enqueue_style( 'customizr-common', CZR_init::$instance -> tc_get_style_src( 'common') , array() , CUSTOMIZR_VER, 'all' );
           //Customizr active skin
-	      wp_register_style( 'customizr-skin', TC_init::$instance -> tc_get_style_src( 'skin'), array('customizr-common'), CUSTOMIZR_VER, 'all' );
+	      wp_register_style( 'customizr-skin', CZR_init::$instance -> tc_get_style_src( 'skin'), array('customizr-common'), CUSTOMIZR_VER, 'all' );
 	      wp_enqueue_style( 'customizr-skin' );
 	      //Customizr stylesheet (style.css)
 	      wp_enqueue_style( 'customizr-style', get_stylesheet_uri(), array( 'customizr-skin' ), CUSTOMIZR_VER , 'all' );
@@ -212,16 +212,16 @@ if ( ! class_exists( 'TC_resources' ) ) :
 
       //carousel options
       //gets slider options if any for home/front page or for others posts/pages
-      $js_slidername      = tc__f('__is_home') ? TC_utils::$inst->tc_opt( 'tc_front_slider' ) : get_post_meta( TC_utils::tc_id() , $key = 'post_slider_key' , $single = true );
-      $js_sliderdelay     = tc__f('__is_home') ? TC_utils::$inst->tc_opt( 'tc_slider_delay' ) : get_post_meta( TC_utils::tc_id() , $key = 'slider_delay_key' , $single = true );
+      $js_slidername      = tc__f('__is_home') ? CZR_utils::$inst->tc_opt( 'tc_front_slider' ) : get_post_meta( CZR_utils::tc_id() , $key = 'post_slider_key' , $single = true );
+      $js_sliderdelay     = tc__f('__is_home') ? CZR_utils::$inst->tc_opt( 'tc_slider_delay' ) : get_post_meta( CZR_utils::tc_id() , $key = 'slider_delay_key' , $single = true );
 
 			//has the post comments ? adds a boolean parameter in js
 			global $wp_query;
 			$has_post_comments 	= ( 0 != $wp_query -> post_count && comments_open() && get_comments_number() != 0 ) ? true : false;
 
 			//adds the jquery effect library if smooth scroll is enabled => easeOutExpo effect
-			$anchor_smooth_scroll 		  = ( false != esc_attr( TC_utils::$inst->tc_opt( 'tc_link_scroll') ) ) ? 'easeOutExpo' : 'linear';
-			if ( false != esc_attr( TC_utils::$inst->tc_opt( 'tc_link_scroll') ) )
+			$anchor_smooth_scroll 		  = ( false != esc_attr( CZR_utils::$inst->tc_opt( 'tc_link_scroll') ) ) ? 'easeOutExpo' : 'linear';
+			if ( false != esc_attr( CZR_utils::$inst->tc_opt( 'tc_link_scroll') ) )
 				wp_enqueue_script('jquery-effects-core');
             $anchor_smooth_scroll_exclude =  apply_filters( 'tc_anchor_smoothscroll_excl' , array(
                 'simple' => array( '[class*=edd]' , '.tc-carousel-control', '.carousel-control', '[data-toggle="modal"]', '[data-toggle="dropdown"]', '[data-toggle="tooltip"]', '[data-toggle="popover"]', '[data-toggle="collapse"]', '[data-toggle="tab"]', '[class*=upme]', '[class*=um-]' ),
@@ -231,11 +231,11 @@ if ( ! class_exists( 'TC_resources' ) ) :
                 )
             ));
 
-      $smooth_scroll_enabled = apply_filters('tc_enable_smoothscroll', ! wp_is_mobile() && 1 == esc_attr( TC_utils::$inst->tc_opt( 'tc_smoothscroll') ) );
+      $smooth_scroll_enabled = apply_filters('tc_enable_smoothscroll', ! wp_is_mobile() && 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_smoothscroll') ) );
       $smooth_scroll_options = apply_filters('tc_smoothscroll_options', array( 'touchpadSupport' => false ) );
 
       //smart load
-      $smart_load_enabled   = esc_attr( TC_utils::$inst->tc_opt( 'tc_img_smart_load' ) );
+      $smart_load_enabled   = esc_attr( CZR_utils::$inst->tc_opt( 'tc_img_smart_load' ) );
       $smart_load_opts      = apply_filters( 'tc_img_smart_load_options' , array(
             'parentSelectors' => array(
                 '.article-container', '.__before_main_wrapper', '.widget-front',
@@ -245,9 +245,9 @@ if ( ! class_exists( 'TC_resources' ) ) :
             )
       ));
 			//gets current screen layout
-    	$screen_layout      = TC_utils::tc_get_layout( TC_utils::tc_id() , 'sidebar'  );
+    	$screen_layout      = CZR_utils::tc_get_layout( CZR_utils::tc_id() , 'sidebar'  );
     	//gets the global layout settings
-    	$global_layout      = apply_filters( 'tc_global_layout' , TC_init::$instance -> global_layout );
+    	$global_layout      = apply_filters( 'tc_global_layout' , CZR_init::$instance -> global_layout );
     	$sidebar_layout     = isset($global_layout[$screen_layout]['sidebar']) ? $global_layout[$screen_layout]['sidebar'] : false;
 			//Gets the left and right sidebars class for js actions
 			$left_sb_class     	= sprintf( '.%1$s.left.tc-sidebar', (false != $sidebar_layout) ? $sidebar_layout : 'span3' );
@@ -259,39 +259,39 @@ if ( ! class_exists( 'TC_resources' ) ) :
 	        apply_filters( 'tc_customizr_script_params' , array(
 	          	'_disabled'          => apply_filters( 'tc_disabled_front_js_parts', array() ),
               'FancyBoxState' 		=> $this -> tc_is_fancyboxjs_required(),
-	          	'FancyBoxAutoscale' => ( 1 == TC_utils::$inst->tc_opt( 'tc_fancybox_autoscale') ) ? true : false,
+	          	'FancyBoxAutoscale' => ( 1 == CZR_utils::$inst->tc_opt( 'tc_fancybox_autoscale') ) ? true : false,
 	          	'SliderName' 			  => $js_slidername,
 	          	'SliderDelay' 			=> $js_sliderdelay,
 	          	'SliderHover'			  => apply_filters( 'tc_stop_slider_hover', true ),
-	          	'centerSliderImg'   => esc_attr( TC_utils::$inst->tc_opt( 'tc_center_slider_img') ),
+	          	'centerSliderImg'   => esc_attr( CZR_utils::$inst->tc_opt( 'tc_center_slider_img') ),
               'SmoothScroll'      => array( 'Enabled' => $smooth_scroll_enabled, 'Options' => $smooth_scroll_options ),
               'anchorSmoothScroll'			=> $anchor_smooth_scroll,
               'anchorSmoothScrollExclude' => $anchor_smooth_scroll_exclude,
-	          	'ReorderBlocks' 		=> esc_attr( TC_utils::$inst->tc_opt( 'tc_block_reorder') ),
-	          	'centerAllImg' 			=> esc_attr( TC_utils::$inst->tc_opt( 'tc_center_img') ),
+	          	'ReorderBlocks' 		=> esc_attr( CZR_utils::$inst->tc_opt( 'tc_block_reorder') ),
+	          	'centerAllImg' 			=> esc_attr( CZR_utils::$inst->tc_opt( 'tc_center_img') ),
 	          	'HasComments' 			=> $has_post_comments,
 	          	'LeftSidebarClass' 		=> $left_sb_class,
 	          	'RightSidebarClass' 	=> $right_sb_class,
 	          	'LoadModernizr' 		=> apply_filters( 'tc_load_modernizr' , true ),
 	          	'stickyCustomOffset' 	=> apply_filters( 'tc_sticky_custom_offset' , array( "_initial" => 0, "_scrolling" => 0, "options" => array( "_static" => true, "_element" => "" ) ) ),
-	          	'stickyHeader' 			=> esc_attr( TC_utils::$inst->tc_opt( 'tc_sticky_header' ) ),
-	          	'dropdowntoViewport' 	=> esc_attr( TC_utils::$inst->tc_opt( 'tc_menu_resp_dropdown_limit_to_viewport') ),
+	          	'stickyHeader' 			=> esc_attr( CZR_utils::$inst->tc_opt( 'tc_sticky_header' ) ),
+	          	'dropdowntoViewport' 	=> esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_resp_dropdown_limit_to_viewport') ),
 	          	'timerOnScrollAllBrowsers' => apply_filters( 'tc_timer_on_scroll_for_all_browser' , true), //<= if false, for ie only
-              'extLinksStyle'       => esc_attr( TC_utils::$inst->tc_opt( 'tc_ext_link_style' ) ),
-              'extLinksTargetExt'   => esc_attr( TC_utils::$inst->tc_opt( 'tc_ext_link_target' ) ),
+              'extLinksStyle'       => esc_attr( CZR_utils::$inst->tc_opt( 'tc_ext_link_style' ) ),
+              'extLinksTargetExt'   => esc_attr( CZR_utils::$inst->tc_opt( 'tc_ext_link_target' ) ),
               'extLinksSkipSelectors'   => apply_filters( 'tc_ext_links_skip_selectors' , array( 'classes' => array('btn', 'button') , 'ids' => array() ) ),
-              'dropcapEnabled'      => esc_attr( TC_utils::$inst->tc_opt( 'tc_enable_dropcap' ) ),
-              'dropcapWhere'      => array( 'post' => esc_attr( TC_utils::$inst->tc_opt( 'tc_post_dropcap' ) ) , 'page' => esc_attr( TC_utils::$inst->tc_opt( 'tc_page_dropcap' ) ) ),
-              'dropcapMinWords'     => esc_attr( TC_utils::$inst->tc_opt( 'tc_dropcap_minwords' ) ),
+              'dropcapEnabled'      => esc_attr( CZR_utils::$inst->tc_opt( 'tc_enable_dropcap' ) ),
+              'dropcapWhere'      => array( 'post' => esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_dropcap' ) ) , 'page' => esc_attr( CZR_utils::$inst->tc_opt( 'tc_page_dropcap' ) ) ),
+              'dropcapMinWords'     => esc_attr( CZR_utils::$inst->tc_opt( 'tc_dropcap_minwords' ) ),
               'dropcapSkipSelectors'  => apply_filters( 'tc_dropcap_skip_selectors' , array( 'tags' => array('IMG' , 'IFRAME', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'BLOCKQUOTE', 'UL', 'OL'), 'classes' => array('btn') , 'id' => array() ) ),
               'imgSmartLoadEnabled' => $smart_load_enabled,
               'imgSmartLoadOpts'    => $smart_load_opts,
               'goldenRatio'         => apply_filters( 'tc_grid_golden_ratio' , 1.618 ),
-              'gridGoldenRatioLimit' => esc_attr( TC_utils::$inst->tc_opt( 'tc_grid_thumb_height' ) ),
-              'isSecondMenuEnabled'  => TC_utils::$inst->tc_is_secondary_menu_enabled(),
-              'secondMenuRespSet'   => esc_attr( TC_utils::$inst->tc_opt( 'tc_second_menu_resp_setting' ) )
+              'gridGoldenRatioLimit' => esc_attr( CZR_utils::$inst->tc_opt( 'tc_grid_thumb_height' ) ),
+              'isSecondMenuEnabled'  => CZR_utils::$inst->tc_is_secondary_menu_enabled(),
+              'secondMenuRespSet'   => esc_attr( CZR_utils::$inst->tc_opt( 'tc_second_menu_resp_setting' ) )
 	        	),
-	        	TC_utils::tc_id()
+	        	CZR_utils::tc_id()
 		    )//end of filter
 	     );
 
@@ -300,7 +300,7 @@ if ( ! class_exists( 'TC_resources' ) ) :
 	      wp_enqueue_style( 'fancyboxcss' , TC_BASE_URL . 'inc/assets/js/fancybox/jquery.fancybox-1.3.4.min.css' );
 
 	    //holder.js is loaded when featured pages are enabled AND FP are set to show images and at least one holder should be displayed.
-      $tc_show_featured_pages 	         = class_exists('TC_featured_pages') && TC_featured_pages::$instance -> tc_show_featured_pages();
+      $tc_show_featured_pages 	         = class_exists('CZR_featured_pages') && CZR_featured_pages::$instance -> tc_show_featured_pages();
     	if ( 0 != $tc_show_featured_pages && $this -> tc_maybe_is_holder_js_required() ) {
 	    	wp_enqueue_script(
 	    		'holder',
@@ -312,7 +312,7 @@ if ( ! class_exists( 'TC_resources' ) ) :
 	    }
 
 	    //load retina.js in footer if enabled
-	    if ( apply_filters('tc_load_retinajs', 1 == TC_utils::$inst->tc_opt( 'tc_retina_support' ) ) )
+	    if ( apply_filters('tc_load_retinajs', 1 == CZR_utils::$inst->tc_opt( 'tc_retina_support' ) ) )
 	    	wp_enqueue_script( 'retinajs' ,TC_BASE_URL . 'inc/assets/js/retina.min.js', array(), CUSTOMIZR_VER, $in_footer = true);
 
 	    //Load hammer.js for mobile
@@ -346,7 +346,7 @@ if ( ! class_exists( 'TC_resources' ) ) :
     * @since Customizr 3.3.2
     */
     public function tc_get_inline_font_icons_css() {
-      if ( false == TC_utils::$inst -> tc_opt( 'tc_font_awesome_icons' ) )
+      if ( false == CZR_utils::$inst -> tc_opt( 'tc_font_awesome_icons' ) )
         return;
 
       $_path = apply_filters( 'tc_font_icons_path' , TC_BASE_URL . 'inc/assets/css' );
@@ -376,14 +376,14 @@ if ( ! class_exists( 'TC_resources' ) ) :
     */
     function tc_write_custom_css( $_css = null ) {
       $_css               = isset($_css) ? $_css : '';
-      $tc_custom_css      = esc_html( TC_utils::$inst->tc_opt( 'tc_custom_css') );
+      $tc_custom_css      = esc_html( CZR_utils::$inst->tc_opt( 'tc_custom_css') );
       if ( ! isset($tc_custom_css) || empty($tc_custom_css) )
         return $_css;
 
       return apply_filters( 'tc_write_custom_css',
         $_css . "\n" . html_entity_decode( $tc_custom_css ),
         $_css,
-        TC_utils::$inst->tc_opt( 'tc_custom_css')
+        CZR_utils::$inst->tc_opt( 'tc_custom_css')
       );
     }//end of function
 
@@ -410,14 +410,14 @@ if ( ! class_exists( 'TC_resources' ) ) :
     * @since Customizr 3.2.9
     */
     function tc_enqueue_gfonts() {
-      $_font_pair         = esc_attr( TC_utils::$inst->tc_opt( 'tc_fonts' ) );
-      $_all_font_pairs    = TC_init::$instance -> font_pairs;
+      $_font_pair         = esc_attr( CZR_utils::$inst->tc_opt( 'tc_fonts' ) );
+      $_all_font_pairs    = CZR_init::$instance -> font_pairs;
       if ( ! $this -> tc_is_gfont( $_font_pair , '_g_') )
         return;
 
       wp_enqueue_style(
         'tc-gfonts',
-        sprintf( '//fonts.googleapis.com/css?family=%s', TC_utils::$inst -> tc_get_font( 'single' , $_font_pair ) ),
+        sprintf( '//fonts.googleapis.com/css?family=%s', CZR_utils::$inst -> tc_get_font( 'single' , $_font_pair ) ),
         array(),
         null,
         'all'
@@ -435,12 +435,12 @@ if ( ! class_exists( 'TC_resources' ) ) :
     */
     function tc_write_fonts_inline_css( $_css = null , $_context = null ) {
       $_css               = isset($_css) ? $_css : '';
-      $_font_pair         = esc_attr( TC_utils::$inst->tc_opt( 'tc_fonts' ) );
-      $_body_font_size    = esc_attr( TC_utils::$inst->tc_opt( 'tc_body_font_size' ) );
-      $_font_selectors    = TC_init::$instance -> font_selectors;
+      $_font_pair         = esc_attr( CZR_utils::$inst->tc_opt( 'tc_fonts' ) );
+      $_body_font_size    = esc_attr( CZR_utils::$inst->tc_opt( 'tc_body_font_size' ) );
+      $_font_selectors    = CZR_init::$instance -> font_selectors;
 
       //create the $body and $titles vars
-      extract( TC_init::$instance -> font_selectors, EXTR_OVERWRITE );
+      extract( CZR_init::$instance -> font_selectors, EXTR_OVERWRITE );
 
       if ( ! isset($body) || ! isset($titles) )
         return;
@@ -455,7 +455,7 @@ if ( ! class_exists( 'TC_resources' ) ) :
       $body   = apply_filters('tc_body_fonts_selectors' , $body );
 
       if ( 'helvetica_arial' != $_font_pair ) {//check if not default
-        $_selector_fonts  = explode( '|', TC_utils::$inst -> tc_get_font( 'single' , $_font_pair ) );
+        $_selector_fonts  = explode( '|', CZR_utils::$inst -> tc_get_font( 'single' , $_font_pair ) );
         if ( ! is_array($_selector_fonts) )
           return $_css;
 
@@ -518,13 +518,13 @@ if ( ! class_exists( 'TC_resources' ) ) :
     */
     function tc_write_dropcap_inline_css( $_css = null , $_context = null ) {
       $_css               = isset($_css) ? $_css : '';
-      if ( ! esc_attr( TC_utils::$inst->tc_opt( 'tc_enable_dropcap' ) ) )
+      if ( ! esc_attr( CZR_utils::$inst->tc_opt( 'tc_enable_dropcap' ) ) )
         return $_css;
 
-      $_main_color_pair = TC_utils::$inst -> tc_get_skin_color( 'pair' );
+      $_main_color_pair = CZR_utils::$inst -> tc_get_skin_color( 'pair' );
       $_color           = $_main_color_pair[0];
       $_shad_color      = $_main_color_pair[1];
-      $_pad_right       = false !== strpos( esc_attr( TC_utils::$inst->tc_opt( 'tc_fonts' ) ), 'lobster' ) ? 26 : 8;
+      $_pad_right       = false !== strpos( esc_attr( CZR_utils::$inst->tc_opt( 'tc_fonts' ) ), 'lobster' ) ? 26 : 8;
       $_css .= "
         .tc-dropcap {
           color: {$_color};
@@ -554,11 +554,11 @@ if ( ! class_exists( 'TC_resources' ) ) :
     * @since Customizr 3.3+
     */
     function tc_set_random_skin ( $_skin ) {
-      if ( false == esc_attr( TC_utils::$inst -> tc_opt( 'tc_skin_random' ) ) )
+      if ( false == esc_attr( CZR_utils::$inst -> tc_opt( 'tc_skin_random' ) ) )
         return $_skin;
 
       //allow custom skins to be taken in account
-      $_skins = apply_filters( 'tc_get_skin_color', TC_init::$instance -> skin_color_map, 'all' );
+      $_skins = apply_filters( 'tc_get_skin_color', CZR_init::$instance -> skin_color_map, 'all' );
 
       //allow users to filter the list of skins they want to randomize
       $_skins = apply_filters( 'tc_skins_to_randomize', $_skins );
@@ -662,7 +662,7 @@ if ( ! class_exists( 'TC_resources' ) ) :
     * @since v3.3+
     */
     function tc_load_concatenated_front_scripts() {
-      return apply_filters( 'tc_load_concatenated_front_scripts' , ! defined('TC_DEV')  || ( defined('TC_DEV') && false == TC_DEV ) );
+      return apply_filters( 'tc_load_concatenated_front_scripts' , ! defined('CZR_DEV')  || ( defined('CZR_DEV') && false == CZR_DEV ) );
     }
 
     /**
@@ -673,7 +673,7 @@ if ( ! class_exists( 'TC_resources' ) ) :
     * @since v3.3+
     */
     private function tc_is_fancyboxjs_required() {
-      return TC_utils::$inst -> tc_opt( 'tc_fancybox' ) || TC_utils::$inst -> tc_opt( 'tc_gallery_fancybox');
+      return CZR_utils::$inst -> tc_opt( 'tc_fancybox' ) || CZR_utils::$inst -> tc_opt( 'tc_gallery_fancybox');
     }
 
     /**
@@ -686,19 +686,19 @@ if ( ! class_exists( 'TC_resources' ) ) :
     function tc_maybe_is_holder_js_required(){
       $bool = false;
 
-      if ( ! ( class_exists('TC_featured_pages') && TC_featured_pages::$instance -> tc_show_featured_pages_img() ) )
+      if ( ! ( class_exists('CZR_featured_pages') && CZR_featured_pages::$instance -> tc_show_featured_pages_img() ) )
         return $bool;
 
-      $fp_ids = apply_filters( 'tc_featured_pages_ids' , TC_init::$instance -> fp_ids);
+      $fp_ids = apply_filters( 'tc_featured_pages_ids' , CZR_init::$instance -> fp_ids);
 
       foreach ( $fp_ids as $fp_single_id ){
-        $featured_page_id = TC_utils::$inst->tc_opt( 'tc_featured_page_'.$fp_single_id );
-        if ( null == $featured_page_id || ! $featured_page_id || ! TC_featured_pages::$instance -> tc_get_fp_img( null, $featured_page_id, null ) ) {
+        $featured_page_id = CZR_utils::$inst->tc_opt( 'tc_featured_page_'.$fp_single_id );
+        if ( null == $featured_page_id || ! $featured_page_id || ! CZR_featured_pages::$instance -> tc_get_fp_img( null, $featured_page_id, null ) ) {
           $bool = true;
           break;
         }
       }
       return $bool;
     }
-  }//end of TC_ressources
+  }//end of CZR_ressources
 endif;

--- a/inc/class-fire-utils.php
+++ b/inc/class-fire-utils.php
@@ -28,33 +28,33 @@ if ( ! class_exists( 'CZR_utils' ) ) :
         self::$instance =& $this;
 
         //init properties
-        add_action( 'after_setup_theme'       , array( $this , 'czr_init_properties') );
+        add_action( 'after_setup_theme'       , array( $this , 'czr_fn_init_properties') );
 
         //Various WP filters for
         //content
         //thumbnails => parses image if smartload enabled
         //title
-        add_action( 'wp_head'                 , array( $this , 'czr_wp_filters') );
+        add_action( 'wp_head'                 , array( $this , 'czr_fn_wp_filters') );
 
         //get all options
-        add_filter( '__options'               , array( $this , 'czr_get_theme_options' ), 10, 1);
+        add_filter( '__options'               , array( $this , 'czr_fn_get_theme_options' ), 10, 1);
         //get single option
-        add_filter( '__get_option'            , array( $this , 'czr_opt' ), 10, 2 );//deprecated
+        add_filter( '__get_option'            , array( $this , 'czr_fn_opt' ), 10, 2 );//deprecated
 
         //some useful filters
-        add_filter( '__ID'                    , array( $this , 'czr_id' ));//deprecated
-        add_filter( '__screen_layout'         , array( $this , 'czr_get_layout' ) , 10 , 2 );//deprecated
-        add_filter( '__is_home'               , array( $this , 'czr_is_home' ) );
-        add_filter( '__is_home_empty'         , array( $this , 'czr_is_home_empty' ) );
-        add_filter( '__post_type'             , array( $this , 'czr_get_post_type' ) );
-        add_filter( '__is_no_results'         , array( $this , 'czr_is_no_results') );
-        add_filter( '__article_selectors'     , array( $this , 'czr_article_selectors' ) );
+        add_filter( '__ID'                    , array( $this , 'czr_fn_id' ));//deprecated
+        add_filter( '__screen_layout'         , array( $this , 'czr_fn_get_layout' ) , 10 , 2 );//deprecated
+        add_filter( '__is_home'               , array( $this , 'czr_fn_is_home' ) );
+        add_filter( '__is_home_empty'         , array( $this , 'czr_fn_is_home_empty' ) );
+        add_filter( '__post_type'             , array( $this , 'czr_fn_get_post_type' ) );
+        add_filter( '__is_no_results'         , array( $this , 'czr_fn_is_no_results') );
+        add_filter( '__article_selectors'     , array( $this , 'czr_fn_article_selectors' ) );
 
         //social networks
-        add_filter( '__get_socials'           , array( $this , 'czr_get_social_networks' ) );
+        add_filter( '__get_socials'           , array( $this , 'czr_fn_get_social_networks' ) );
 
         //refresh the theme options right after the _preview_filter when previewing
-        add_action( 'customize_preview_init'  , array( $this , 'czr_customize_refresh_db_opt' ) );
+        add_action( 'customize_preview_init'  , array( $this , 'czr_fn_customize_refresh_db_opt' ) );
       }
 
       /***************************
@@ -69,13 +69,13 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 3.2.3
       */
-      function czr_init_properties() {
+      function czr_fn_init_properties() {
         //all customizr theme options start by "tc_" by convention
         $this -> tc_options_prefixes = apply_filters('tc_options_prefixes', array('tc_') );
-        $this -> is_customizing   = CZR___::$instance -> czr_is_customizing();
+        $this -> is_customizing   = CZR___::$instance -> czr_fn_is_customizing();
         $this -> db_options       = false === get_option( CZR___::$tc_option_group ) ? array() : (array)get_option( CZR___::$tc_option_group );
-        $this -> default_options  = $this -> czr_get_default_options();
-        $_trans                   = CZR___::czr_is_pro() ? 'started_using_customizr_pro' : 'started_using_customizr';
+        $this -> default_options  = $this -> czr_fn_get_default_options();
+        $_trans                   = CZR___::czr_fn_is_pro() ? 'started_using_customizr_pro' : 'started_using_customizr';
 
         //What was the theme version when the user started to use Customizr?
         //new install = no options yet
@@ -96,13 +96,13 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 3.3.0
       */
-      function czr_wp_filters() {
-        add_filter( 'the_content'                         , array( $this , 'czr_fancybox_content_filter' ) );
-        if ( esc_attr( CZR_utils::$inst->czr_opt( 'tc_img_smart_load' ) ) ) {
-          add_filter( 'the_content'                       , array( $this , 'czr_parse_imgs' ), PHP_INT_MAX );
-          add_filter( 'tc_thumb_html'                     , array( $this , 'czr_parse_imgs' ) );
+      function czr_fn_wp_filters() {
+        add_filter( 'the_content'                         , array( $this , 'czr_fn_fancybox_content_filter' ) );
+        if ( esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_img_smart_load' ) ) ) {
+          add_filter( 'the_content'                       , array( $this , 'czr_fn_parse_imgs' ), PHP_INT_MAX );
+          add_filter( 'tc_thumb_html'                     , array( $this , 'czr_fn_parse_imgs' ) );
         }
-        add_filter( 'wp_title'                            , array( $this , 'czr_wp_title' ), 10, 2 );
+        add_filter( 'wp_title'                            , array( $this , 'czr_fn_wp_title' ), 10, 2 );
       }
 
 
@@ -114,11 +114,11 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 3.3.0
       */
-      function czr_parse_imgs( $_html ) {
+      function czr_fn_parse_imgs( $_html ) {
         if( is_feed() || is_preview() || ( wp_is_mobile() && apply_filters('tc_disable_img_smart_load_mobiles', false ) ) )
           return $_html;
 
-        return preg_replace_callback('#<img([^>]+?)src=[\'"]?([^\'"\s>]+)[\'"]?([^>]*)>#', array( $this , 'czr_regex_callback' ) , $_html);
+        return preg_replace_callback('#<img([^>]+?)src=[\'"]?([^\'"\s>]+)[\'"]?([^>]*)>#', array( $this , 'czr_fn_regex_callback' ) , $_html);
       }
 
 
@@ -130,7 +130,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 3.3.0
       */
-      private function czr_regex_callback( $matches ) {
+      private function czr_fn_regex_callback( $matches ) {
         $_placeholder = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
         if ( false !== strpos( $matches[0], 'data-src' ) ||
@@ -158,11 +158,11 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 3.1.23
       */
-      function czr_get_skin_color( $_what = null ) {
+      function czr_fn_get_skin_color( $_what = null ) {
         $_color_map    = CZR_init::$instance -> skin_color_map;
         $_color_map    = ( is_array($_color_map) ) ? $_color_map : array();
 
-        $_active_skin =  str_replace('.min.', '.', basename( CZR_init::$instance -> czr_get_style_src() ) );
+        $_active_skin =  str_replace('.min.', '.', basename( CZR_init::$instance -> czr_fn_get_style_src() ) );
         //falls back to blue3 ( default #27CDA5 ) if not defined
         $_to_return = array( '#27CDA5', '#1b8d71' );
 
@@ -179,7 +179,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
             $_to_return = ( false != $_active_skin && isset($_color_map[$_active_skin][0]) ) ? $_color_map[$_active_skin][0] : $_to_return[0];
           break;
         }
-        return apply_filters( 'czr_get_skin_color' , $_to_return , $_what );
+        return apply_filters( 'czr_fn_get_skin_color' , $_to_return , $_what );
       }
 
 
@@ -194,9 +194,9 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 3.4.9
       */
-      function czr_is_customizr_option( $option_key ) {
+      function czr_fn_is_customizr_option( $option_key ) {
         $_is_tc_option = in_array( substr( $option_key, 0, 3 ), $this -> tc_options_prefixes );
-        return apply_filters( 'czr_is_customizr_option', $_is_tc_option , $option_key );
+        return apply_filters( 'czr_fn_is_customizr_option', $_is_tc_option , $option_key );
       }
 
 
@@ -207,8 +207,8 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 3.1.11
       */
-      function czr_get_default_options() {
-        $_db_opts     = empty($this -> db_options) ? $this -> czr_cache_db_options() : $this -> db_options;
+      function czr_fn_get_default_options() {
+        $_db_opts     = empty($this -> db_options) ? $this -> czr_fn_cache_db_options() : $this -> db_options;
         $def_options  = isset($_db_opts['defaults']) ? $_db_opts['defaults'] : array();
 
         //Don't update if default options are not empty + customizing context
@@ -223,7 +223,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
         // 3) theme version not defined
         // 4) versions are different
         if ( is_user_logged_in() || empty($def_options) || ! isset($def_options['ver']) || 0 != version_compare( $def_options['ver'] , CUSTOMIZR_VER ) ) {
-          $def_options          = $this -> czr_generate_default_options( CZR_utils_settings_map::$instance -> czr_get_customizer_map( $get_default_option = 'true' ) , 'tc_theme_options' );
+          $def_options          = $this -> czr_fn_generate_default_options( CZR_utils_settings_map::$instance -> czr_fn_get_customizer_map( $get_default_option = 'true' ) , 'tc_theme_options' );
           //Adds the version in default
           $def_options['ver']   =  CUSTOMIZR_VER;
 
@@ -243,7 +243,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 3.0.3
       */
-      function czr_generate_default_options( $map, $option_group = null ) {
+      function czr_fn_generate_default_options( $map, $option_group = null ) {
         //do we have to look in a specific group of option (plugin?)
         $option_group   = is_null($option_group) ? 'tc_theme_options' : $option_group;
 
@@ -252,7 +252,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
 
         foreach ($map['add_setting_control'] as $key => $options) {
           //check it is a customizr option
-          if(  ! $this -> czr_is_customizr_option( $key ) )
+          if(  ! $this -> czr_fn_is_customizr_option( $key ) )
             continue;
 
           $option_name = $key;
@@ -275,10 +275,10 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @since Customizr 1.0
       *
       */
-      function czr_get_theme_options ( $option_group = null ) {
+      function czr_fn_get_theme_options ( $option_group = null ) {
           //do we have to look in a specific group of option (plugin?)
           $option_group       = is_null($option_group) ? CZR___::$tc_option_group : $option_group;
-          $saved              = empty($this -> db_options) ? $this -> czr_cache_db_options() : $this -> db_options;
+          $saved              = empty($this -> db_options) ? $this -> czr_fn_cache_db_options() : $this -> db_options;
           $defaults           = $this -> default_options;
           $__options          = wp_parse_args( $saved, $defaults );
           //$__options        = array_intersect_key( $__options, $defaults );
@@ -294,11 +294,11 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 1.0
       */
-      function czr_opt( $option_name , $option_group = null, $use_default = true ) {
+      function czr_fn_opt( $option_name , $option_group = null, $use_default = true ) {
         //do we have to look for a specific group of option (plugin?)
         $option_group = is_null($option_group) ? CZR___::$tc_option_group : $option_group;
         //when customizing, the db_options property is refreshed each time the preview is refreshed in 'customize_preview_init'
-        $_db_options  = empty($this -> db_options) ? $this -> czr_cache_db_options() : $this -> db_options;
+        $_db_options  = empty($this -> db_options) ? $this -> czr_fn_cache_db_options() : $this -> db_options;
 
         //do we have to use the default ?
         $__options    = $_db_options;
@@ -315,7 +315,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
 
         //ctx retro compat => falls back to default val if ctx like option detected
         //important note : some options like tc_slider are not concerned by ctx
-        if ( ! $this -> czr_is_option_excluded_from_ctx( $option_name ) ) {
+        if ( ! $this -> czr_fn_is_option_excluded_from_ctx( $option_name ) ) {
           if ( is_array( $_single_opt ) && ! class_exists( 'CZR_contx' ) )
             $_single_opt = $_default_val;
         }
@@ -341,7 +341,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       *
       * @since  v3.4+
       */
-      function czr_customize_refresh_db_opt(){
+      function czr_fn_customize_refresh_db_opt(){
         $this -> db_options = false === get_option( CZR___::$tc_option_group ) ? array() : (array)get_option( CZR___::$tc_option_group );
       }
 
@@ -357,9 +357,9 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 3.4+
       */
-      function czr_set_option( $option_name , $option_value, $option_group = null ) {
+      function czr_fn_set_option( $option_name , $option_value, $option_group = null ) {
         $option_group           = is_null($option_group) ? CZR___::$tc_option_group : $option_group;
-        $_options               = $this -> czr_get_theme_options( $option_group );
+        $_options               = $this -> czr_fn_get_theme_options( $option_group );
         $_options[$option_name] = $option_value;
 
         update_option( $option_group, $_options );
@@ -373,7 +373,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 3.2.0
       */
-      function czr_cache_db_options($opt_group = null) {
+      function czr_fn_cache_db_options($opt_group = null) {
         $opts_group = is_null($opt_group) ? CZR___::$tc_option_group : $opt_group;
         $this -> db_options = false === get_option( $opt_group ) ? array() : (array)get_option( $opt_group );
         return $this -> db_options;
@@ -389,7 +389,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 1.0
       */
-      public static function czr_id()  {
+      public static function czr_fn_id()  {
         if ( in_the_loop() ) {
           $tc_id            = get_the_ID();
         } else {
@@ -410,8 +410,8 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 1.0
       */
-      public static function czr_get_layout( $post_id , $sidebar_or_class = 'class' ) {
-          $__options                    = czr__f ( '__options' );
+      public static function czr_fn_get_layout( $post_id , $sidebar_or_class = 'class' ) {
+          $__options                    = czr_fn__f ( '__options' );
           global $post;
           //Article wrapper class definition
           $global_layout                = apply_filters( 'tc_global_layout' , CZR_init::$instance -> global_layout );
@@ -486,8 +486,8 @@ if ( ! class_exists( 'CZR_utils' ) ) :
        * @package Customizr
        * @since Customizr 2.0.7
        */
-      function czr_fancybox_content_filter( $content) {
-        $tc_fancybox = esc_attr( CZR_utils::$inst->czr_opt( 'tc_fancybox' ) );
+      function czr_fn_fancybox_content_filter( $content) {
+        $tc_fancybox = esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_fancybox' ) );
 
         if ( 1 != $tc_fancybox )
           return $content;
@@ -500,7 +500,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
         $replacement = '<a$1href=$2$3.$4$5 class="grouped_elements" rel="tc-fancybox-group'.$post -> ID.'"$6>';
         $r_content = preg_replace( $pattern, $replacement, $content);
         $content = $r_content ? $r_content : $content;
-        return apply_filters( 'czr_fancybox_content_filter', $content );
+        return apply_filters( 'czr_fn_fancybox_content_filter', $content );
       }
 
 
@@ -512,7 +512,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @since Customizr 2.1.6
       *
       */
-      function czr_wp_title( $title, $sep ) {
+      function czr_fn_wp_title( $title, $sep ) {
         if ( function_exists( '_wp_render_title_tag' ) )
           return $title;
 
@@ -526,7 +526,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
 
         // Add the site description for the home/front page.
         $site_description = get_bloginfo( 'description' , 'display' );
-        if ( $site_description && czr__f('__is_home') )
+        if ( $site_description && czr_fn__f('__is_home') )
           $title = "$title $sep $site_description";
 
         // Add a page number if necessary.
@@ -545,7 +545,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @since Customizr 3.0.6
       *
       */
-      function czr_is_home() {
+      function czr_fn_is_home() {
         //get info whether the front page is a list of last posts or a page
         return ( is_home() && ( 'posts' == get_option( 'show_on_front' ) || 'nothing' == get_option( 'show_on_front' ) ) ) || is_front_page();
       }
@@ -560,7 +560,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @since Customizr 3.0.6
       *
       */
-      function czr_is_home_empty() {
+      function czr_fn_is_home_empty() {
         //check if the users has choosen the "no posts or page" option for home page
         return ( ( is_home() || is_front_page() ) && 'nothing' == get_option( 'show_on_front' ) ) ? true : false;
       }
@@ -574,7 +574,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @since Customizr 3.0.10
       *
       */
-      function czr_get_post_type() {
+      function czr_fn_get_post_type() {
         global $post;
 
         if ( ! isset($post) )
@@ -596,7 +596,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since 3.0.10
       */
-      function czr_get_post_class( $class = '', $post_id = null ) {
+      function czr_fn_get_post_class( $class = '', $post_id = null ) {
         //Separates classes with a single space, collates classes for post DIV
         return 'class="' . join( ' ', get_post_class( $class, $post_id ) ) . '"';
       }
@@ -612,7 +612,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since 3.0.10
       */
-      function czr_is_no_results() {
+      function czr_fn_is_no_results() {
         global $wp_query;
         return ( is_search() && 0 == $wp_query -> post_count ) ? true : false;
       }
@@ -627,7 +627,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since 3.1.0
       */
-      function czr_article_selectors() {
+      function czr_fn_article_selectors() {
 
         //gets global vars
         global $post;
@@ -638,20 +638,20 @@ if ( ! class_exists( 'CZR_utils' ) ) :
 
         // SINGLE POST
         $single_post_selector_bool  = isset($post) && 'page' != $post -> post_type && 'attachment' != $post -> post_type && is_singular();
-        $selectors                  = $single_post_selector_bool ? apply_filters( 'tc_single_post_selectors' ,'id="post-'.get_the_ID().'" '.$this -> czr_get_post_class('row-fluid') ) : $selectors;
+        $selectors                  = $single_post_selector_bool ? apply_filters( 'tc_single_post_selectors' ,'id="post-'.get_the_ID().'" '.$this -> czr_fn_get_post_class('row-fluid') ) : $selectors;
 
         // POST LIST
-        $post_list_selector_bool    = ( isset($post) && !is_singular() && !is_404() && !czr__f( '__is_home_empty') ) || ( is_search() && 0 != $wp_query -> post_count );
-        $selectors                  = $post_list_selector_bool ? apply_filters( 'tc_post_list_selectors' , 'id="post-'.get_the_ID().'" '.$this -> czr_get_post_class('row-fluid') ) : $selectors;
+        $post_list_selector_bool    = ( isset($post) && !is_singular() && !is_404() && !czr_fn__f( '__is_home_empty') ) || ( is_search() && 0 != $wp_query -> post_count );
+        $selectors                  = $post_list_selector_bool ? apply_filters( 'tc_post_list_selectors' , 'id="post-'.get_the_ID().'" '.$this -> czr_fn_get_post_class('row-fluid') ) : $selectors;
 
         // PAGE
-        $page_selector_bool         = isset($post) && 'page' == czr__f('__post_type') && is_singular() && !czr__f( '__is_home_empty');
-        $selectors                  = $page_selector_bool ? apply_filters( 'tc_page_selectors' , 'id="page-'.get_the_ID().'" '.$this -> czr_get_post_class('row-fluid') ) : $selectors;
+        $page_selector_bool         = isset($post) && 'page' == czr_fn__f('__post_type') && is_singular() && !czr_fn__f( '__is_home_empty');
+        $selectors                  = $page_selector_bool ? apply_filters( 'tc_page_selectors' , 'id="page-'.get_the_ID().'" '.$this -> czr_fn_get_post_class('row-fluid') ) : $selectors;
 
         // ATTACHMENT
         //checks if attachement is image and add a selector
         $format_image               = wp_attachment_is_image() ? 'format-image' : '';
-        $selectors                  = ( isset($post) && 'attachment' == $post -> post_type && is_singular() ) ? apply_filters( 'tc_attachment_selectors' , 'id="post-'.get_the_ID().'" '.$this -> czr_get_post_class(array('row-fluid', $format_image) ) ) : $selectors;
+        $selectors                  = ( isset($post) && 'attachment' == $post -> post_type && is_singular() ) ? apply_filters( 'tc_attachment_selectors' , 'id="post-'.get_the_ID().'" '.$this -> czr_fn_get_post_class(array('row-fluid', $format_image) ) ) : $selectors;
 
         // NO SEARCH RESULTS
         $selectors                  = ( is_search() && 0 == $wp_query -> post_count ) ? apply_filters( 'tc_no_results_selectors' , 'id="post-0" class="post error404 no-results not-found row-fluid"' ) : $selectors;
@@ -659,7 +659,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
         // 404
         $selectors                  = is_404() ? apply_filters( 'tc_404_selectors' , 'id="post-0" class="post error404 no-results not-found row-fluid"' ) : $selectors;
 
-        echo apply_filters( 'czr_article_selectors', $selectors );
+        echo apply_filters( 'czr_fn_article_selectors', $selectors );
 
       }//end of function
 
@@ -672,8 +672,8 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 3.0.10
       */
-      function czr_get_social_networks() {
-        $__options    = czr__f( '__options' );
+      function czr_fn_get_social_networks() {
+        $__options    = czr_fn__f( '__options' );
 
         //gets the social network array
         $socials      = apply_filters( 'tc_default_socials' , CZR_init::$instance -> socials );
@@ -688,7 +688,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
               if ( isset($data['custom_icon_url']) && @getimagesize($data['custom_icon_url']) ) { list( $width, $height ) = getimagesize($data['custom_icon_url']); }
               $type = isset( $data['type'] ) && ! empty( $data['type'] ) ? $data['type'] : 'url';
               $link = 'email' == $type ? 'mailto:' : '';
-              $link .=  call_user_func( array( CZR_utils_settings_map::$instance, 'czr_sanitize_'.$type ), $__options[$key] );
+              $link .=  call_user_func( array( CZR_utils_settings_map::$instance, 'czr_fn_sanitize_'.$type ), $__options[$key] );
               //there is one exception : rss feed has no target _blank and special icon title
               $html .= sprintf('<a class="%1$s" href="%2$s" title="%3$s" %4$s %5$s>%6$s</a>',
                   apply_filters( 'tc_social_link_class',
@@ -727,7 +727,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     * @param array  $mimes    Optional. Key is the file extension with value as the mime type.
     * @return array Values with extension first and mime type.
     */
-    function czr_check_filetype( $filename, $mimes = null ) {
+    function czr_fn_check_filetype( $filename, $mimes = null ) {
       $filename = basename( $filename );
       if ( empty($mimes) )
         $mimes = get_allowed_mime_types();
@@ -756,7 +756,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     * @param int $cat_id.
     * @return bool
     */
-    public function czr_category_id_exists( $cat_id ) {
+    public function czr_fn_category_id_exists( $cat_id ) {
       return term_exists( (int) $cat_id, 'category');
     }
 
@@ -771,7 +771,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     * @param date one object.
     * @param date two object.
     */
-    private function czr_date_diff( $_date_one , $_date_two ) {
+    private function czr_fn_date_diff( $_date_one , $_date_two ) {
       //if version is at least 5.3.0, use date_diff function
       if ( version_compare( PHP_VERSION, '5.3.0' ) >= 0) {
         return date_diff( $_date_one , $_date_two );
@@ -790,7 +790,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     * @package Customizr
     * @since Customizr 3.2.6
     */
-    function czr_post_has_update( $_bool = false) {
+    function czr_fn_post_has_update( $_bool = false) {
       //php version check for DateTime
       //http://php.net/manual/fr/class.datetime.php
       if ( version_compare( PHP_VERSION, '5.2.0' ) < 0 )
@@ -803,7 +803,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
         'current'   => date('Y-m-d g:i:s')
       );
       //ALL dates must be valid
-      if ( 1 != array_product( array_map( array($this , 'czr_is_date_valid') , $dates_to_check ) ) )
+      if ( 1 != array_product( array_map( array($this , 'czr_fn_is_date_valid') , $dates_to_check ) ) )
         return false;
 
       //Import variables into the current symbol table
@@ -814,8 +814,8 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       $updated                = new DateTime( $updated );
       $current                = new DateTime( $current );
 
-      $created_to_updated     = $this -> czr_date_diff( $created , $updated );
-      $updated_to_today       = $this -> czr_date_diff( $updated, $current );
+      $created_to_updated     = $this -> czr_fn_date_diff( $created , $updated );
+      $updated_to_today       = $this -> czr_fn_date_diff( $updated, $current );
 
       if ( true === $_bool )
         //return ( 0 == $created_to_updated -> days && 0 == $created_to_updated -> s ) ? false : true;
@@ -831,7 +831,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     * @return boolean
     * http://stackoverflow.com/questions/11343403/php-exception-handling-on-datetime-object
     */
-    private function czr_is_date_valid($str) {
+    private function czr_fn_is_date_valid($str) {
       if ( ! is_string($str) )
          return false;
 
@@ -854,7 +854,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     * @package Customizr
     * @since Customizr 3.2.9
     */
-    function czr_get_font( $_what = 'list' , $_requested = null ) {
+    function czr_fn_get_font( $_what = 'list' , $_requested = null ) {
       $_to_return = ( 'list' == $_what ) ? array() : false;
       $_font_groups = apply_filters(
         'tc_font_pairs',
@@ -901,8 +901,8 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     * @package Customizr
     * @since Customizr 3.2.9
     */
-    function czr_user_started_before_version( $_czr_ver, $_pro_ver = null ) {
-      $_ispro = CZR___::czr_is_pro();
+    function czr_fn_user_started_before_version( $_czr_ver, $_pro_ver = null ) {
+      $_ispro = CZR___::czr_fn_is_pro();
 
       if ( $_ispro && ! get_transient( 'started_using_customizr_pro' ) )
         return false;
@@ -942,8 +942,8 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     * Boolean helper to check if the secondary menu is enabled
     * since v3.4+
     */
-    function czr_is_secondary_menu_enabled() {
-      return (bool) esc_attr( CZR_utils::$inst->czr_opt( 'tc_display_second_menu' ) ) && 'aside' == esc_attr( CZR_utils::$inst->czr_opt( 'tc_menu_style' ) );
+    function czr_fn_is_secondary_menu_enabled() {
+      return (bool) esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_display_second_menu' ) ) && 'aside' == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_menu_style' ) );
     }
 
 
@@ -955,9 +955,9 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     * Helper : define a set of options not impacted by ctx like tc_slider, last_update_notice.
     * @return  array of excluded option names
     */
-    function czr_get_ctx_excluded_options() {
+    function czr_fn_get_ctx_excluded_options() {
       return apply_filters(
-        'czr_get_ctx_excluded_options',
+        'czr_fn_get_ctx_excluded_options',
         array(
           'defaults',
           'tc_sliders',
@@ -973,8 +973,8 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     * Boolean helper : tells if this option is excluded from the ctx treatments.
     * @return bool
     */
-    function czr_is_option_excluded_from_ctx( $opt_name ) {
-      return in_array( $opt_name, $this -> czr_get_ctx_excluded_options() );
+    function czr_fn_is_option_excluded_from_ctx( $opt_name ) {
+      return in_array( $opt_name, $this -> czr_fn_get_ctx_excluded_options() );
     }
 
 
@@ -993,7 +993,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     * @return url string
     * @since Customizr 3.4+
     */
-    static function czr_get_customizer_url( $autofocus = null, $control_wrapper = 'tc_theme_options' ) {
+    static function czr_fn_get_customizer_url( $autofocus = null, $control_wrapper = 'tc_theme_options' ) {
       $_current_url       = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
       $_customize_url     = add_query_arg( 'url', urlencode( $_current_url ), wp_customize_url() );
       $autofocus  = ( ! is_array($autofocus) || empty($autofocus) ) ? null : $autofocus;
@@ -1020,7 +1020,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     * @return bool
     * @since  v3.4+
     */
-    function czr_has_location_menu( $_location ) {
+    function czr_fn_has_location_menu( $_location ) {
       $_all_locations  = get_nav_menu_locations();
       return isset($_all_locations[$_location]) && is_object( wp_get_nav_menu_object( $_all_locations[$_location] ) );
     }

--- a/inc/class-fire-utils.php
+++ b/inc/class-fire-utils.php
@@ -11,8 +11,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_utils' ) ) :
-  class TC_utils {
+if ( ! class_exists( 'CZR_utils' ) ) :
+  class CZR_utils {
 
       //Access any method or var of the class with classname::$instance -> var or method():
       static $inst;
@@ -61,7 +61,7 @@ if ( ! class_exists( 'TC_utils' ) ) :
       * EARLY HOOKS
       ****************************/
       /**
-      * Init TC_utils class properties after_setup_theme
+      * Init CZR_utils class properties after_setup_theme
       * Fixes the bbpress bug : Notice: bbp_setup_current_user was called incorrectly. The current user is being initialized without using $wp->init()
       * tc_get_default_options uses is_user_logged_in() => was causing the bug
       * hook : after_setup_theme
@@ -72,10 +72,10 @@ if ( ! class_exists( 'TC_utils' ) ) :
       function tc_init_properties() {
         //all customizr theme options start by "tc_" by convention
         $this -> tc_options_prefixes = apply_filters('tc_options_prefixes', array('tc_') );
-        $this -> is_customizing   = TC___::$instance -> tc_is_customizing();
-        $this -> db_options       = false === get_option( TC___::$tc_option_group ) ? array() : (array)get_option( TC___::$tc_option_group );
+        $this -> is_customizing   = CZR___::$instance -> tc_is_customizing();
+        $this -> db_options       = false === get_option( CZR___::$tc_option_group ) ? array() : (array)get_option( CZR___::$tc_option_group );
         $this -> default_options  = $this -> tc_get_default_options();
-        $_trans                   = TC___::tc_is_pro() ? 'started_using_customizr_pro' : 'started_using_customizr';
+        $_trans                   = CZR___::tc_is_pro() ? 'started_using_customizr_pro' : 'started_using_customizr';
 
         //What was the theme version when the user started to use Customizr?
         //new install = no options yet
@@ -98,7 +98,7 @@ if ( ! class_exists( 'TC_utils' ) ) :
       */
       function tc_wp_filters() {
         add_filter( 'the_content'                         , array( $this , 'tc_fancybox_content_filter' ) );
-        if ( esc_attr( TC_utils::$inst->tc_opt( 'tc_img_smart_load' ) ) ) {
+        if ( esc_attr( CZR_utils::$inst->tc_opt( 'tc_img_smart_load' ) ) ) {
           add_filter( 'the_content'                       , array( $this , 'tc_parse_imgs' ), PHP_INT_MAX );
           add_filter( 'tc_thumb_html'                     , array( $this , 'tc_parse_imgs' ) );
         }
@@ -159,10 +159,10 @@ if ( ! class_exists( 'TC_utils' ) ) :
       * @since Customizr 3.1.23
       */
       function tc_get_skin_color( $_what = null ) {
-        $_color_map    = TC_init::$instance -> skin_color_map;
+        $_color_map    = CZR_init::$instance -> skin_color_map;
         $_color_map    = ( is_array($_color_map) ) ? $_color_map : array();
 
-        $_active_skin =  str_replace('.min.', '.', basename( TC_init::$instance -> tc_get_style_src() ) );
+        $_active_skin =  str_replace('.min.', '.', basename( CZR_init::$instance -> tc_get_style_src() ) );
         //falls back to blue3 ( default #27CDA5 ) if not defined
         $_to_return = array( '#27CDA5', '#1b8d71' );
 
@@ -223,7 +223,7 @@ if ( ! class_exists( 'TC_utils' ) ) :
         // 3) theme version not defined
         // 4) versions are different
         if ( is_user_logged_in() || empty($def_options) || ! isset($def_options['ver']) || 0 != version_compare( $def_options['ver'] , CUSTOMIZR_VER ) ) {
-          $def_options          = $this -> tc_generate_default_options( TC_utils_settings_map::$instance -> tc_get_customizer_map( $get_default_option = 'true' ) , 'tc_theme_options' );
+          $def_options          = $this -> tc_generate_default_options( CZR_utils_settings_map::$instance -> tc_get_customizer_map( $get_default_option = 'true' ) , 'tc_theme_options' );
           //Adds the version in default
           $def_options['ver']   =  CUSTOMIZR_VER;
 
@@ -277,7 +277,7 @@ if ( ! class_exists( 'TC_utils' ) ) :
       */
       function tc_get_theme_options ( $option_group = null ) {
           //do we have to look in a specific group of option (plugin?)
-          $option_group       = is_null($option_group) ? TC___::$tc_option_group : $option_group;
+          $option_group       = is_null($option_group) ? CZR___::$tc_option_group : $option_group;
           $saved              = empty($this -> db_options) ? $this -> tc_cache_db_options() : $this -> db_options;
           $defaults           = $this -> default_options;
           $__options          = wp_parse_args( $saved, $defaults );
@@ -296,7 +296,7 @@ if ( ! class_exists( 'TC_utils' ) ) :
       */
       function tc_opt( $option_name , $option_group = null, $use_default = true ) {
         //do we have to look for a specific group of option (plugin?)
-        $option_group = is_null($option_group) ? TC___::$tc_option_group : $option_group;
+        $option_group = is_null($option_group) ? CZR___::$tc_option_group : $option_group;
         //when customizing, the db_options property is refreshed each time the preview is refreshed in 'customize_preview_init'
         $_db_options  = empty($this -> db_options) ? $this -> tc_cache_db_options() : $this -> db_options;
 
@@ -316,7 +316,7 @@ if ( ! class_exists( 'TC_utils' ) ) :
         //ctx retro compat => falls back to default val if ctx like option detected
         //important note : some options like tc_slider are not concerned by ctx
         if ( ! $this -> tc_is_option_excluded_from_ctx( $option_name ) ) {
-          if ( is_array( $_single_opt ) && ! class_exists( 'TC_contx' ) )
+          if ( is_array( $_single_opt ) && ! class_exists( 'CZR_contx' ) )
             $_single_opt = $_default_val;
         }
 
@@ -342,7 +342,7 @@ if ( ! class_exists( 'TC_utils' ) ) :
       * @since  v3.4+
       */
       function tc_customize_refresh_db_opt(){
-        $this -> db_options = false === get_option( TC___::$tc_option_group ) ? array() : (array)get_option( TC___::$tc_option_group );
+        $this -> db_options = false === get_option( CZR___::$tc_option_group ) ? array() : (array)get_option( CZR___::$tc_option_group );
       }
 
 
@@ -358,7 +358,7 @@ if ( ! class_exists( 'TC_utils' ) ) :
       * @since Customizr 3.4+
       */
       function tc_set_option( $option_name , $option_value, $option_group = null ) {
-        $option_group           = is_null($option_group) ? TC___::$tc_option_group : $option_group;
+        $option_group           = is_null($option_group) ? CZR___::$tc_option_group : $option_group;
         $_options               = $this -> tc_get_theme_options( $option_group );
         $_options[$option_name] = $option_value;
 
@@ -374,7 +374,7 @@ if ( ! class_exists( 'TC_utils' ) ) :
       * @since Customizr 3.2.0
       */
       function tc_cache_db_options($opt_group = null) {
-        $opts_group = is_null($opt_group) ? TC___::$tc_option_group : $opt_group;
+        $opts_group = is_null($opt_group) ? CZR___::$tc_option_group : $opt_group;
         $this -> db_options = false === get_option( $opt_group ) ? array() : (array)get_option( $opt_group );
         return $this -> db_options;
       }
@@ -414,7 +414,7 @@ if ( ! class_exists( 'TC_utils' ) ) :
           $__options                    = tc__f ( '__options' );
           global $post;
           //Article wrapper class definition
-          $global_layout                = apply_filters( 'tc_global_layout' , TC_init::$instance -> global_layout );
+          $global_layout                = apply_filters( 'tc_global_layout' , CZR_init::$instance -> global_layout );
 
           /* DEFAULT LAYOUTS */
           //what is the default layout we want to apply? By default we apply the global default layout
@@ -487,7 +487,7 @@ if ( ! class_exists( 'TC_utils' ) ) :
        * @since Customizr 2.0.7
        */
       function tc_fancybox_content_filter( $content) {
-        $tc_fancybox = esc_attr( TC_utils::$inst->tc_opt( 'tc_fancybox' ) );
+        $tc_fancybox = esc_attr( CZR_utils::$inst->tc_opt( 'tc_fancybox' ) );
 
         if ( 1 != $tc_fancybox )
           return $content;
@@ -676,7 +676,7 @@ if ( ! class_exists( 'TC_utils' ) ) :
         $__options    = tc__f( '__options' );
 
         //gets the social network array
-        $socials      = apply_filters( 'tc_default_socials' , TC_init::$instance -> socials );
+        $socials      = apply_filters( 'tc_default_socials' , CZR_init::$instance -> socials );
 
         //declares some vars
         $html         = '';
@@ -688,7 +688,7 @@ if ( ! class_exists( 'TC_utils' ) ) :
               if ( isset($data['custom_icon_url']) && @getimagesize($data['custom_icon_url']) ) { list( $width, $height ) = getimagesize($data['custom_icon_url']); }
               $type = isset( $data['type'] ) && ! empty( $data['type'] ) ? $data['type'] : 'url';
               $link = 'email' == $type ? 'mailto:' : '';
-              $link .=  call_user_func( array( TC_utils_settings_map::$instance, 'tc_sanitize_'.$type ), $__options[$key] );
+              $link .=  call_user_func( array( CZR_utils_settings_map::$instance, 'tc_sanitize_'.$type ), $__options[$key] );
               //there is one exception : rss feed has no target _blank and special icon title
               $html .= sprintf('<a class="%1$s" href="%2$s" title="%3$s" %4$s %5$s>%6$s</a>',
                   apply_filters( 'tc_social_link_class',
@@ -778,7 +778,7 @@ if ( ! class_exists( 'TC_utils' ) ) :
       } else {
         $_date_one_timestamp   = $_date_one->format("U");
         $_date_two_timestamp   = $_date_two->format("U");
-        return new TC_DateInterval( $_date_two_timestamp - $_date_one_timestamp );
+        return new CZR_DateInterval( $_date_two_timestamp - $_date_one_timestamp );
       }
     }
 
@@ -858,7 +858,7 @@ if ( ! class_exists( 'TC_utils' ) ) :
       $_to_return = ( 'list' == $_what ) ? array() : false;
       $_font_groups = apply_filters(
         'tc_font_pairs',
-        TC_init::$instance -> font_pairs
+        CZR_init::$instance -> font_pairs
       );
       foreach ( $_font_groups as $_group_slug => $_font_list ) {
         if ( 'list' == $_what ) {
@@ -902,7 +902,7 @@ if ( ! class_exists( 'TC_utils' ) ) :
     * @since Customizr 3.2.9
     */
     function tc_user_started_before_version( $_czr_ver, $_pro_ver = null ) {
-      $_ispro = TC___::tc_is_pro();
+      $_ispro = CZR___::tc_is_pro();
 
       if ( $_ispro && ! get_transient( 'started_using_customizr_pro' ) )
         return false;
@@ -943,7 +943,7 @@ if ( ! class_exists( 'TC_utils' ) ) :
     * since v3.4+
     */
     function tc_is_secondary_menu_enabled() {
-      return (bool) esc_attr( TC_utils::$inst->tc_opt( 'tc_display_second_menu' ) ) && 'aside' == esc_attr( TC_utils::$inst->tc_opt( 'tc_menu_style' ) );
+      return (bool) esc_attr( CZR_utils::$inst->tc_opt( 'tc_display_second_menu' ) ) && 'aside' == esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_style' ) );
     }
 
 
@@ -1033,8 +1033,8 @@ endif;
 //Helper class to build a simple date diff object
 //Alternative to date_diff for php version < 5.3.0
 //http://stackoverflow.com/questions/9373718/php-5-3-date-diff-equivalent-for-php-5-2-on-own-function
-if ( ! class_exists( 'TC_DateInterval' ) ) :
-Class TC_DateInterval {
+if ( ! class_exists( 'CZR_DateInterval' ) ) :
+Class CZR_DateInterval {
     /* Properties */
     public $y = 0;
     public $m = 0;

--- a/inc/class-fire-utils.php
+++ b/inc/class-fire-utils.php
@@ -179,7 +179,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
             $_to_return = ( false != $_active_skin && isset($_color_map[$_active_skin][0]) ) ? $_color_map[$_active_skin][0] : $_to_return[0];
           break;
         }
-        return apply_filters( 'czr_fn_get_skin_color' , $_to_return , $_what );
+        return apply_filters( 'tc_get_skin_color' , $_to_return , $_what );
       }
 
 
@@ -196,7 +196,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       */
       function czr_fn_is_customizr_option( $option_key ) {
         $_is_tc_option = in_array( substr( $option_key, 0, 3 ), $this -> tc_options_prefixes );
-        return apply_filters( 'czr_fn_is_customizr_option', $_is_tc_option , $option_key );
+        return apply_filters( 'tc_is_customizr_option', $_is_tc_option , $option_key );
       }
 
 
@@ -500,7 +500,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
         $replacement = '<a$1href=$2$3.$4$5 class="grouped_elements" rel="tc-fancybox-group'.$post -> ID.'"$6>';
         $r_content = preg_replace( $pattern, $replacement, $content);
         $content = $r_content ? $r_content : $content;
-        return apply_filters( 'czr_fn_fancybox_content_filter', $content );
+        return apply_filters( 'tc_fancybox_content_filter', $content );
       }
 
 
@@ -659,7 +659,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
         // 404
         $selectors                  = is_404() ? apply_filters( 'tc_404_selectors' , 'id="post-0" class="post error404 no-results not-found row-fluid"' ) : $selectors;
 
-        echo apply_filters( 'czr_fn_article_selectors', $selectors );
+        echo apply_filters( 'tc_article_selectors', $selectors );
 
       }//end of function
 
@@ -957,7 +957,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     */
     function czr_fn_get_ctx_excluded_options() {
       return apply_filters(
-        'czr_fn_get_ctx_excluded_options',
+        'tc_get_ctx_excluded_options',
         array(
           'defaults',
           'tc_sliders',

--- a/inc/class-fire-utils.php
+++ b/inc/class-fire-utils.php
@@ -72,10 +72,10 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       function czr_init_properties() {
         //all customizr theme options start by "tc_" by convention
         $this -> tc_options_prefixes = apply_filters('tc_options_prefixes', array('tc_') );
-        $this -> is_customizing   = CZR___::$instance -> tc_is_customizing();
+        $this -> is_customizing   = CZR___::$instance -> czr_is_customizing();
         $this -> db_options       = false === get_option( CZR___::$tc_option_group ) ? array() : (array)get_option( CZR___::$tc_option_group );
-        $this -> default_options  = $this -> tc_get_default_options();
-        $_trans                   = CZR___::tc_is_pro() ? 'started_using_customizr_pro' : 'started_using_customizr';
+        $this -> default_options  = $this -> czr_get_default_options();
+        $_trans                   = CZR___::czr_is_pro() ? 'started_using_customizr_pro' : 'started_using_customizr';
 
         //What was the theme version when the user started to use Customizr?
         //new install = no options yet
@@ -98,7 +98,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       */
       function czr_wp_filters() {
         add_filter( 'the_content'                         , array( $this , 'tc_fancybox_content_filter' ) );
-        if ( esc_attr( CZR_utils::$inst->tc_opt( 'tc_img_smart_load' ) ) ) {
+        if ( esc_attr( CZR_utils::$inst->czr_opt( 'tc_img_smart_load' ) ) ) {
           add_filter( 'the_content'                       , array( $this , 'tc_parse_imgs' ), PHP_INT_MAX );
           add_filter( 'tc_thumb_html'                     , array( $this , 'tc_parse_imgs' ) );
         }
@@ -162,7 +162,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
         $_color_map    = CZR_init::$instance -> skin_color_map;
         $_color_map    = ( is_array($_color_map) ) ? $_color_map : array();
 
-        $_active_skin =  str_replace('.min.', '.', basename( CZR_init::$instance -> tc_get_style_src() ) );
+        $_active_skin =  str_replace('.min.', '.', basename( CZR_init::$instance -> czr_get_style_src() ) );
         //falls back to blue3 ( default #27CDA5 ) if not defined
         $_to_return = array( '#27CDA5', '#1b8d71' );
 
@@ -208,7 +208,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @since Customizr 3.1.11
       */
       function czr_get_default_options() {
-        $_db_opts     = empty($this -> db_options) ? $this -> tc_cache_db_options() : $this -> db_options;
+        $_db_opts     = empty($this -> db_options) ? $this -> czr_cache_db_options() : $this -> db_options;
         $def_options  = isset($_db_opts['defaults']) ? $_db_opts['defaults'] : array();
 
         //Don't update if default options are not empty + customizing context
@@ -223,7 +223,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
         // 3) theme version not defined
         // 4) versions are different
         if ( is_user_logged_in() || empty($def_options) || ! isset($def_options['ver']) || 0 != version_compare( $def_options['ver'] , CUSTOMIZR_VER ) ) {
-          $def_options          = $this -> tc_generate_default_options( CZR_utils_settings_map::$instance -> tc_get_customizer_map( $get_default_option = 'true' ) , 'tc_theme_options' );
+          $def_options          = $this -> czr_generate_default_options( CZR_utils_settings_map::$instance -> czr_get_customizer_map( $get_default_option = 'true' ) , 'tc_theme_options' );
           //Adds the version in default
           $def_options['ver']   =  CUSTOMIZR_VER;
 
@@ -252,7 +252,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
 
         foreach ($map['add_setting_control'] as $key => $options) {
           //check it is a customizr option
-          if(  ! $this -> tc_is_customizr_option( $key ) )
+          if(  ! $this -> czr_is_customizr_option( $key ) )
             continue;
 
           $option_name = $key;
@@ -278,7 +278,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       function czr_get_theme_options ( $option_group = null ) {
           //do we have to look in a specific group of option (plugin?)
           $option_group       = is_null($option_group) ? CZR___::$tc_option_group : $option_group;
-          $saved              = empty($this -> db_options) ? $this -> tc_cache_db_options() : $this -> db_options;
+          $saved              = empty($this -> db_options) ? $this -> czr_cache_db_options() : $this -> db_options;
           $defaults           = $this -> default_options;
           $__options          = wp_parse_args( $saved, $defaults );
           //$__options        = array_intersect_key( $__options, $defaults );
@@ -298,7 +298,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
         //do we have to look for a specific group of option (plugin?)
         $option_group = is_null($option_group) ? CZR___::$tc_option_group : $option_group;
         //when customizing, the db_options property is refreshed each time the preview is refreshed in 'customize_preview_init'
-        $_db_options  = empty($this -> db_options) ? $this -> tc_cache_db_options() : $this -> db_options;
+        $_db_options  = empty($this -> db_options) ? $this -> czr_cache_db_options() : $this -> db_options;
 
         //do we have to use the default ?
         $__options    = $_db_options;
@@ -315,7 +315,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
 
         //ctx retro compat => falls back to default val if ctx like option detected
         //important note : some options like tc_slider are not concerned by ctx
-        if ( ! $this -> tc_is_option_excluded_from_ctx( $option_name ) ) {
+        if ( ! $this -> czr_is_option_excluded_from_ctx( $option_name ) ) {
           if ( is_array( $_single_opt ) && ! class_exists( 'CZR_contx' ) )
             $_single_opt = $_default_val;
         }
@@ -359,7 +359,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       */
       function czr_set_option( $option_name , $option_value, $option_group = null ) {
         $option_group           = is_null($option_group) ? CZR___::$tc_option_group : $option_group;
-        $_options               = $this -> tc_get_theme_options( $option_group );
+        $_options               = $this -> czr_get_theme_options( $option_group );
         $_options[$option_name] = $option_value;
 
         update_option( $option_group, $_options );
@@ -411,7 +411,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @since Customizr 1.0
       */
       public static function czr_get_layout( $post_id , $sidebar_or_class = 'class' ) {
-          $__options                    = tc__f ( '__options' );
+          $__options                    = czr__f ( '__options' );
           global $post;
           //Article wrapper class definition
           $global_layout                = apply_filters( 'tc_global_layout' , CZR_init::$instance -> global_layout );
@@ -487,7 +487,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
        * @since Customizr 2.0.7
        */
       function czr_fancybox_content_filter( $content) {
-        $tc_fancybox = esc_attr( CZR_utils::$inst->tc_opt( 'tc_fancybox' ) );
+        $tc_fancybox = esc_attr( CZR_utils::$inst->czr_opt( 'tc_fancybox' ) );
 
         if ( 1 != $tc_fancybox )
           return $content;
@@ -526,7 +526,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
 
         // Add the site description for the home/front page.
         $site_description = get_bloginfo( 'description' , 'display' );
-        if ( $site_description && tc__f('__is_home') )
+        if ( $site_description && czr__f('__is_home') )
           $title = "$title $sep $site_description";
 
         // Add a page number if necessary.
@@ -638,20 +638,20 @@ if ( ! class_exists( 'CZR_utils' ) ) :
 
         // SINGLE POST
         $single_post_selector_bool  = isset($post) && 'page' != $post -> post_type && 'attachment' != $post -> post_type && is_singular();
-        $selectors                  = $single_post_selector_bool ? apply_filters( 'tc_single_post_selectors' ,'id="post-'.get_the_ID().'" '.$this -> tc_get_post_class('row-fluid') ) : $selectors;
+        $selectors                  = $single_post_selector_bool ? apply_filters( 'tc_single_post_selectors' ,'id="post-'.get_the_ID().'" '.$this -> czr_get_post_class('row-fluid') ) : $selectors;
 
         // POST LIST
-        $post_list_selector_bool    = ( isset($post) && !is_singular() && !is_404() && !tc__f( '__is_home_empty') ) || ( is_search() && 0 != $wp_query -> post_count );
-        $selectors                  = $post_list_selector_bool ? apply_filters( 'tc_post_list_selectors' , 'id="post-'.get_the_ID().'" '.$this -> tc_get_post_class('row-fluid') ) : $selectors;
+        $post_list_selector_bool    = ( isset($post) && !is_singular() && !is_404() && !czr__f( '__is_home_empty') ) || ( is_search() && 0 != $wp_query -> post_count );
+        $selectors                  = $post_list_selector_bool ? apply_filters( 'tc_post_list_selectors' , 'id="post-'.get_the_ID().'" '.$this -> czr_get_post_class('row-fluid') ) : $selectors;
 
         // PAGE
-        $page_selector_bool         = isset($post) && 'page' == tc__f('__post_type') && is_singular() && !tc__f( '__is_home_empty');
-        $selectors                  = $page_selector_bool ? apply_filters( 'tc_page_selectors' , 'id="page-'.get_the_ID().'" '.$this -> tc_get_post_class('row-fluid') ) : $selectors;
+        $page_selector_bool         = isset($post) && 'page' == czr__f('__post_type') && is_singular() && !czr__f( '__is_home_empty');
+        $selectors                  = $page_selector_bool ? apply_filters( 'tc_page_selectors' , 'id="page-'.get_the_ID().'" '.$this -> czr_get_post_class('row-fluid') ) : $selectors;
 
         // ATTACHMENT
         //checks if attachement is image and add a selector
         $format_image               = wp_attachment_is_image() ? 'format-image' : '';
-        $selectors                  = ( isset($post) && 'attachment' == $post -> post_type && is_singular() ) ? apply_filters( 'tc_attachment_selectors' , 'id="post-'.get_the_ID().'" '.$this -> tc_get_post_class(array('row-fluid', $format_image) ) ) : $selectors;
+        $selectors                  = ( isset($post) && 'attachment' == $post -> post_type && is_singular() ) ? apply_filters( 'tc_attachment_selectors' , 'id="post-'.get_the_ID().'" '.$this -> czr_get_post_class(array('row-fluid', $format_image) ) ) : $selectors;
 
         // NO SEARCH RESULTS
         $selectors                  = ( is_search() && 0 == $wp_query -> post_count ) ? apply_filters( 'tc_no_results_selectors' , 'id="post-0" class="post error404 no-results not-found row-fluid"' ) : $selectors;
@@ -673,7 +673,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @since Customizr 3.0.10
       */
       function czr_get_social_networks() {
-        $__options    = tc__f( '__options' );
+        $__options    = czr__f( '__options' );
 
         //gets the social network array
         $socials      = apply_filters( 'tc_default_socials' , CZR_init::$instance -> socials );
@@ -814,8 +814,8 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       $updated                = new DateTime( $updated );
       $current                = new DateTime( $current );
 
-      $created_to_updated     = $this -> tc_date_diff( $created , $updated );
-      $updated_to_today       = $this -> tc_date_diff( $updated, $current );
+      $created_to_updated     = $this -> czr_date_diff( $created , $updated );
+      $updated_to_today       = $this -> czr_date_diff( $updated, $current );
 
       if ( true === $_bool )
         //return ( 0 == $created_to_updated -> days && 0 == $created_to_updated -> s ) ? false : true;
@@ -902,7 +902,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     * @since Customizr 3.2.9
     */
     function czr_user_started_before_version( $_czr_ver, $_pro_ver = null ) {
-      $_ispro = CZR___::tc_is_pro();
+      $_ispro = CZR___::czr_is_pro();
 
       if ( $_ispro && ! get_transient( 'started_using_customizr_pro' ) )
         return false;
@@ -943,7 +943,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     * since v3.4+
     */
     function czr_is_secondary_menu_enabled() {
-      return (bool) esc_attr( CZR_utils::$inst->tc_opt( 'tc_display_second_menu' ) ) && 'aside' == esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_style' ) );
+      return (bool) esc_attr( CZR_utils::$inst->czr_opt( 'tc_display_second_menu' ) ) && 'aside' == esc_attr( CZR_utils::$inst->czr_opt( 'tc_menu_style' ) );
     }
 
 
@@ -974,7 +974,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     * @return bool
     */
     function czr_is_option_excluded_from_ctx( $opt_name ) {
-      return in_array( $opt_name, $this -> tc_get_ctx_excluded_options() );
+      return in_array( $opt_name, $this -> czr_get_ctx_excluded_options() );
     }
 
 

--- a/inc/class-fire-utils.php
+++ b/inc/class-fire-utils.php
@@ -28,33 +28,33 @@ if ( ! class_exists( 'CZR_utils' ) ) :
         self::$instance =& $this;
 
         //init properties
-        add_action( 'after_setup_theme'       , array( $this , 'tc_init_properties') );
+        add_action( 'after_setup_theme'       , array( $this , 'czr_init_properties') );
 
         //Various WP filters for
         //content
         //thumbnails => parses image if smartload enabled
         //title
-        add_action( 'wp_head'                 , array( $this , 'tc_wp_filters') );
+        add_action( 'wp_head'                 , array( $this , 'czr_wp_filters') );
 
         //get all options
-        add_filter( '__options'               , array( $this , 'tc_get_theme_options' ), 10, 1);
+        add_filter( '__options'               , array( $this , 'czr_get_theme_options' ), 10, 1);
         //get single option
-        add_filter( '__get_option'            , array( $this , 'tc_opt' ), 10, 2 );//deprecated
+        add_filter( '__get_option'            , array( $this , 'czr_opt' ), 10, 2 );//deprecated
 
         //some useful filters
-        add_filter( '__ID'                    , array( $this , 'tc_id' ));//deprecated
-        add_filter( '__screen_layout'         , array( $this , 'tc_get_layout' ) , 10 , 2 );//deprecated
-        add_filter( '__is_home'               , array( $this , 'tc_is_home' ) );
-        add_filter( '__is_home_empty'         , array( $this , 'tc_is_home_empty' ) );
-        add_filter( '__post_type'             , array( $this , 'tc_get_post_type' ) );
-        add_filter( '__is_no_results'         , array( $this , 'tc_is_no_results') );
-        add_filter( '__article_selectors'     , array( $this , 'tc_article_selectors' ) );
+        add_filter( '__ID'                    , array( $this , 'czr_id' ));//deprecated
+        add_filter( '__screen_layout'         , array( $this , 'czr_get_layout' ) , 10 , 2 );//deprecated
+        add_filter( '__is_home'               , array( $this , 'czr_is_home' ) );
+        add_filter( '__is_home_empty'         , array( $this , 'czr_is_home_empty' ) );
+        add_filter( '__post_type'             , array( $this , 'czr_get_post_type' ) );
+        add_filter( '__is_no_results'         , array( $this , 'czr_is_no_results') );
+        add_filter( '__article_selectors'     , array( $this , 'czr_article_selectors' ) );
 
         //social networks
-        add_filter( '__get_socials'           , array( $this , 'tc_get_social_networks' ) );
+        add_filter( '__get_socials'           , array( $this , 'czr_get_social_networks' ) );
 
         //refresh the theme options right after the _preview_filter when previewing
-        add_action( 'customize_preview_init'  , array( $this , 'tc_customize_refresh_db_opt' ) );
+        add_action( 'customize_preview_init'  , array( $this , 'czr_customize_refresh_db_opt' ) );
       }
 
       /***************************
@@ -97,12 +97,12 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @since Customizr 3.3.0
       */
       function czr_wp_filters() {
-        add_filter( 'the_content'                         , array( $this , 'tc_fancybox_content_filter' ) );
+        add_filter( 'the_content'                         , array( $this , 'czr_fancybox_content_filter' ) );
         if ( esc_attr( CZR_utils::$inst->czr_opt( 'tc_img_smart_load' ) ) ) {
-          add_filter( 'the_content'                       , array( $this , 'tc_parse_imgs' ), PHP_INT_MAX );
-          add_filter( 'tc_thumb_html'                     , array( $this , 'tc_parse_imgs' ) );
+          add_filter( 'the_content'                       , array( $this , 'czr_parse_imgs' ), PHP_INT_MAX );
+          add_filter( 'tc_thumb_html'                     , array( $this , 'czr_parse_imgs' ) );
         }
-        add_filter( 'wp_title'                            , array( $this , 'tc_wp_title' ), 10, 2 );
+        add_filter( 'wp_title'                            , array( $this , 'czr_wp_title' ), 10, 2 );
       }
 
 
@@ -118,7 +118,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
         if( is_feed() || is_preview() || ( wp_is_mobile() && apply_filters('tc_disable_img_smart_load_mobiles', false ) ) )
           return $_html;
 
-        return preg_replace_callback('#<img([^>]+?)src=[\'"]?([^\'"\s>]+)[\'"]?([^>]*)>#', array( $this , 'tc_regex_callback' ) , $_html);
+        return preg_replace_callback('#<img([^>]+?)src=[\'"]?([^\'"\s>]+)[\'"]?([^>]*)>#', array( $this , 'czr_regex_callback' ) , $_html);
       }
 
 
@@ -179,7 +179,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
             $_to_return = ( false != $_active_skin && isset($_color_map[$_active_skin][0]) ) ? $_color_map[$_active_skin][0] : $_to_return[0];
           break;
         }
-        return apply_filters( 'tc_get_skin_color' , $_to_return , $_what );
+        return apply_filters( 'czr_get_skin_color' , $_to_return , $_what );
       }
 
 
@@ -196,7 +196,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       */
       function czr_is_customizr_option( $option_key ) {
         $_is_tc_option = in_array( substr( $option_key, 0, 3 ), $this -> tc_options_prefixes );
-        return apply_filters( 'tc_is_customizr_option', $_is_tc_option , $option_key );
+        return apply_filters( 'czr_is_customizr_option', $_is_tc_option , $option_key );
       }
 
 
@@ -500,7 +500,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
         $replacement = '<a$1href=$2$3.$4$5 class="grouped_elements" rel="tc-fancybox-group'.$post -> ID.'"$6>';
         $r_content = preg_replace( $pattern, $replacement, $content);
         $content = $r_content ? $r_content : $content;
-        return apply_filters( 'tc_fancybox_content_filter', $content );
+        return apply_filters( 'czr_fancybox_content_filter', $content );
       }
 
 
@@ -659,7 +659,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
         // 404
         $selectors                  = is_404() ? apply_filters( 'tc_404_selectors' , 'id="post-0" class="post error404 no-results not-found row-fluid"' ) : $selectors;
 
-        echo apply_filters( 'tc_article_selectors', $selectors );
+        echo apply_filters( 'czr_article_selectors', $selectors );
 
       }//end of function
 
@@ -688,7 +688,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
               if ( isset($data['custom_icon_url']) && @getimagesize($data['custom_icon_url']) ) { list( $width, $height ) = getimagesize($data['custom_icon_url']); }
               $type = isset( $data['type'] ) && ! empty( $data['type'] ) ? $data['type'] : 'url';
               $link = 'email' == $type ? 'mailto:' : '';
-              $link .=  call_user_func( array( CZR_utils_settings_map::$instance, 'tc_sanitize_'.$type ), $__options[$key] );
+              $link .=  call_user_func( array( CZR_utils_settings_map::$instance, 'czr_sanitize_'.$type ), $__options[$key] );
               //there is one exception : rss feed has no target _blank and special icon title
               $html .= sprintf('<a class="%1$s" href="%2$s" title="%3$s" %4$s %5$s>%6$s</a>',
                   apply_filters( 'tc_social_link_class',
@@ -803,7 +803,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
         'current'   => date('Y-m-d g:i:s')
       );
       //ALL dates must be valid
-      if ( 1 != array_product( array_map( array($this , 'tc_is_date_valid') , $dates_to_check ) ) )
+      if ( 1 != array_product( array_map( array($this , 'czr_is_date_valid') , $dates_to_check ) ) )
         return false;
 
       //Import variables into the current symbol table
@@ -957,7 +957,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     */
     function czr_get_ctx_excluded_options() {
       return apply_filters(
-        'tc_get_ctx_excluded_options',
+        'czr_get_ctx_excluded_options',
         array(
           'defaults',
           'tc_sliders',

--- a/inc/class-fire-utils.php
+++ b/inc/class-fire-utils.php
@@ -69,7 +69,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 3.2.3
       */
-      function tc_init_properties() {
+      function czr_init_properties() {
         //all customizr theme options start by "tc_" by convention
         $this -> tc_options_prefixes = apply_filters('tc_options_prefixes', array('tc_') );
         $this -> is_customizing   = CZR___::$instance -> tc_is_customizing();
@@ -96,7 +96,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 3.3.0
       */
-      function tc_wp_filters() {
+      function czr_wp_filters() {
         add_filter( 'the_content'                         , array( $this , 'tc_fancybox_content_filter' ) );
         if ( esc_attr( CZR_utils::$inst->tc_opt( 'tc_img_smart_load' ) ) ) {
           add_filter( 'the_content'                       , array( $this , 'tc_parse_imgs' ), PHP_INT_MAX );
@@ -114,7 +114,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 3.3.0
       */
-      function tc_parse_imgs( $_html ) {
+      function czr_parse_imgs( $_html ) {
         if( is_feed() || is_preview() || ( wp_is_mobile() && apply_filters('tc_disable_img_smart_load_mobiles', false ) ) )
           return $_html;
 
@@ -130,7 +130,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 3.3.0
       */
-      private function tc_regex_callback( $matches ) {
+      private function czr_regex_callback( $matches ) {
         $_placeholder = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
         if ( false !== strpos( $matches[0], 'data-src' ) ||
@@ -158,7 +158,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 3.1.23
       */
-      function tc_get_skin_color( $_what = null ) {
+      function czr_get_skin_color( $_what = null ) {
         $_color_map    = CZR_init::$instance -> skin_color_map;
         $_color_map    = ( is_array($_color_map) ) ? $_color_map : array();
 
@@ -194,7 +194,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 3.4.9
       */
-      function tc_is_customizr_option( $option_key ) {
+      function czr_is_customizr_option( $option_key ) {
         $_is_tc_option = in_array( substr( $option_key, 0, 3 ), $this -> tc_options_prefixes );
         return apply_filters( 'tc_is_customizr_option', $_is_tc_option , $option_key );
       }
@@ -207,7 +207,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 3.1.11
       */
-      function tc_get_default_options() {
+      function czr_get_default_options() {
         $_db_opts     = empty($this -> db_options) ? $this -> tc_cache_db_options() : $this -> db_options;
         $def_options  = isset($_db_opts['defaults']) ? $_db_opts['defaults'] : array();
 
@@ -243,7 +243,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 3.0.3
       */
-      function tc_generate_default_options( $map, $option_group = null ) {
+      function czr_generate_default_options( $map, $option_group = null ) {
         //do we have to look in a specific group of option (plugin?)
         $option_group   = is_null($option_group) ? 'tc_theme_options' : $option_group;
 
@@ -275,7 +275,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @since Customizr 1.0
       *
       */
-      function tc_get_theme_options ( $option_group = null ) {
+      function czr_get_theme_options ( $option_group = null ) {
           //do we have to look in a specific group of option (plugin?)
           $option_group       = is_null($option_group) ? CZR___::$tc_option_group : $option_group;
           $saved              = empty($this -> db_options) ? $this -> tc_cache_db_options() : $this -> db_options;
@@ -294,7 +294,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 1.0
       */
-      function tc_opt( $option_name , $option_group = null, $use_default = true ) {
+      function czr_opt( $option_name , $option_group = null, $use_default = true ) {
         //do we have to look for a specific group of option (plugin?)
         $option_group = is_null($option_group) ? CZR___::$tc_option_group : $option_group;
         //when customizing, the db_options property is refreshed each time the preview is refreshed in 'customize_preview_init'
@@ -341,7 +341,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       *
       * @since  v3.4+
       */
-      function tc_customize_refresh_db_opt(){
+      function czr_customize_refresh_db_opt(){
         $this -> db_options = false === get_option( CZR___::$tc_option_group ) ? array() : (array)get_option( CZR___::$tc_option_group );
       }
 
@@ -357,7 +357,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 3.4+
       */
-      function tc_set_option( $option_name , $option_value, $option_group = null ) {
+      function czr_set_option( $option_name , $option_value, $option_group = null ) {
         $option_group           = is_null($option_group) ? CZR___::$tc_option_group : $option_group;
         $_options               = $this -> tc_get_theme_options( $option_group );
         $_options[$option_name] = $option_value;
@@ -373,7 +373,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 3.2.0
       */
-      function tc_cache_db_options($opt_group = null) {
+      function czr_cache_db_options($opt_group = null) {
         $opts_group = is_null($opt_group) ? CZR___::$tc_option_group : $opt_group;
         $this -> db_options = false === get_option( $opt_group ) ? array() : (array)get_option( $opt_group );
         return $this -> db_options;
@@ -389,7 +389,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 1.0
       */
-      public static function tc_id()  {
+      public static function czr_id()  {
         if ( in_the_loop() ) {
           $tc_id            = get_the_ID();
         } else {
@@ -410,7 +410,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 1.0
       */
-      public static function tc_get_layout( $post_id , $sidebar_or_class = 'class' ) {
+      public static function czr_get_layout( $post_id , $sidebar_or_class = 'class' ) {
           $__options                    = tc__f ( '__options' );
           global $post;
           //Article wrapper class definition
@@ -486,7 +486,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
        * @package Customizr
        * @since Customizr 2.0.7
        */
-      function tc_fancybox_content_filter( $content) {
+      function czr_fancybox_content_filter( $content) {
         $tc_fancybox = esc_attr( CZR_utils::$inst->tc_opt( 'tc_fancybox' ) );
 
         if ( 1 != $tc_fancybox )
@@ -512,7 +512,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @since Customizr 2.1.6
       *
       */
-      function tc_wp_title( $title, $sep ) {
+      function czr_wp_title( $title, $sep ) {
         if ( function_exists( '_wp_render_title_tag' ) )
           return $title;
 
@@ -545,7 +545,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @since Customizr 3.0.6
       *
       */
-      function tc_is_home() {
+      function czr_is_home() {
         //get info whether the front page is a list of last posts or a page
         return ( is_home() && ( 'posts' == get_option( 'show_on_front' ) || 'nothing' == get_option( 'show_on_front' ) ) ) || is_front_page();
       }
@@ -560,7 +560,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @since Customizr 3.0.6
       *
       */
-      function tc_is_home_empty() {
+      function czr_is_home_empty() {
         //check if the users has choosen the "no posts or page" option for home page
         return ( ( is_home() || is_front_page() ) && 'nothing' == get_option( 'show_on_front' ) ) ? true : false;
       }
@@ -574,7 +574,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @since Customizr 3.0.10
       *
       */
-      function tc_get_post_type() {
+      function czr_get_post_type() {
         global $post;
 
         if ( ! isset($post) )
@@ -596,7 +596,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since 3.0.10
       */
-      function tc_get_post_class( $class = '', $post_id = null ) {
+      function czr_get_post_class( $class = '', $post_id = null ) {
         //Separates classes with a single space, collates classes for post DIV
         return 'class="' . join( ' ', get_post_class( $class, $post_id ) ) . '"';
       }
@@ -612,7 +612,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since 3.0.10
       */
-      function tc_is_no_results() {
+      function czr_is_no_results() {
         global $wp_query;
         return ( is_search() && 0 == $wp_query -> post_count ) ? true : false;
       }
@@ -627,7 +627,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since 3.1.0
       */
-      function tc_article_selectors() {
+      function czr_article_selectors() {
 
         //gets global vars
         global $post;
@@ -672,7 +672,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
       * @package Customizr
       * @since Customizr 3.0.10
       */
-      function tc_get_social_networks() {
+      function czr_get_social_networks() {
         $__options    = tc__f( '__options' );
 
         //gets the social network array
@@ -727,7 +727,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     * @param array  $mimes    Optional. Key is the file extension with value as the mime type.
     * @return array Values with extension first and mime type.
     */
-    function tc_check_filetype( $filename, $mimes = null ) {
+    function czr_check_filetype( $filename, $mimes = null ) {
       $filename = basename( $filename );
       if ( empty($mimes) )
         $mimes = get_allowed_mime_types();
@@ -756,7 +756,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     * @param int $cat_id.
     * @return bool
     */
-    public function tc_category_id_exists( $cat_id ) {
+    public function czr_category_id_exists( $cat_id ) {
       return term_exists( (int) $cat_id, 'category');
     }
 
@@ -771,7 +771,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     * @param date one object.
     * @param date two object.
     */
-    private function tc_date_diff( $_date_one , $_date_two ) {
+    private function czr_date_diff( $_date_one , $_date_two ) {
       //if version is at least 5.3.0, use date_diff function
       if ( version_compare( PHP_VERSION, '5.3.0' ) >= 0) {
         return date_diff( $_date_one , $_date_two );
@@ -790,7 +790,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     * @package Customizr
     * @since Customizr 3.2.6
     */
-    function tc_post_has_update( $_bool = false) {
+    function czr_post_has_update( $_bool = false) {
       //php version check for DateTime
       //http://php.net/manual/fr/class.datetime.php
       if ( version_compare( PHP_VERSION, '5.2.0' ) < 0 )
@@ -831,7 +831,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     * @return boolean
     * http://stackoverflow.com/questions/11343403/php-exception-handling-on-datetime-object
     */
-    private function tc_is_date_valid($str) {
+    private function czr_is_date_valid($str) {
       if ( ! is_string($str) )
          return false;
 
@@ -854,7 +854,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     * @package Customizr
     * @since Customizr 3.2.9
     */
-    function tc_get_font( $_what = 'list' , $_requested = null ) {
+    function czr_get_font( $_what = 'list' , $_requested = null ) {
       $_to_return = ( 'list' == $_what ) ? array() : false;
       $_font_groups = apply_filters(
         'tc_font_pairs',
@@ -901,7 +901,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     * @package Customizr
     * @since Customizr 3.2.9
     */
-    function tc_user_started_before_version( $_czr_ver, $_pro_ver = null ) {
+    function czr_user_started_before_version( $_czr_ver, $_pro_ver = null ) {
       $_ispro = CZR___::tc_is_pro();
 
       if ( $_ispro && ! get_transient( 'started_using_customizr_pro' ) )
@@ -942,7 +942,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     * Boolean helper to check if the secondary menu is enabled
     * since v3.4+
     */
-    function tc_is_secondary_menu_enabled() {
+    function czr_is_secondary_menu_enabled() {
       return (bool) esc_attr( CZR_utils::$inst->tc_opt( 'tc_display_second_menu' ) ) && 'aside' == esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_style' ) );
     }
 
@@ -955,7 +955,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     * Helper : define a set of options not impacted by ctx like tc_slider, last_update_notice.
     * @return  array of excluded option names
     */
-    function tc_get_ctx_excluded_options() {
+    function czr_get_ctx_excluded_options() {
       return apply_filters(
         'tc_get_ctx_excluded_options',
         array(
@@ -973,7 +973,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     * Boolean helper : tells if this option is excluded from the ctx treatments.
     * @return bool
     */
-    function tc_is_option_excluded_from_ctx( $opt_name ) {
+    function czr_is_option_excluded_from_ctx( $opt_name ) {
       return in_array( $opt_name, $this -> tc_get_ctx_excluded_options() );
     }
 
@@ -993,7 +993,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     * @return url string
     * @since Customizr 3.4+
     */
-    static function tc_get_customizer_url( $autofocus = null, $control_wrapper = 'tc_theme_options' ) {
+    static function czr_get_customizer_url( $autofocus = null, $control_wrapper = 'tc_theme_options' ) {
       $_current_url       = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
       $_customize_url     = add_query_arg( 'url', urlencode( $_current_url ), wp_customize_url() );
       $autofocus  = ( ! is_array($autofocus) || empty($autofocus) ) ? null : $autofocus;
@@ -1020,7 +1020,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
     * @return bool
     * @since  v3.4+
     */
-    function tc_has_location_menu( $_location ) {
+    function czr_has_location_menu( $_location ) {
       $_all_locations  = get_nav_menu_locations();
       return isset($_all_locations[$_location]) && is_object( wp_get_nav_menu_object( $_all_locations[$_location] ) );
     }

--- a/inc/class-fire-utils_settings_map.php
+++ b/inc/class-fire-utils_settings_map.php
@@ -39,19 +39,19 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
         return $this -> customizer_map;
 
       //POPULATE THE MAP WITH DEFAULT CUSTOMIZR SETTINGS
-      add_filter( 'tc_add_panel_map'        , array( $this, 'tc_popul_panels_map'));
-      add_filter( 'tc_remove_section_map'   , array( $this, 'tc_popul_remove_section_map'));
+      add_filter( 'tc_add_panel_map'        , array( $this, 'czr_popul_panels_map'));
+      add_filter( 'tc_remove_section_map'   , array( $this, 'czr_popul_remove_section_map'));
       //theme switcher's enabled when user opened the customizer from the theme's page
-      add_filter( 'tc_remove_section_map'   , array( $this, 'tc_set_theme_switcher_visibility'));
-      add_filter( 'tc_add_section_map'      , array( $this, 'tc_popul_section_map' ));
+      add_filter( 'tc_remove_section_map'   , array( $this, 'czr_set_theme_switcher_visibility'));
+      add_filter( 'tc_add_section_map'      , array( $this, 'czr_popul_section_map' ));
       //add controls to the map
-      add_filter( 'tc_add_setting_control_map' , array( $this , 'tc_popul_setting_control_map' ), 10, 2 );
+      add_filter( 'tc_add_setting_control_map' , array( $this , 'czr_popul_setting_control_map' ), 10, 2 );
       //$this -> tc_populate_setting_control_map();
 
       //FILTER SPECIFIC SETTING-CONTROL MAPS
       //ADDS SETTING / CONTROLS TO THE RELEVANT SECTIONS
-      add_filter( 'tc_social_option_map'     , array( $this, 'tc_generates_socials' ));
-      add_filter( 'tc_front_page_option_map' , array( $this, 'tc_generates_featured_pages' ));
+      add_filter( 'czr_social_option_map'     , array( $this, 'czr_generates_socials' ));
+      add_filter( 'czr_front_page_option_map' , array( $this, 'czr_generates_featured_pages' ));
 
       //CACHE THE GLOBAL CUSTOMIZER MAP
       $this -> customizer_map = array_merge(
@@ -78,39 +78,39 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
       $_new_map = array();
       $_settings_sections = array(
         //GLOBAL SETTINGS
-        'tc_logo_favicon_option_map',
-        'tc_skin_option_map',
-        'tc_fonts_option_map',
-        'tc_social_option_map',
-        'tc_icons_option_map',
-        'tc_links_option_map',
-        'tc_images_option_map',
-        'tc_responsive_option_map',
-        'tc_authors_option_map',
-        'tc_smoothscroll_option_map',
+        'czr_logo_favicon_option_map',
+        'czr_skin_option_map',
+        'czr_fonts_option_map',
+        'czr_social_option_map',
+        'czr_icons_option_map',
+        'czr_links_option_map',
+        'czr_images_option_map',
+        'czr_responsive_option_map',
+        'czr_authors_option_map',
+        'czr_smoothscroll_option_map',
         //HEADER
-        'tc_header_design_option_map',
-        'tc_navigation_option_map',
+        'czr_header_design_option_map',
+        'czr_navigation_option_map',
         //CONTENT
-        'tc_front_page_option_map',
-        'tc_layout_option_map',
-        'tc_comment_option_map',
-        'tc_breadcrumb_option_map',
-        'tc_post_metas_option_map',
-        'tc_post_list_option_map',
-        'tc_single_post_option_map',
-        'tc_gallery_option_map',
-        'tc_paragraph_option_map',
-        'tc_post_navigation_option_map',
+        'czr_front_page_option_map',
+        'czr_layout_option_map',
+        'czr_comment_option_map',
+        'czr_breadcrumb_option_map',
+        'czr_post_metas_option_map',
+        'czr_post_list_option_map',
+        'czr_single_post_option_map',
+        'czr_gallery_option_map',
+        'czr_paragraph_option_map',
+        'czr_post_navigation_option_map',
         //SIDEBARS
-        'tc_sidebars_option_map',
+        'czr_sidebars_option_map',
         //FOOTER
-        'tc_footer_global_settings_option_map',
+        'czr_footer_global_settings_option_map',
         //ADVANCED OPTIONS
-        'tc_custom_css_option_map',
-        'tc_performance_option_map',
-        'tc_placeholders_notice_map',
-        'tc_external_resources_option_map'
+        'czr_custom_css_option_map',
+        'czr_performance_option_map',
+        'czr_placeholders_notice_map',
+        'czr_external_resources_option_map'
       );
 
       foreach ( $_settings_sections as $_section_cb ) {
@@ -149,7 +149,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'label'     =>  __( 'Logo Upload (supported formats : .jpg, .png, .gif, svg, svgz)' , 'customizr' ),
                                 'title'     => __( 'LOGO' , 'customizr'),
                                 'section'   => 'logo_sec',
-                                'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
+                                'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
                                 //we can define suggested cropping area and allow it to be flexible (def 150x150 and not flexible)
                                 'width'     => 250,
                                 'height'    => 100,
@@ -172,7 +172,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'control'   =>  version_compare( $wp_version, '4.3', '>=' ) ? 'CZR_Customize_Cropped_Image_Control' : 'CZR_Customize_Upload_Control',
                                 'label'     =>  __( 'Sticky Logo Upload (supported formats : .jpg, .png, .gif, svg, svgz)' , 'customizr' ),
                                 'section'   =>  'logo_sec' ,
-                                'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
+                                'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
                         //we can define suggested cropping area and allow it to be flexible (def 150x150 and not flexible)
                                 'width'     => 75,
                                 'height'    => 30,
@@ -191,7 +191,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'title'     => __( 'FAVICON' , 'customizr'),
                                 'section'   =>  'logo_sec' ,
                                 'type'      => 'tc_upload',
-                                'sanitize_callback' => array( $this , 'tc_sanitize_number'),
+                                'sanitize_callback' => array( $this , 'czr_sanitize_number'),
               )
       );
     }
@@ -243,7 +243,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
               ),
               'tc_body_font_size'      => array(
                                 'default'       => CZR_utils::$inst -> czr_user_started_before_version( '3.2.9', '1.0.1' ) ? 14 : 15,
-                                'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
+                                'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
                                 'label'         => __( 'Set your website default font size in pixels.' , 'customizr' ),
                                 'control'       =>  'CZR_controls',
                                 'section'       => 'fonts_sec',
@@ -694,7 +694,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
               'tc_sticky_z_index'  =>  array(
                                 'default'       => 100,
                                 'control'       => 'CZR_controls' ,
-                                'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
+                                'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
                                 'label'         => __( "Set the header z-index" , "customizr" ),
                                 'section'       => 'header_layout_sec' ,
                                 'type'          => 'number' ,
@@ -1055,7 +1055,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
               //Delay between each slides
               'tc_slider_delay' => array(
                                 'default'       => 5000,
-                                'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
+                                'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
                                 'control'   => 'CZR_controls' ,
                                 'label'       => __( 'Delay between each slides' , 'customizr' ),
                                 'section'     => 'frontpage_sec' ,
@@ -1067,7 +1067,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
               ),
               'tc_slider_default_height' => array(
                                 'default'       => 500,
-                                'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
+                                'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
                                 'control'   => 'CZR_controls' ,
                                 'label'       => __( "Set slider's height in pixels" , 'customizr' ),
                                 'section'     => 'frontpage_sec' ,
@@ -1182,7 +1182,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
               //Post per page
               'posts_per_page'  =>  array(
                               'default'     => get_option( 'posts_per_page' ),
-                              'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
+                              'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
                               'control'     => 'CZR_controls' ,
                               'title'         => __( 'Global Post Lists Settings' , 'customizr' ),
                               'label'         => __( 'Maximum number of posts per page' , 'customizr' ),
@@ -1236,7 +1236,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
       return array(
               'tc_post_list_excerpt_length'  =>  array(
                                 'default'       => 50,
-                                'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
+                                'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
                                 'control'       => 'CZR_controls' ,
                                 'label'         => __( "Set the excerpt length (in number of words) " , "customizr" ),
                                 'section'       => 'post_lists_sec' ,
@@ -1268,7 +1268,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'control'   =>  version_compare( $wp_version, '4.3', '>=' ) ? 'CZR_Customize_Cropped_Image_Control' : 'CZR_Customize_Upload_Control',
                                 'label'         => __( 'Upload a default thumbnail' , 'customizr' ),
                                 'section'   =>  'post_lists_sec' ,
-                                'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
+                                'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
                         //we can define suggested cropping area and allow it to be flexible (def 150x150 and not flexible)
                                 'width'         => 570,
                                 'height'        => 350,
@@ -1301,7 +1301,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
               ),
               'tc_post_list_thumb_height' => array(
                                 'default'       => 250,
-                                'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
+                                'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
                                 'control'   => 'CZR_controls' ,
                                 'label'       => __( "Set the thumbnail's max height in pixels" , 'customizr' ),
                                 'section'     => 'post_lists_sec' ,
@@ -1465,7 +1465,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                ),
               'tc_grid_num_words'  =>  array(
                                 'default'       => 10,
-                                'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
+                                'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
                                 'control'       => 'CZR_controls' ,
                                 'label'         => __( 'Max. length for post titles (in words)' , "customizr" ),
                                 'section'       => 'post_lists_sec' ,
@@ -1476,7 +1476,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
               ),
               'tc_grid_thumb_height' => array(
                                 'default'       => 350,
-                                'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
+                                'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
                                 'control'       => 'CZR_controls' ,
                                 'title'         => __( 'Thumbnails max height for the grid layout' , 'customizr' ),
                                 'label'         => __( "Set the post grid thumbnail's max height in pixels" , 'customizr' ),
@@ -1519,7 +1519,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
           ),
           'tc_single_post_thumb_height' => array(
                             'default'       => 250,
-                            'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
+                            'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
                             'control'   => 'CZR_controls' ,
                             'label'       => __( "Set the thumbnail's max height in pixels" , 'customizr' ),
                             'section'     => 'single_posts_sec' ,
@@ -1720,7 +1720,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
               'tc_post_metas_update_notice_interval'  =>  array(
                                 'default'       => 10,
                                 'control'       => 'CZR_controls',
-                                'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
+                                'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
                                 'label'         => __( "Display the notice if the last update is less (strictly) than n days old" , "customizr" ),
                                 'section'       => 'post_metas_sec',
                                 'type'          => 'number' ,
@@ -1814,7 +1814,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
               ),
               'tc_dropcap_minwords'  =>  array(
                                 'default'       => 50,
-                                'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
+                                'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
                                 'control'       => 'CZR_controls' ,
                                 'label'         => __( "Apply a drop cap when the paragraph includes at least the following number of words :" , "customizr" ),
                                 'notice'         => __( "(number of words)" , "customizr" ),
@@ -1906,7 +1906,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'section'     => 'comments_sec',
                                 'type'        =>  'color' ,
                                 'priority'    => 30,
-                                'sanitize_callback'    => array( $this, 'tc_sanitize_hex_color' ),
+                                'sanitize_callback'    => array( $this, 'czr_sanitize_hex_color' ),
                                 'sanitize_js_callback' => 'maybe_hash_hex_color',
                                 'transport'   => 'postMessage'
               ),
@@ -2614,7 +2614,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
       foreach ( $fp_ids as $id ) {
         $priority = $priority + $incr;
         $fp_setting_control['tc_featured_text_' . $id]   = array(
-                      'sanitize_callback' => array( $this , 'tc_sanitize_textarea' ),
+                      'sanitize_callback' => array( $this , 'czr_sanitize_textarea' ),
                       'transport'   => 'postMessage',
                       'control'   => 'CZR_controls' ,
                       'label'       => isset($default['text'][$id]) ? $default['text'][$id] : sprintf( __('Featured text %1$s (200 char. max)' , 'customizr' ) , $id ),
@@ -2655,7 +2655,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
 
         $_new_map[$key]  = array(
                       'default'       => ( isset($data['default']) && !is_null($data['default']) ) ? $data['default'] : null,
-                      'sanitize_callback' => array( $this , 'tc_sanitize_' . $type ),
+                      'sanitize_callback' => array( $this , 'czr_sanitize_' . $type ),
                       'control'       => 'CZR_controls' ,
                       'label'         => ( isset($data['option_label']) ) ? call_user_func( '__' , $data['option_label'] , 'customizr' ) : $key,
                       'section'       => 'socials_sec' ,

--- a/inc/class-fire-utils_settings_map.php
+++ b/inc/class-fire-utils_settings_map.php
@@ -208,7 +208,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'label'     =>  __( 'Choose a predefined skin' , 'customizr' ),
                                 'section'   =>  'skins_sec' ,
                                 'type'      =>  'select' ,
-                                'choices'    =>  $this -> tc_build_skin_list(),
+                                'choices'    =>  $this -> czr_build_skin_list(),
                                 'transport'   =>  'postMessage',
                                 'notice'    => __( 'Disabled if the random option is on.' , 'customizr' )
               ),
@@ -231,18 +231,18 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     function czr_fonts_option_map( $get_default = null ) {
       return array(
               'tc_fonts'      => array(
-                                'default'       => CZR_utils::$inst -> tc_user_started_before_version( '3.2.9' , '1.0.1') ? 'helvetica_arial' : '_g_fjalla_cantarell',
+                                'default'       => CZR_utils::$inst -> czr_user_started_before_version( '3.2.9' , '1.0.1') ? 'helvetica_arial' : '_g_fjalla_cantarell',
                                 'label'         => __( 'Select a beautiful font pair (headings &amp; default fonts) or single font for your website.' , 'customizr' ),
                                 'control'       =>  'CZR_controls',
                                 'section'       => 'fonts_sec',
                                 'type'          => 'select' ,
-                                'choices'       => CZR_utils::$inst -> tc_get_font( 'list' , 'name' ),
+                                'choices'       => CZR_utils::$inst -> czr_get_font( 'list' , 'name' ),
                                 'priority'      => 10,
                                 'transport'     => 'postMessage',
                                 'notice'        => __( "This font picker allows you to preview and select among a handy selection of font pairs and single fonts. If you choose a pair, the first font will be applied to the site main headings : site name, site description, titles h1, h2, h3., while the second will be the default font of your website for any texts or paragraphs." , 'customizr' )
               ),
               'tc_body_font_size'      => array(
-                                'default'       => CZR_utils::$inst -> tc_user_started_before_version( '3.2.9', '1.0.1' ) ? 14 : 15,
+                                'default'       => CZR_utils::$inst -> czr_user_started_before_version( '3.2.9', '1.0.1' ) ? 14 : 15,
                                 'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
                                 'label'         => __( 'Set your website default font size in pixels.' , 'customizr' ),
                                 'control'       =>  'CZR_controls',
@@ -331,7 +331,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'transport'   => 'postMessage'
               ),
               'tc_show_page_title_icon'  =>  array(
-                                'default'       => CZR_utils::$inst -> tc_user_started_before_version( '3.3.0', '1.0.11' ) ? 1 : 0,
+                                'default'       => CZR_utils::$inst -> czr_user_started_before_version( '3.3.0', '1.0.11' ) ? 1 : 0,
                                 'control'       => 'CZR_controls' ,
                                 'label'         => __( "Display a page icon next to the page title" , "customizr" ),
                                 'section'       => 'titles_icons_sec' ,
@@ -340,7 +340,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'transport'   => 'postMessage'
               ),
               'tc_show_post_title_icon'  =>  array(
-                                'default'       => CZR_utils::$inst -> tc_user_started_before_version( '3.3.0', '1.0.11' ) ? 1 : 0,
+                                'default'       => CZR_utils::$inst -> czr_user_started_before_version( '3.3.0', '1.0.11' ) ? 1 : 0,
                                 'control'     => 'CZR_controls' ,
                                 'label'         => __( "Display a post icon next to the single post title" , "customizr" ),
                                 'section'       => 'titles_icons_sec' ,
@@ -359,7 +359,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'transport'   => 'postMessage'
               ),
               'tc_show_post_list_title_icon'  =>  array(
-                                'default'       => CZR_utils::$inst -> tc_user_started_before_version( '3.3.0' , '1.0.11' ) ? 1 : 0,
+                                'default'       => CZR_utils::$inst -> czr_user_started_before_version( '3.3.0' , '1.0.11' ) ? 1 : 0,
                                 'control'     => 'CZR_controls' ,
                                 'label'         => __( "Display an icon next to each post title in an archive page" , "customizr" ),
                                 'section'       => 'titles_icons_sec' ,
@@ -614,7 +614,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'transport'   => 'postMessage'
               ),
               'tc_display_boxed_navbar'  =>  array(
-                                'default'       => CZR_utils::$inst -> tc_user_started_before_version( '3.3.13', '1.0.18' ) ? 1 : 0,
+                                'default'       => CZR_utils::$inst -> czr_user_started_before_version( '3.3.13', '1.0.18' ) ? 1 : 0,
                                 'control'       => 'CZR_controls' ,
                                 'label'         => __( "Display menu in a box" , "customizr" ),
                                 'section'       => 'header_layout_sec' ,
@@ -730,7 +730,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'notice'        => __( "When you've set your main menu as a vertical side navigation, you can check this option to display a complementary horizontal menu in the header." , 'customizr' ),
               ),
               'tc_menu_style'  =>  array(
-                              'default'       => CZR_utils::$inst -> tc_user_started_before_version( '3.4.0', '1.2.0' ) ? 'navbar' : 'aside',
+                              'default'       => CZR_utils::$inst -> czr_user_started_before_version( '3.4.0', '1.2.0' ) ? 'navbar' : 'aside',
                               'control'       => 'CZR_controls' ,
                               'title'         => __( 'Main menu design' , 'customizr'),
                               'label'         => __( 'Select a design : side menu (vertical) or regular (horizontal)' , 'customizr' ),
@@ -761,7 +761,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'notice'        => __( 'Note : the label is hidden on mobile devices.' , 'customizr' ),
               ),
               'tc_menu_position'  =>  array(
-                                'default'       => CZR_utils::$inst -> tc_user_started_before_version( '3.4.0', '1.2.0' ) ? 'pull-menu-left' : 'pull-menu-right',
+                                'default'       => CZR_utils::$inst -> czr_user_started_before_version( '3.4.0', '1.2.0' ) ? 'pull-menu-left' : 'pull-menu-right',
                                 'control'       => 'CZR_controls' ,
                                 'label'         => __( 'Menu position (for "main" menu)' , "customizr" ),
                                 'section'       => 'nav' ,
@@ -801,7 +801,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
               //The hover menu type has been introduced in v3.1.0.
               //For users already using the theme (no theme's option set), the default choice is click, for new users, it is hover.
               'tc_menu_type'  => array(
-                                'default'   =>  CZR_utils::$inst -> tc_user_started_before_version( '3.1.0' , '1.0.0' ) ? 'click' : 'hover',
+                                'default'   =>  CZR_utils::$inst -> czr_user_started_before_version( '3.1.0' , '1.0.0' ) ? 'click' : 'hover',
                                 'control'   =>  'CZR_controls' ,
                                 'label'     =>  __( 'Select a submenu expansion option' , 'customizr' ),
                                 'section'   =>  'nav' ,
@@ -962,7 +962,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'section'     => 'frontpage_sec' ,
                                 'control'     => 'CZR_controls' ,
                                 'type'        => 'select' ,
-                                'choices'     => $this -> tc_layout_choices(),
+                                'choices'     => $this -> czr_layout_choices(),
                                 'priority'    => 2,
               ),
 
@@ -975,7 +975,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'section'     => 'frontpage_sec' ,
                                 'type'        => 'select' ,
                                 //!important
-                                'choices'     => ( true == $get_default ) ? null : $this -> tc_slider_choices(),
+                                'choices'     => ( true == $get_default ) ? null : $this -> czr_slider_choices(),
                                 'priority'    => 20
               ),
               //posts slider
@@ -1153,7 +1153,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                               'label'         => __( 'Choose the global default layout' , 'customizr' ),
                               'section'     => 'post_layout_sec' ,
                               'type'          => 'select' ,
-                              'choices'     => $this -> tc_layout_choices(),
+                              'choices'     => $this -> czr_layout_choices(),
                               'notice'      => __( 'Note : the home page layout has to be set in the home page section' , 'customizr' ),
                               'priority'      => 10
                ),
@@ -1175,7 +1175,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                               'label'       => __( 'Choose the posts default layout' , 'customizr' ),
                               'section'     => 'post_layout_sec' ,
                               'type'        => 'select' ,
-                              'choices'   => $this -> tc_layout_choices(),
+                              'choices'   => $this -> czr_layout_choices(),
                               'priority'      => 30
               ),
 
@@ -1212,7 +1212,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'label'       => __( 'Choose the pages default layout' , 'customizr' ),
                                 'section'     => 'post_layout_sec' ,
                                 'type'        => 'select' ,
-                                'choices'   => $this -> tc_layout_choices(),
+                                'choices'   => $this -> czr_layout_choices(),
                                 'priority'       => 40,
                                 'notice'    => sprintf('<br/> %s<br/>%s',
                                     sprintf( __("The above layout options will set your layout globally for your post and pages. But you can also define the layout for each post and page individually. Learn how in the %s.", "customizr"),
@@ -1375,7 +1375,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
               ),
 
               'tc_post_list_grid'  =>  array(
-                                'default'       => CZR_utils::$inst -> tc_user_started_before_version( '3.2.18', '1.0.13' ) ? 'alternate' : 'grid',
+                                'default'       => CZR_utils::$inst -> czr_user_started_before_version( '3.2.18', '1.0.13' ) ? 'alternate' : 'grid',
                                 'control'       => 'CZR_controls' ,
                                 'title'         => __( 'Post List Design' , 'customizr' ),
                                 'label'         => __( 'Select a Layout' , "customizr" ),
@@ -1608,7 +1608,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'transport'   => 'postMessage'
               ),
               'tc_post_metas_design'  =>  array(
-                                'default'       => CZR_utils::$inst -> tc_user_started_before_version( '3.3.2' , '1.0.11' ) ? 'buttons' : 'no-buttons',
+                                'default'       => CZR_utils::$inst -> czr_user_started_before_version( '3.3.2' , '1.0.11' ) ? 'buttons' : 'no-buttons',
                                 'control'     => 'CZR_controls' ,
                                 'title'         => __( 'Metas Design' , 'customizr' ),
                                 'label'         => __( "Select a design for the post metas" , "customizr" ),
@@ -1708,7 +1708,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
               ),
 
               'tc_post_metas_update_notice_in_title'  =>  array(
-                                'default'       => CZR_utils::$inst -> tc_user_started_before_version( '3.3.2' , '1.0.11' ) ? 1 : 0,
+                                'default'       => CZR_utils::$inst -> czr_user_started_before_version( '3.3.2' , '1.0.11' ) ? 1 : 0,
                                 'control'       => 'CZR_controls',
                                 'title'         => __( 'Recent update notice after post titles' , 'customizr' ),
                                 'label'         => __( "Display a recent update notice" , "customizr" ),
@@ -1888,7 +1888,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
               ),
 
               'tc_comment_bubble_color_type' => array(
-                                'default'     => CZR_utils::$inst -> tc_user_started_before_version( '3.3.2' , '1.0.11' ) ? 'custom' : 'skin',
+                                'default'     => CZR_utils::$inst -> czr_user_started_before_version( '3.3.2' , '1.0.11' ) ? 'custom' : 'skin',
                                 'control'     => 'CZR_controls',
                                 'label'       => __( 'Comments bubble color' , 'customizr' ),
                                 'section'     => 'comments_sec',
@@ -1900,7 +1900,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'priority'    => 20,
               ),
               'tc_comment_bubble_color' => array(
-                                'default'     => CZR_utils::$inst -> tc_user_started_before_version( '3.3.2' , '1.0.11' ) ? '#F00' : CZR_utils::$inst -> tc_get_skin_color(),
+                                'default'     => CZR_utils::$inst -> czr_user_started_before_version( '3.3.2' , '1.0.11' ) ? '#F00' : CZR_utils::$inst -> czr_get_skin_color(),
                                 'control'     => 'WP_Customize_Color_Control',
                                 'label'       => __( 'Comments bubble color' , 'customizr' ),
                                 'section'     => 'comments_sec',
@@ -2067,7 +2067,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'transport'   => 'postMessage'
               ),
               'tc_sticky_footer'  =>  array(
-                                'default'       => CZR_utils::$inst -> tc_user_started_before_version( '3.4.0' , '1.1.14' ) ? 0 : 1,
+                                'default'       => CZR_utils::$inst -> czr_user_started_before_version( '3.4.0' , '1.1.14' ) ? 0 : 1,
                                 'control'       => 'CZR_controls' ,
                                 'label'         => __( "Stick the footer to the bottom of the page", "customizr" ),
                                 'section'       => 'footer_global_sec' ,
@@ -2290,7 +2290,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
       //=> because once the preview is ready, a postMessage is sent to the panel frame to refresh the sections and panels
       //Do nothing if WP version under 4.2
       global $wp_version;
-      if ( CZR___::$instance -> tc_is_customize_preview_frame() || ! version_compare( $wp_version, '4.2', '>=') )
+      if ( CZR___::$instance -> czr_is_customize_preview_frame() || ! version_compare( $wp_version, '4.2', '>=') )
         return $_sections;
 
       //when user access the theme switcher from the admin bar
@@ -2767,8 +2767,8 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     * @updated Customizr 3.0.15
     */
     private function czr_build_skin_list() {
-        $parent_skins   = $this -> tc_get_skins(TC_BASE .'inc/assets/css');
-        $child_skins    = ( CZR___::$instance -> tc_is_child() && file_exists(TC_BASE_CHILD .'inc/assets/css') ) ? $this -> tc_get_skins(TC_BASE_CHILD .'inc/assets/css') : array();
+        $parent_skins   = $this -> czr_get_skins(TC_BASE .'inc/assets/css');
+        $child_skins    = ( CZR___::$instance -> czr_is_child() && file_exists(TC_BASE_CHILD .'inc/assets/css') ) ? $this -> czr_get_skins(TC_BASE_CHILD .'inc/assets/css') : array();
         $skin_list      = array_merge( $parent_skins , $child_skins );
 
       return apply_filters( 'tc_skin_list', $skin_list );

--- a/inc/class-fire-utils_settings_map.php
+++ b/inc/class-fire-utils_settings_map.php
@@ -34,7 +34,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     * @package Customizr
     * @since Customizr 3.0
     */
-    public function tc_get_customizer_map( $get_default = null ) {
+    public function czr_get_customizer_map( $get_default = null ) {
       if ( ! empty( $this -> customizer_map ) )
         return $this -> customizer_map;
 
@@ -74,7 +74,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    function tc_popul_setting_control_map( $_map, $get_default = null ) {
+    function czr_popul_setting_control_map( $_map, $get_default = null ) {
       $_new_map = array();
       $_settings_sections = array(
         //GLOBAL SETTINGS
@@ -141,7 +141,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    LOGO & FAVICON SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function tc_logo_favicon_option_map( $get_default = null ) {
+    function czr_logo_favicon_option_map( $get_default = null ) {
       global $wp_version;
       return array(
               'tc_logo_upload'  => array(
@@ -199,7 +199,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                       SKIN SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function tc_skin_option_map( $get_default = null ) {
+    function czr_skin_option_map( $get_default = null ) {
       return array(
               //skin select
               'tc_skin'     => array(
@@ -228,7 +228,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                      FONT SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function tc_fonts_option_map( $get_default = null ) {
+    function czr_fonts_option_map( $get_default = null ) {
       return array(
               'tc_fonts'      => array(
                                 'default'       => CZR_utils::$inst -> tc_user_started_before_version( '3.2.9' , '1.0.1') ? 'helvetica_arial' : '_g_fjalla_cantarell',
@@ -261,7 +261,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                              SOCIAL NETWORKS + POSITION SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function tc_social_option_map( $get_default = null ) {
+    function czr_social_option_map( $get_default = null ) {
       return array();//end of social layout map
     }
 
@@ -269,7 +269,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    LINKS SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function tc_links_option_map( $get_default = null ) {
+    function czr_links_option_map( $get_default = null ) {
       return array(
               'tc_link_scroll'  =>  array(
                                 'default'       => 0,
@@ -318,7 +318,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    ICONS SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function tc_icons_option_map( $get_default = null ) {
+    function czr_icons_option_map( $get_default = null ) {
       return array(
               'tc_show_title_icon'  =>  array(
                                 'default'       => 1,
@@ -393,7 +393,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    IMAGE SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function tc_images_option_map( $get_default = null ) {
+    function czr_images_option_map( $get_default = null ) {
       global $wp_version;
 
       $_image_options =  array(
@@ -496,7 +496,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                   RESPONSIVE SETTINGS SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function tc_responsive_option_map( $get_default = null ) {
+    function czr_responsive_option_map( $get_default = null ) {
       return array(
               'tc_block_reorder'  =>  array(
                                 'default'       => 1,
@@ -514,7 +514,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                   AUTHORS SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function tc_authors_option_map( $get_default = null ) {
+    function czr_authors_option_map( $get_default = null ) {
       return array(
               'tc_show_author_info'  =>  array(
                                 'default'       => 1,
@@ -533,7 +533,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                   SMOOTH SCROLL SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function tc_smoothscroll_option_map( $get_default = null ) {
+    function czr_smoothscroll_option_map( $get_default = null ) {
       return array(
               'tc_smoothscroll'  =>  array(
                                 'default'       => 1,
@@ -558,7 +558,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    HEADER DESIGN AND LAYOUT
     ------------------------------------------------------------------------------------------------------*/
-    function tc_header_design_option_map( $get_default = null ) {
+    function czr_header_design_option_map( $get_default = null ) {
       return array(
               'tc_header_layout'  =>  array(
                               'default'       => 'left',
@@ -718,7 +718,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                         NAVIGATION SECTION
     ------------------------------------------------------------------------------------------------------*/
     //NOTE : priorities 10 and 20 are "used" bu menus main and secondary
-    function tc_navigation_option_map( $get_default = null ) {
+    function czr_navigation_option_map( $get_default = null ) {
       return array(
               'tc_display_second_menu'  =>  array(
                                 'default'       => 0,
@@ -871,7 +871,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    FRONT PAGE SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function tc_front_page_option_map( $get_default = null ) {
+    function czr_front_page_option_map( $get_default = null ) {
       //prepare the cat picker notice
       global $wp_version;
       $_cat_picker_notice = sprintf( '%1$s <a href="%2$s" target="_blank">%3$s<span style="font-size: 17px;" class="dashicons dashicons-external"></span></a>' ,
@@ -1145,7 +1145,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    PAGES AND POST LAYOUT SETTINGS
     ------------------------------------------------------------------------------------------------------*/
-    function tc_layout_option_map( $get_default = null ) {
+    function czr_layout_option_map( $get_default = null ) {
       return array(
               //Global sidebar layout
               'tc_sidebar_global_layout' => array(
@@ -1231,7 +1231,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                   POST LISTS SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function tc_post_list_option_map( $get_default = null ) {
+    function czr_post_list_option_map( $get_default = null ) {
       global $wp_version;
       return array(
               'tc_post_list_excerpt_length'  =>  array(
@@ -1495,7 +1495,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    SINGLE POSTS SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function tc_single_post_option_map( $get_default = null ) {
+    function czr_single_post_option_map( $get_default = null ) {
       return array(
           'tc_single_post_thumb_location'  =>  array(
                             'default'       => 'hide',
@@ -1542,7 +1542,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    BREADCRUMB SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function tc_breadcrumb_option_map( $get_default = null ) {
+    function czr_breadcrumb_option_map( $get_default = null ) {
         return array(
               'tc_breadcrumb' => array(
                               'default'       => 1,//Breadcrumb is checked by default
@@ -1595,7 +1595,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                   POST METAS SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function tc_post_metas_option_map( $get_default = null ){
+    function czr_post_metas_option_map( $get_default = null ){
       return array(
               'tc_show_post_metas'  =>  array(
                                 'default'       => 1,
@@ -1762,7 +1762,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    GALLERY SECTION
     -----------------------------------------------------------------------------------------------------*/
-    function tc_gallery_option_map( $get_default = null ){
+    function czr_gallery_option_map( $get_default = null ){
       return array(
               'tc_enable_gallery'  =>  array(
                                 'default'       => 1,
@@ -1800,7 +1800,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    PARAGRAPHS SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function tc_paragraph_option_map( $get_default = null ){
+    function czr_paragraph_option_map( $get_default = null ){
       return array(
               'tc_enable_dropcap'  =>  array(
                                 'default'       => 0,
@@ -1862,7 +1862,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    COMMENTS SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function tc_comment_option_map( $get_default = null ) {
+    function czr_comment_option_map( $get_default = null ) {
       return array(
               'tc_comment_show_bubble'  =>  array(
                                 'default'       => 1,
@@ -1958,7 +1958,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    POST NAVIGATION SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function tc_post_navigation_option_map( $get_default = null ) {
+    function czr_post_navigation_option_map( $get_default = null ) {
       return array(
               'tc_show_post_navigation'  =>  array(
                                 'default'       => 1,
@@ -2011,7 +2011,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    SIDEBAR SOCIAL LINKS SETTINGS SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function tc_sidebars_option_map( $get_default = null ) {
+    function czr_sidebars_option_map( $get_default = null ) {
       return array(
               'tc_social_in_left-sidebar' =>  array(
                                 'default'       => 0,
@@ -2055,7 +2055,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    FOOTER GLOBAL SETTINGS SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function tc_footer_global_settings_option_map( $get_default = null ) {
+    function czr_footer_global_settings_option_map( $get_default = null ) {
       return array(
               'tc_social_in_footer' =>  array(
                                 'default'       => 1,
@@ -2112,7 +2112,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    CUSTOM CSS SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function tc_custom_css_option_map( $get_default = null ) {
+    function czr_custom_css_option_map( $get_default = null ) {
       return array(
               'tc_custom_css' =>  array(
                                 'sanitize_callback' => 'wp_filter_nohtml_kses',
@@ -2136,7 +2136,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                               WEBSITE PERFORMANCES SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function tc_performance_option_map( $get_default = null ) {
+    function czr_performance_option_map( $get_default = null ) {
       return array(
               'tc_minified_skin'  =>  array(
                                 'default'       => 1,
@@ -2161,7 +2161,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                               FRONT END NOTICES AND PLACEHOLDERS SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function tc_placeholders_notice_map( $get_default = null ) {
+    function czr_placeholders_notice_map( $get_default = null ) {
       return array(
               'tc_display_front_help'  =>  array(
                                 'default'       => 1,
@@ -2177,7 +2177,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                               FRONT END EXTERNAL RESOURCES SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function tc_external_resources_option_map( $get_default = null ) {
+    function czr_external_resources_option_map( $get_default = null ) {
       return array(
               'tc_font_awesome_icons'  =>  array(
                                 'default'       => 1,
@@ -2214,7 +2214,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     * hook : tc_add_panel_map
     * @return  associative array of customizer panels
     */
-    function tc_popul_panels_map( $panel_map ) {
+    function czr_popul_panels_map( $panel_map ) {
       $_new_panels = array(
         'tc-global-panel' => array(
                   'priority'       => 10,
@@ -2266,7 +2266,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /**
      * hook : tc_remove_section_map
      */
-    function tc_popul_remove_section_map( $_sections ) {
+    function czr_popul_remove_section_map( $_sections ) {
       //customizer option array
       $remove_section = array(
         'static_front_page' ,
@@ -2285,7 +2285,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     * Print the themes section (themes switcher) when previewing the themes from wp-admin/themes.php
     * hook : tc_remove_section_map
     */
-    function tc_set_theme_switcher_visibility( $_sections) {
+    function czr_set_theme_switcher_visibility( $_sections) {
       //Don't do anything is in preview frame
       //=> because once the preview is ready, a postMessage is sent to the panel frame to refresh the sections and panels
       //Do nothing if WP version under 4.2
@@ -2318,7 +2318,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /**
     * hook : tc_add_section_map
     */
-    function tc_popul_section_map( $_sections ) {
+    function czr_popul_section_map( $_sections ) {
       //For nav menus option
       $locations      = get_registered_nav_menus();
       $menus          = wp_get_nav_menus();
@@ -2575,7 +2575,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     * @since Customizr 3.0.15
     *
     */
-    function tc_generates_featured_pages( $_original_map ) {
+    function czr_generates_featured_pages( $_original_map ) {
       $default = array(
         'dropdown'  =>  array(
               'one'   => __( 'Home featured page one' , 'customizr' ),
@@ -2640,7 +2640,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     * @since Customizr 3.0.15
     *
     */
-    function tc_generates_socials( $_original_map ) {
+    function czr_generates_socials( $_original_map ) {
       //gets the social network array
       $socials      = apply_filters( 'tc_default_socials' , CZR_init::$instance -> socials );
 
@@ -2678,7 +2678,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     * @since Customizr 3.0.15
     *
     */
-    private function tc_get_skins($path) {
+    private function czr_get_skins($path) {
       //checks if path exists
       if ( !file_exists($path) )
         return;
@@ -2726,7 +2726,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     * @package Customizr
     * @since Customizr 3.1.0
     */
-    private function tc_layout_choices() {
+    private function czr_layout_choices() {
         $global_layout  = apply_filters( 'tc_global_layout' , CZR_init::$instance -> global_layout );
         $layout_choices = array();
         foreach ($global_layout as $key => $value) {
@@ -2741,7 +2741,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     * @package Customizr
     * @since Customizr 3.0.1
     */
-    private function tc_slider_choices() {
+    private function czr_slider_choices() {
       $__options    =   get_option('tc_theme_options');
       $slider_names   =   isset($__options['tc_sliders']) ? $__options['tc_sliders'] : array();
 
@@ -2766,7 +2766,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     * @since Customizr 3.0.11
     * @updated Customizr 3.0.15
     */
-    private function tc_build_skin_list() {
+    private function czr_build_skin_list() {
         $parent_skins   = $this -> tc_get_skins(TC_BASE .'inc/assets/css');
         $child_skins    = ( CZR___::$instance -> tc_is_child() && file_exists(TC_BASE_CHILD .'inc/assets/css') ) ? $this -> tc_get_skins(TC_BASE_CHILD .'inc/assets/css') : array();
         $skin_list      = array_merge( $parent_skins , $child_skins );
@@ -2784,7 +2784,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
      * @package Customizr
      * @since Customizr 1.1.4
      */
-    function tc_sanitize_textarea( $value) {
+    function czr_sanitize_textarea( $value) {
       $value = esc_html( $value);
       return $value;
     }
@@ -2796,7 +2796,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
      * @package Customizr
      * @since Customizr 1.1.4
      */
-    function tc_sanitize_number( $value) {
+    function czr_sanitize_number( $value) {
       if ( ! $value || is_null($value) )
         return $value;
       $value = esc_attr( $value); // clean input
@@ -2809,7 +2809,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
      * @package Customizr
      * @since Customizr 1.1.4
      */
-    function tc_sanitize_url( $value) {
+    function czr_sanitize_url( $value) {
       $value = esc_url( $value);
       return $value;
     }
@@ -2819,7 +2819,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
      * @package Customizr
      * @since Customizr 3.4.11
      */
-    function tc_sanitize_email( $value) {
+    function czr_sanitize_email( $value) {
       return sanitize_email( $value );
     }
 
@@ -2828,7 +2828,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
      * @package Customizr
      * @since Customizr 1.1.4
      */
-    function tc_sanitize_hex_color( $color ) {
+    function czr_sanitize_hex_color( $color ) {
       if ( $unhashed = sanitize_hex_color_no_hash( $color ) )
         return '#' . $unhashed;
 
@@ -2841,7 +2841,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     * @package Customizr
     * @since Customizr 3.1.11
     */
-    function tc_sanitize_uploads( $url ) {
+    function czr_sanitize_uploads( $url ) {
       $upload_dir = wp_upload_dir();
       return str_replace($upload_dir['baseurl'], '', $url);
     }

--- a/inc/class-fire-utils_settings_map.php
+++ b/inc/class-fire-utils_settings_map.php
@@ -12,8 +12,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_utils_settings_map' ) ) :
-  class TC_utils_settings_map {
+if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
+  class CZR_utils_settings_map {
     static $instance;
     private $is_wp_version_before_4_0;
     public $customizer_map = array();
@@ -145,7 +145,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
       global $wp_version;
       return array(
               'tc_logo_upload'  => array(
-                                'control'   =>  version_compare( $wp_version, '4.3', '>=' ) ? 'TC_Customize_Cropped_Image_Control' : 'TC_Customize_Upload_Control',
+                                'control'   =>  version_compare( $wp_version, '4.3', '>=' ) ? 'CZR_Customize_Cropped_Image_Control' : 'CZR_Customize_Upload_Control',
                                 'label'     =>  __( 'Logo Upload (supported formats : .jpg, .png, .gif, svg, svgz)' , 'customizr' ),
                                 'title'     => __( 'LOGO' , 'customizr'),
                                 'section'   => 'logo_sec',
@@ -163,13 +163,13 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_logo_resize'  => array(
                                 'default'   =>  1,
                                 'label'     =>  __( 'Force logo dimensions to max-width:250px and max-height:100px' , 'customizr' ),
-                                'control'   =>  'TC_controls' ,
+                                'control'   =>  'CZR_controls' ,
                                 'section'   =>  'logo_sec' ,
                                 'type'        => 'checkbox' ,
                                 'notice'    => __( "Uncheck this option to keep your original logo dimensions." , 'customizr')
               ),
               'tc_sticky_logo_upload'  => array(
-                                'control'   =>  version_compare( $wp_version, '4.3', '>=' ) ? 'TC_Customize_Cropped_Image_Control' : 'TC_Customize_Upload_Control',
+                                'control'   =>  version_compare( $wp_version, '4.3', '>=' ) ? 'CZR_Customize_Cropped_Image_Control' : 'CZR_Customize_Upload_Control',
                                 'label'     =>  __( 'Sticky Logo Upload (supported formats : .jpg, .png, .gif, svg, svgz)' , 'customizr' ),
                                 'section'   =>  'logo_sec' ,
                                 'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
@@ -186,7 +186,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
 
               //favicon
               'tc_fav_upload' => array(
-                                'control'   =>  'TC_Customize_Upload_Control' ,
+                                'control'   =>  'CZR_Customize_Upload_Control' ,
                                 'label'       => __( 'Favicon Upload (supported formats : .ico, .png, .gif)' , 'customizr' ),
                                 'title'     => __( 'FAVICON' , 'customizr'),
                                 'section'   =>  'logo_sec' ,
@@ -204,7 +204,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               //skin select
               'tc_skin'     => array(
                                 'default'   =>  'blue3.css' ,
-                                'control'   => 'TC_controls' ,
+                                'control'   => 'CZR_controls' ,
                                 'label'     =>  __( 'Choose a predefined skin' , 'customizr' ),
                                 'section'   =>  'skins_sec' ,
                                 'type'      =>  'select' ,
@@ -214,7 +214,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_skin_random' => array(
                                 'default'   => 0,
-                                'control'   => 'TC_controls',
+                                'control'   => 'CZR_controls',
                                 'label'     => __('Randomize the skin', 'customizr'),
                                 'section'   => 'skins_sec',
                                 'type'      => 'checkbox',
@@ -231,21 +231,21 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
     function tc_fonts_option_map( $get_default = null ) {
       return array(
               'tc_fonts'      => array(
-                                'default'       => TC_utils::$inst -> tc_user_started_before_version( '3.2.9' , '1.0.1') ? 'helvetica_arial' : '_g_fjalla_cantarell',
+                                'default'       => CZR_utils::$inst -> tc_user_started_before_version( '3.2.9' , '1.0.1') ? 'helvetica_arial' : '_g_fjalla_cantarell',
                                 'label'         => __( 'Select a beautiful font pair (headings &amp; default fonts) or single font for your website.' , 'customizr' ),
-                                'control'       =>  'TC_controls',
+                                'control'       =>  'CZR_controls',
                                 'section'       => 'fonts_sec',
                                 'type'          => 'select' ,
-                                'choices'       => TC_utils::$inst -> tc_get_font( 'list' , 'name' ),
+                                'choices'       => CZR_utils::$inst -> tc_get_font( 'list' , 'name' ),
                                 'priority'      => 10,
                                 'transport'     => 'postMessage',
                                 'notice'        => __( "This font picker allows you to preview and select among a handy selection of font pairs and single fonts. If you choose a pair, the first font will be applied to the site main headings : site name, site description, titles h1, h2, h3., while the second will be the default font of your website for any texts or paragraphs." , 'customizr' )
               ),
               'tc_body_font_size'      => array(
-                                'default'       => TC_utils::$inst -> tc_user_started_before_version( '3.2.9', '1.0.1' ) ? 14 : 15,
+                                'default'       => CZR_utils::$inst -> tc_user_started_before_version( '3.2.9', '1.0.1' ) ? 14 : 15,
                                 'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
                                 'label'         => __( 'Set your website default font size in pixels.' , 'customizr' ),
-                                'control'       =>  'TC_controls',
+                                'control'       =>  'CZR_controls',
                                 'section'       => 'fonts_sec',
                                 'type'          => 'number' ,
                                 'step'          => 1,
@@ -273,7 +273,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
       return array(
               'tc_link_scroll'  =>  array(
                                 'default'       => 0,
-                                'control'   => 'TC_controls' ,
+                                'control'   => 'CZR_controls' ,
                                 'label'       => __( 'Smooth scroll on click' , 'customizr' ),
                                 'section'     => 'links_sec' ,
                                 'type'        => 'checkbox' ,
@@ -281,7 +281,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_link_hover_effect'  =>  array(
                                 'default'       => 1,
-                                'control'     => 'TC_controls' ,
+                                'control'     => 'CZR_controls' ,
                                 'label'         => __( "Fade effect on link hover" , "customizr" ),
                                 'section'       => 'links_sec' ,
                                 'type'          => 'checkbox' ,
@@ -291,7 +291,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
 
               'tc_ext_link_style'  =>  array(
                                 'default'       => 0,
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( "Display an icon next to external links" , "customizr" ),
                                 'section'       => 'links_sec' ,
                                 'type'          => 'checkbox' ,
@@ -302,7 +302,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
 
               'tc_ext_link_target'  =>  array(
                                 'default'       => 0,
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( "Open external links in a new tab" , "customizr" ),
                                 'section'       => 'links_sec' ,
                                 'type'          => 'checkbox' ,
@@ -322,7 +322,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
       return array(
               'tc_show_title_icon'  =>  array(
                                 'default'       => 1,
-                                'control'     => 'TC_controls' ,
+                                'control'     => 'CZR_controls' ,
                                 'label'         => __( "Display icons next to titles" , "customizr" ),
                                 'section'       => 'titles_icons_sec' ,
                                 'type'          => 'checkbox',
@@ -331,8 +331,8 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
                                 'transport'   => 'postMessage'
               ),
               'tc_show_page_title_icon'  =>  array(
-                                'default'       => TC_utils::$inst -> tc_user_started_before_version( '3.3.0', '1.0.11' ) ? 1 : 0,
-                                'control'       => 'TC_controls' ,
+                                'default'       => CZR_utils::$inst -> tc_user_started_before_version( '3.3.0', '1.0.11' ) ? 1 : 0,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( "Display a page icon next to the page title" , "customizr" ),
                                 'section'       => 'titles_icons_sec' ,
                                 'type'          => 'checkbox',
@@ -340,8 +340,8 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
                                 'transport'   => 'postMessage'
               ),
               'tc_show_post_title_icon'  =>  array(
-                                'default'       => TC_utils::$inst -> tc_user_started_before_version( '3.3.0', '1.0.11' ) ? 1 : 0,
-                                'control'     => 'TC_controls' ,
+                                'default'       => CZR_utils::$inst -> tc_user_started_before_version( '3.3.0', '1.0.11' ) ? 1 : 0,
+                                'control'     => 'CZR_controls' ,
                                 'label'         => __( "Display a post icon next to the single post title" , "customizr" ),
                                 'section'       => 'titles_icons_sec' ,
                                 'type'          => 'checkbox',
@@ -350,7 +350,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_show_archive_title_icon'  =>  array(
                                 'default'       => 1,
-                                'control'     => 'TC_controls' ,
+                                'control'     => 'CZR_controls' ,
                                 'label'         => __( "Display an icon next to the archive title" , "customizr" ),
                                 'section'       => 'titles_icons_sec' ,
                                 'type'          => 'checkbox',
@@ -359,8 +359,8 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
                                 'transport'   => 'postMessage'
               ),
               'tc_show_post_list_title_icon'  =>  array(
-                                'default'       => TC_utils::$inst -> tc_user_started_before_version( '3.3.0' , '1.0.11' ) ? 1 : 0,
-                                'control'     => 'TC_controls' ,
+                                'default'       => CZR_utils::$inst -> tc_user_started_before_version( '3.3.0' , '1.0.11' ) ? 1 : 0,
+                                'control'     => 'CZR_controls' ,
                                 'label'         => __( "Display an icon next to each post title in an archive page" , "customizr" ),
                                 'section'       => 'titles_icons_sec' ,
                                 'type'          => 'checkbox',
@@ -370,7 +370,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_show_sidebar_widget_icon'  =>  array(
                                 'default'       => 1,
-                                'control'     => 'TC_controls' ,
+                                'control'     => 'CZR_controls' ,
                                 'label'         => __( "WP sidebar widgets : display icons next to titles" , "customizr" ),
                                 'section'       => 'titles_icons_sec' ,
                                 'type'          => 'checkbox',
@@ -379,7 +379,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_show_footer_widget_icon'  =>  array(
                                 'default'       => 1,
-                                'control'     => 'TC_controls' ,
+                                'control'     => 'CZR_controls' ,
                                 'label'         => __( "WP footer widgets : display icons next to titles" , "customizr" ),
                                 'section'       => 'titles_icons_sec' ,
                                 'type'          => 'checkbox',
@@ -399,7 +399,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
       $_image_options =  array(
               'tc_fancybox' =>  array(
                                 'default'       => 1,
-                                'control'   => 'TC_controls' ,
+                                'control'   => 'CZR_controls' ,
                                 'label'       => __( 'Lightbox effect on images' , 'customizr' ),
                                 'section'     => 'images_sec' ,
                                 'type'        => 'checkbox' ,
@@ -408,7 +408,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
 
               'tc_fancybox_autoscale' =>  array(
                                 'default'       => 1,
-                                'control'   => 'TC_controls' ,
+                                'control'   => 'CZR_controls' ,
                                 'label'       => __( 'Autoscale images on zoom' , 'customizr' ),
                                 'section'     => 'images_sec' ,
                                 'type'        => 'checkbox' ,
@@ -417,7 +417,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
 
               'tc_retina_support' =>  array(
                                 'default'       => 0,
-                                'control'   => 'TC_controls' ,
+                                'control'   => 'CZR_controls' ,
                                 'label'       => __( 'High resolution (Retina) support' , 'customizr' ),
                                 'section'     => 'images_sec' ,
                                 'type'        => 'checkbox' ,
@@ -431,7 +431,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_slider_parallax'  =>  array(
                                 'default'       => 1,
-                                'control'   => 'TC_controls' ,
+                                'control'   => 'CZR_controls' ,
                                 'label'       => __( "Sliders : use parallax scrolling" , "customizr" ),
                                 'section'     => 'images_sec' ,
                                 'type'        => 'checkbox' ,
@@ -439,7 +439,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_display_slide_loader'  =>  array(
                                 'default'       => 1,
-                                'control'   => 'TC_controls' ,
+                                'control'   => 'CZR_controls' ,
                                 'label'       => __( "Sliders : display on loading icon before rendering the slides" , "customizr" ),
                                 'section'     => 'images_sec' ,
                                 'type'        => 'checkbox' ,
@@ -448,7 +448,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
 
                'tc_center_slider_img'  =>  array(
                                 'default'       => 1,
-                                'control'   => 'TC_controls' ,
+                                'control'   => 'CZR_controls' ,
                                 'label'       => __( "Dynamic slider images centering on any devices" , "customizr" ),
                                 'section'     => 'images_sec' ,
                                 'type'        => 'checkbox' ,
@@ -456,7 +456,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_center_img'  =>  array(
                                 'default'       => 1,
-                                'control'   => 'TC_controls' ,
+                                'control'   => 'CZR_controls' ,
                                 'label'       => __( "Dynamic thumbnails centering on any devices" , "customizr" ),
                                 'section'     => 'images_sec' ,
                                 'type'        => 'checkbox' ,
@@ -468,7 +468,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
         $_image_options = array_merge( $_image_options, array(
                'tc_resp_slider_img'  =>  array(
                                 'default'     => 0,
-                                'control'     => 'TC_controls' ,
+                                'control'     => 'CZR_controls' ,
                                 'title'       => __( 'Responsive settings', 'customizr' ),
                                 'label'       => __( "Enable the WordPress responsive image feature for the slider" , "customizr" ),
                                 'section'     => 'images_sec' ,
@@ -476,7 +476,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_resp_thumbs_img'  =>  array(
                                 'default'     => 0,
-                                'control'     => 'TC_controls' ,
+                                'control'     => 'CZR_controls' ,
                                 'label'       => __( "Enable the WordPress responsive image feature for the theme's thumbnails" , "customizr" ),
                                 'section'     => 'images_sec' ,
                                 'notice'      => __( 'This feature has been introduced in WordPress v4.4+ (dec-2015), and might have minor side effects on some of your existing images. Check / uncheck this option to safely verify that your images are displayed nicely.' , 'customizr' ),
@@ -500,7 +500,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
       return array(
               'tc_block_reorder'  =>  array(
                                 'default'       => 1,
-                                'control'   => 'TC_controls' ,
+                                'control'   => 'CZR_controls' ,
                                 'label'         => sprintf('<span class="dashicons dashicons-smartphone"></span> %s', __( 'Dynamic sidebar reordering on small devices' , 'customizr' ) ),
                                 'section'     => 'responsive_sec' ,
                                 'type'        => 'checkbox' ,
@@ -518,7 +518,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
       return array(
               'tc_show_author_info'  =>  array(
                                 'default'       => 1,
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( "Display an author box after each single post content" , "customizr" ),
                                 'section'       => 'authors_sec',
                                 'type'          => 'checkbox',
@@ -537,7 +537,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
       return array(
               'tc_smoothscroll'  =>  array(
                                 'default'       => 1,
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __("Enable Smooth Scroll", "customizr"),
                                 'section'       => 'smoothscroll_sec',
                                 'type'          => 'checkbox',
@@ -563,7 +563,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_header_layout'  =>  array(
                               'default'       => 'left',
                               'title'         => __( 'Header design and layout' , 'customizr'),
-                              'control'       => 'TC_controls' ,
+                              'control'       => 'CZR_controls' ,
                               'label'         => __( "Choose a layout for the header" , "customizr" ),
                               'section'       => 'header_layout_sec' ,
                               'type'          =>  'select' ,
@@ -579,7 +579,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_top_border' => array(
                                 'default'       =>  1,//top border on by default
                                 'label'         =>  __( 'Display top border' , 'customizr' ),
-                                'control'       =>  'TC_controls' ,
+                                'control'       =>  'CZR_controls' ,
                                 'section'       =>  'header_layout_sec' ,
                                 'type'          =>  'checkbox' ,
                                 'notice'        =>  __( 'Uncheck this option to remove the colored top border.' , 'customizr' ),
@@ -587,7 +587,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_show_tagline'  =>  array(
                                 'default'       => 1,
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( "Display the tagline" , "customizr" ),
                                 'section'       => 'header_layout_sec' ,
                                 'type'          => 'checkbox' ,
@@ -597,7 +597,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_woocommerce_header_cart' => array(
                                'default'   => 1,
                                'label'     => sprintf('<span class="dashicons dashicons-cart"></span> %s', __( "Display the shopping cart in the header" , "customizr" ) ),
-                               'control'   => 'TC_controls' ,
+                               'control'   => 'CZR_controls' ,
                                'section'   => 'header_layout_sec',
                                'notice'    => __( "WooCommerce: check to display a cart icon showing the number of items in your cart next to your header's tagline.", 'customizr' ),
                                'type'      => 'checkbox' ,
@@ -607,15 +607,15 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_social_in_header' =>  array(
                                 'default'       => 1,
                                 'label'       => __( 'Social links in header' , 'customizr' ),
-                                'control'   =>  'TC_controls' ,
+                                'control'   =>  'CZR_controls' ,
                                 'section'     => 'header_layout_sec' ,
                                 'type'        => 'checkbox' ,
                                 'priority'      => 20,
                                 'transport'   => 'postMessage'
               ),
               'tc_display_boxed_navbar'  =>  array(
-                                'default'       => TC_utils::$inst -> tc_user_started_before_version( '3.3.13', '1.0.18' ) ? 1 : 0,
-                                'control'       => 'TC_controls' ,
+                                'default'       => CZR_utils::$inst -> tc_user_started_before_version( '3.3.13', '1.0.18' ) ? 1 : 0,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( "Display menu in a box" , "customizr" ),
                                 'section'       => 'header_layout_sec' ,
                                 'type'          => 'checkbox' ,
@@ -625,7 +625,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_sticky_header'  =>  array(
                                 'default'       => 1,
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'title'         => __( 'Sticky header settings' , 'customizr'),
                                 'label'         => __( "Sticky on scroll" , "customizr" ),
                                 'section'       => 'header_layout_sec' ,
@@ -636,7 +636,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_sticky_show_tagline'  =>  array(
                                 'default'       => 0,
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( "Sticky header : display the tagline" , "customizr" ),
                                 'section'       => 'header_layout_sec' ,
                                 'type'          => 'checkbox' ,
@@ -646,7 +646,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_woocommerce_header_cart_sticky' => array(
                                'default'   => 1,
                                'label'     => sprintf('<span class="dashicons dashicons-cart"></span> %s', __( "Sticky header: display the shopping cart" , "customizr" ) ),
-                               'control'   => 'TC_controls' ,
+                               'control'   => 'CZR_controls' ,
                                'section'   => 'header_layout_sec',
                                'type'      => 'checkbox' ,
                                'priority'  => 45,
@@ -656,7 +656,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_sticky_show_title_logo'  =>  array(
                                 'default'       => 1,
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( "Sticky header : display the title / logo" , "customizr" ),
                                 'section'       => 'header_layout_sec' ,
                                 'type'          => 'checkbox' ,
@@ -665,7 +665,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_sticky_shrink_title_logo'  =>  array(
                                 'default'       => 1,
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( "Sticky header : shrink title / logo" , "customizr" ),
                                 'section'       => 'header_layout_sec' ,
                                 'type'          => 'checkbox' ,
@@ -674,7 +674,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_sticky_show_menu'  =>  array(
                                 'default'       => 1,
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( "Sticky header : display the menu" , "customizr" ),
                                 'section'       => 'header_layout_sec' ,
                                 'type'          => 'checkbox' ,
@@ -684,7 +684,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_sticky_transparent_on_scroll'  =>  array(
                                 'default'       => 1,
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( "Sticky header : semi-transparent on scroll" , "customizr" ),
                                 'section'       => 'header_layout_sec' ,
                                 'type'          => 'checkbox' ,
@@ -693,7 +693,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_sticky_z_index'  =>  array(
                                 'default'       => 100,
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
                                 'label'         => __( "Set the header z-index" , "customizr" ),
                                 'section'       => 'header_layout_sec' ,
@@ -722,7 +722,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
       return array(
               'tc_display_second_menu'  =>  array(
                                 'default'       => 0,
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( "Display a secondary (horizontal) menu in the header." , "customizr" ),
                                 'section'       => 'nav' ,
                                 'type'          => 'checkbox' ,
@@ -730,8 +730,8 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
                                 'notice'        => __( "When you've set your main menu as a vertical side navigation, you can check this option to display a complementary horizontal menu in the header." , 'customizr' ),
               ),
               'tc_menu_style'  =>  array(
-                              'default'       => TC_utils::$inst -> tc_user_started_before_version( '3.4.0', '1.2.0' ) ? 'navbar' : 'aside',
-                              'control'       => 'TC_controls' ,
+                              'default'       => CZR_utils::$inst -> tc_user_started_before_version( '3.4.0', '1.2.0' ) ? 'navbar' : 'aside',
+                              'control'       => 'CZR_controls' ,
                               'title'         => __( 'Main menu design' , 'customizr'),
                               'label'         => __( 'Select a design : side menu (vertical) or regular (horizontal)' , 'customizr' ),
                               'section'       => 'nav' ,
@@ -744,7 +744,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_menu_resp_dropdown_limit_to_viewport'  =>  array(
                                 'default'       => 0,
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => sprintf('<span class="dashicons dashicons-smartphone"></span> %s', __( "For mobile devices (responsive), limit the height of the dropdown menu block to the visible viewport." , "customizr" ) ),
                                 'section'       => 'nav' ,
                                 'type'          => 'checkbox' ,
@@ -753,7 +753,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_display_menu_label'  =>  array(
                                 'default'       => 0,
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( "Display a label next to the menu button." , "customizr" ),
                                 'section'       => 'nav' ,
                                 'type'          => 'checkbox' ,
@@ -761,8 +761,8 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
                                 'notice'        => __( 'Note : the label is hidden on mobile devices.' , 'customizr' ),
               ),
               'tc_menu_position'  =>  array(
-                                'default'       => TC_utils::$inst -> tc_user_started_before_version( '3.4.0', '1.2.0' ) ? 'pull-menu-left' : 'pull-menu-right',
-                                'control'       => 'TC_controls' ,
+                                'default'       => CZR_utils::$inst -> tc_user_started_before_version( '3.4.0', '1.2.0' ) ? 'pull-menu-left' : 'pull-menu-right',
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( 'Menu position (for "main" menu)' , "customizr" ),
                                 'section'       => 'nav' ,
                                 'type'          =>  'select' ,
@@ -786,7 +786,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_second_menu_position'  =>  array(
                                 'default'       => 'pull-menu-left',
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'title'         => __( 'Secondary (horizontal) menu design' , 'customizr'),
                                 'label'         => __( 'Menu position (for the horizontal menu)' , "customizr" ),
                                 'section'       => 'nav' ,
@@ -801,8 +801,8 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               //The hover menu type has been introduced in v3.1.0.
               //For users already using the theme (no theme's option set), the default choice is click, for new users, it is hover.
               'tc_menu_type'  => array(
-                                'default'   =>  TC_utils::$inst -> tc_user_started_before_version( '3.1.0' , '1.0.0' ) ? 'click' : 'hover',
-                                'control'   =>  'TC_controls' ,
+                                'default'   =>  CZR_utils::$inst -> tc_user_started_before_version( '3.1.0' , '1.0.0' ) ? 'click' : 'hover',
+                                'control'   =>  'CZR_controls' ,
                                 'label'     =>  __( 'Select a submenu expansion option' , 'customizr' ),
                                 'section'   =>  'nav' ,
                                 'type'      =>  'select' ,
@@ -814,7 +814,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_menu_submenu_fade_effect'  =>  array(
                                 'default'       => 1,
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( "Reveal the sub-menus blocks with a fade effect" , "customizr" ),
                                 'section'       => 'nav' ,
                                 'type'          => 'checkbox' ,
@@ -823,7 +823,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_menu_submenu_item_move_effect'  =>  array(
                                 'default'       => 1,
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( "Hover move effect for the sub menu items" , "customizr" ),
                                 'section'       => 'nav' ,
                                 'type'          => 'checkbox' ,
@@ -832,7 +832,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_second_menu_resp_setting'  =>  array(
                                 'default'       => 'in-sn-before',
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => sprintf('<span class="dashicons dashicons-smartphone"></span> %s', __( "Choose a mobile devices (responsive) behaviour for the secondary menu." , "customizr" ) ),
                                 'section'       => 'nav',
                                 'type'      =>  'select',
@@ -847,7 +847,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_hide_all_menus'  =>  array(
                                 'default'       => 0,
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'title'         => __( 'Remove all the menus.' , 'customizr'),
                                 'label'         => __( "Don't display any menus in the header of your website" , "customizr" ),
                                 'section'       => 'nav' ,
@@ -901,7 +901,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               //title
               'homecontent_title'         => array(
                       'setting_type'  =>  null,
-                      'control'   =>  'TC_controls' ,
+                      'control'   =>  'CZR_controls' ,
                       'title'       => __( 'Choose content and layout' , 'customizr' ),
                       'section'     => 'frontpage_sec' ,
                       'type'      => 'title' ,
@@ -938,7 +938,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_show_post_navigation_home'  =>  array(
                                 'default'       => 1,
-                                'control'     => 'TC_controls' ,
+                                'control'     => 'CZR_controls' ,
                                 'label'         => __( "Display navigation in your home blog" , "customizr" ),
                                 'section'       => 'frontpage_sec',
                                 'type'          => 'checkbox',
@@ -950,7 +950,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
                                 'default'     => array(),
                                 'label'       =>  __( 'Apply a category filter to your home / blog posts' , 'customizr'  ),
                                 'section'     => 'frontpage_sec',
-                                'control'     => 'TC_Customize_Multipicker_Categories_Control',
+                                'control'     => 'CZR_Customize_Multipicker_Categories_Control',
                                 'type'        => 'tc_multiple_picker',
                                 'priority'    => 1,
                                 'notice'      => $_cat_picker_notice
@@ -960,7 +960,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
                                 'default'       => 'f' ,//Default layout for home page is full width
                                 'label'       =>  __( 'Set up the front page layout' , 'customizr' ),
                                 'section'     => 'frontpage_sec' ,
-                                'control'     => 'TC_controls' ,
+                                'control'     => 'CZR_controls' ,
                                 'type'        => 'select' ,
                                 'choices'     => $this -> tc_layout_choices(),
                                 'priority'    => 2,
@@ -969,7 +969,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               //select slider
               'tc_front_slider' => array(
                                 'default'     => 'demo' ,
-                                'control'     => 'TC_controls' ,
+                                'control'     => 'CZR_controls' ,
                                 'title'       => __( 'Slider options' , 'customizr' ),
                                 'label'       => __( 'Select front page slider' , 'customizr' ),
                                 'section'     => 'frontpage_sec' ,
@@ -981,7 +981,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               //posts slider
               'tc_posts_slider_number' => array(
                                 'default'     => 1 ,
-                                'control'     => 'TC_controls',
+                                'control'     => 'CZR_controls',
                                 'label'       => __('Number of posts to display', 'customizr'),
                                 'section'     => 'frontpage_sec' ,
                                 'type'        => 'number',
@@ -990,7 +990,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_posts_slider_stickies' => array(
                                 'default'     => 0,
-                                'control'     => 'TC_controls',
+                                'control'     => 'CZR_controls',
                                 'label'       => __( 'Include only sticky posts' , 'customizr' ),
                                 'section'     => 'frontpage_sec' ,
                                 'type'        => 'checkbox' ,
@@ -1003,7 +1003,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_posts_slider_title' => array(
                                 'default'     => 1,
-                                'control'     => 'TC_controls',
+                                'control'     => 'CZR_controls',
                                 'label'       => __( 'Display the title' , 'customizr' ),
                                 'section'     => 'frontpage_sec' ,
                                 'type'        => 'checkbox' ,
@@ -1012,7 +1012,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_posts_slider_text' => array(
                                 'default'     => 1,
-                                'control'     => 'TC_controls',
+                                'control'     => 'CZR_controls',
                                 'label'       => __( 'Display the excerpt' , 'customizr' ),
                                 'section'     => 'frontpage_sec' ,
                                 'type'        => 'checkbox' ,
@@ -1021,7 +1021,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_posts_slider_link' => array(
                                 'default'     => 'cta',
-                                'control'     => 'TC_controls',
+                                'control'     => 'CZR_controls',
                                 'label'       => __( 'Link post with' , 'customizr' ),
                                 'section'     => 'frontpage_sec' ,
                                 'type'        => 'select' ,
@@ -1044,7 +1044,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               //select slider
               'tc_slider_width' => array(
                                 'default'       => 1,
-                                'control'   => 'TC_controls' ,
+                                'control'   => 'CZR_controls' ,
                                 'label'       => __( 'Full width slider' , 'customizr' ),
                                 'section'     => 'frontpage_sec' ,
                                 'type'        => 'checkbox' ,
@@ -1056,7 +1056,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_slider_delay' => array(
                                 'default'       => 5000,
                                 'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
-                                'control'   => 'TC_controls' ,
+                                'control'   => 'CZR_controls' ,
                                 'label'       => __( 'Delay between each slides' , 'customizr' ),
                                 'section'     => 'frontpage_sec' ,
                                 'type'        => 'number' ,
@@ -1068,7 +1068,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_slider_default_height' => array(
                                 'default'       => 500,
                                 'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
-                                'control'   => 'TC_controls' ,
+                                'control'   => 'CZR_controls' ,
                                 'label'       => __( "Set slider's height in pixels" , 'customizr' ),
                                 'section'     => 'frontpage_sec' ,
                                 'type'        => 'number' ,
@@ -1080,7 +1080,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_slider_default_height_apply_all'  =>  array(
                                 'default'       => 1,
                                 'label'       => __( 'Apply this height to all sliders' , 'customizr' ),
-                                'control'   =>  'TC_controls' ,
+                                'control'   =>  'CZR_controls' ,
                                 'section'     => 'frontpage_sec' ,
                                 'type'        => 'checkbox' ,
                                 'priority'       => 53,
@@ -1088,7 +1088,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_slider_change_default_img_size'  =>  array(
                                 'default'       => 0,
                                 'label'       => __( "Replace the default image slider's height" , 'customizr' ),
-                                'control'   =>  'TC_controls' ,
+                                'control'   =>  'CZR_controls' ,
                                 'section'     => 'frontpage_sec' ,
                                 'type'        => 'checkbox' ,
                                 'priority'       => 54,
@@ -1101,7 +1101,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               //Front page widget area
               'tc_show_featured_pages'  => array(
                                 'default'       => 1,
-                                'control'   => 'TC_controls' ,
+                                'control'   => 'CZR_controls' ,
                                 'title'       => __( 'Featured pages options' , 'customizr' ),
                                 'label'       => __( 'Display home featured pages area' , 'customizr' ),
                                 'section'     => 'frontpage_sec' ,
@@ -1116,7 +1116,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               //display featured page images
               'tc_show_featured_pages_img' => array(
                                 'default'       => 1,
-                                'control'   => 'TC_controls' ,
+                                'control'   => 'CZR_controls' ,
                                 'label'       => __( 'Show images' , 'customizr' ),
                                 'section'     => 'frontpage_sec' ,
                                 'type'        => 'checkbox' ,
@@ -1161,7 +1161,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               //force default layout on every posts
               'tc_sidebar_force_layout' =>  array(
                               'default'       => 0,
-                              'control'     => 'TC_controls' ,
+                              'control'     => 'CZR_controls' ,
                               'label'         => __( 'Force default layout everywhere' , 'customizr' ),
                               'section'       => 'post_layout_sec' ,
                               'type'          => 'checkbox' ,
@@ -1183,7 +1183,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'posts_per_page'  =>  array(
                               'default'     => get_option( 'posts_per_page' ),
                               'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
-                              'control'     => 'TC_controls' ,
+                              'control'     => 'CZR_controls' ,
                               'title'         => __( 'Global Post Lists Settings' , 'customizr' ),
                               'label'         => __( 'Maximum number of posts per page' , 'customizr' ),
                               'section'       => 'post_lists_sec' ,
@@ -1237,7 +1237,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_post_list_excerpt_length'  =>  array(
                                 'default'       => 50,
                                 'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( "Set the excerpt length (in number of words) " , "customizr" ),
                                 'section'       => 'post_lists_sec' ,
                                 'type'          => 'number' ,
@@ -1247,7 +1247,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_post_list_show_thumb'  =>  array(
                                 'default'       => 1,
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'title'         => __( 'Thumbnails options' , 'customizr' ),
                                 'label'         => __( "Display the post thumbnails" , "customizr" ),
                                 'section'       => 'post_lists_sec' ,
@@ -1257,7 +1257,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_post_list_use_attachment_as_thumb'  =>  array(
                                 'default'       => 1,
-                                'control'     => 'TC_controls' ,
+                                'control'     => 'CZR_controls' ,
                                 'label'         => __( "If no featured image is set, use the last image attached to this post." , "customizr" ),
                                 'section'       => 'post_lists_sec' ,
                                 'type'          => 'checkbox',
@@ -1265,7 +1265,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
 
               'tc_post_list_default_thumb'  => array(
-                                'control'   =>  version_compare( $wp_version, '4.3', '>=' ) ? 'TC_Customize_Cropped_Image_Control' : 'TC_Customize_Upload_Control',
+                                'control'   =>  version_compare( $wp_version, '4.3', '>=' ) ? 'CZR_Customize_Cropped_Image_Control' : 'CZR_Customize_Upload_Control',
                                 'label'         => __( 'Upload a default thumbnail' , 'customizr' ),
                                 'section'   =>  'post_lists_sec' ,
                                 'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
@@ -1283,7 +1283,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
 
               'tc_post_list_thumb_shape'  =>  array(
                                 'default'       => 'rounded',
-                                'control'     => 'TC_controls' ,
+                                'control'     => 'CZR_controls' ,
                                 'title'         => __( 'Thumbnails options for the alternate thumbnails layout' , 'customizr' ),
                                 'label'         => __( "Thumbnails shape" , "customizr" ),
                                 'section'       => 'post_lists_sec' ,
@@ -1302,7 +1302,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_post_list_thumb_height' => array(
                                 'default'       => 250,
                                 'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
-                                'control'   => 'TC_controls' ,
+                                'control'   => 'CZR_controls' ,
                                 'label'       => __( "Set the thumbnail's max height in pixels" , 'customizr' ),
                                 'section'     => 'post_lists_sec' ,
                                 'type'        => 'number' ,
@@ -1314,7 +1314,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
 
               'tc_post_list_thumb_position'  =>  array(
                                 'default'       => 'right',
-                                'control'     => 'TC_controls' ,
+                                'control'     => 'CZR_controls' ,
                                 'label'         => __( "Thumbnails position" , "customizr" ),
                                 'section'       => 'post_lists_sec' ,
                                 'type'      =>  'select' ,
@@ -1328,7 +1328,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_post_list_thumb_alternate'  =>  array(
                                 'default'       => 1,
-                                'control'     => 'TC_controls' ,
+                                'control'     => 'CZR_controls' ,
                                 'label'         => __( "Alternate thumbnail/content" , "customizr" ),
                                 'section'       => 'post_lists_sec' ,
                                 'type'          => 'checkbox',
@@ -1340,7 +1340,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
                                 'default'       => '',
                                 'title'         => __( 'Archive titles' , 'customizr' ),
                                 'label'       => __( 'Category pages titles' , 'customizr' ),
-                                'control'   =>  'TC_controls' ,
+                                'control'   =>  'CZR_controls' ,
                                 'section'     => 'post_lists_sec' ,
                                 'type'        => 'text' ,
                                 'priority'       => 100
@@ -1349,7 +1349,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_tag_title'  =>  array(
                                 'default'         => '',
                                 'label'       => __( 'Tag pages titles' , 'customizr' ),
-                                'control'   =>  'TC_controls' ,
+                                'control'   =>  'CZR_controls' ,
                                 'section'     => 'post_lists_sec' ,
                                 'type'        => 'text' ,
                                 'priority'       => 105
@@ -1358,7 +1358,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_author_title'  =>  array(
                                 'default'         => '',
                                 'label'       => __( 'Author pages titles' , 'customizr' ),
-                                'control'   =>  'TC_controls' ,
+                                'control'   =>  'CZR_controls' ,
                                 'section'     => 'post_lists_sec' ,
                                 'type'        => 'text' ,
                                 'priority'       => 110
@@ -1367,7 +1367,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_search_title'  =>  array(
                                 'default'         => __( 'Search Results for :' , 'customizr' ),
                                 'label'       => __( 'Search results page titles' , 'customizr' ),
-                                'control'   =>  'TC_controls' ,
+                                'control'   =>  'CZR_controls' ,
                                 'section'     => 'post_lists_sec' ,
                                 'type'        => 'text' ,
                                 'priority'       => 115
@@ -1375,8 +1375,8 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
 
               'tc_post_list_grid'  =>  array(
-                                'default'       => TC_utils::$inst -> tc_user_started_before_version( '3.2.18', '1.0.13' ) ? 'alternate' : 'grid',
-                                'control'       => 'TC_controls' ,
+                                'default'       => CZR_utils::$inst -> tc_user_started_before_version( '3.2.18', '1.0.13' ) ? 'alternate' : 'grid',
+                                'control'       => 'CZR_controls' ,
                                 'title'         => __( 'Post List Design' , 'customizr' ),
                                 'label'         => __( 'Select a Layout' , "customizr" ),
                                 'section'       => 'post_lists_sec' ,
@@ -1390,7 +1390,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_grid_columns'  =>  array(
                                 'default'       => '3',
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( 'Number of columns per row' , "customizr" ),
                                 'section'       => 'post_lists_sec' ,
                                 'type'          => 'select',
@@ -1405,7 +1405,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_grid_expand_featured'  =>  array(
                                 'default'       => 1,
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( 'Expand the last sticky post (for home and blog page only)' , "customizr" ),
                                 'section'       => 'post_lists_sec' ,
                                 'type'          => 'checkbox',
@@ -1413,7 +1413,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_grid_in_blog'  =>  array(
                                 'default'       => 1,
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( 'Apply the grid layout to Home/Blog' , "customizr" ),
                                 'section'       => 'post_lists_sec' ,
                                 'type'          => 'checkbox',
@@ -1421,7 +1421,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_grid_in_archive'  =>  array(
                                 'default'       => 1,
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( 'Apply the grid layout to Archives (archives, categories, author posts)' , "customizr" ),
                                 'section'       => 'post_lists_sec' ,
                                 'type'          => 'checkbox',
@@ -1429,7 +1429,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_grid_in_search'  =>  array(
                                 'default'       => 1,
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( 'Apply the grid layout to Search results' , "customizr" ),
                                 'section'       => 'post_lists_sec' ,
                                 'type'          => 'checkbox',
@@ -1438,7 +1438,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
                ),
               'tc_grid_shadow'  =>  array(
                                 'default'       => 1,
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( 'Apply a shadow to each grid items' , "customizr" ),
                                 'section'       => 'post_lists_sec' ,
                                 'type'          => 'checkbox',
@@ -1447,7 +1447,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
                ),
               'tc_grid_bottom_border'  =>  array(
                                 'default'       => 1,
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( 'Apply a colored bottom border to each grid items' , "customizr" ),
                                 'section'       => 'post_lists_sec' ,
                                 'type'          => 'checkbox',
@@ -1456,7 +1456,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
                ),
               'tc_grid_icons'  =>  array(
                                 'default'       => 1,
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( 'Display post format icons in the background' , "customizr" ),
                                 'section'       => 'post_lists_sec' ,
                                 'type'          => 'checkbox',
@@ -1466,7 +1466,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_grid_num_words'  =>  array(
                                 'default'       => 10,
                                 'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( 'Max. length for post titles (in words)' , "customizr" ),
                                 'section'       => 'post_lists_sec' ,
                                 'type'          => 'number' ,
@@ -1477,7 +1477,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_grid_thumb_height' => array(
                                 'default'       => 350,
                                 'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'title'         => __( 'Thumbnails max height for the grid layout' , 'customizr' ),
                                 'label'         => __( "Set the post grid thumbnail's max height in pixels" , 'customizr' ),
                                 'section'       => 'post_lists_sec' ,
@@ -1499,7 +1499,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
       return array(
           'tc_single_post_thumb_location'  =>  array(
                             'default'       => 'hide',
-                            'control'     => 'TC_controls' ,
+                            'control'     => 'CZR_controls' ,
                             'label'         => __( "Post thumbnail position" , "customizr" ),
                             'section'       => 'single_posts_sec' ,
                             'type'      =>  'select' ,
@@ -1520,7 +1520,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
           'tc_single_post_thumb_height' => array(
                             'default'       => 250,
                             'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
-                            'control'   => 'TC_controls' ,
+                            'control'   => 'CZR_controls' ,
                             'label'       => __( "Set the thumbnail's max height in pixels" , 'customizr' ),
                             'section'     => 'single_posts_sec' ,
                             'type'        => 'number' ,
@@ -1547,14 +1547,14 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_breadcrumb' => array(
                               'default'       => 1,//Breadcrumb is checked by default
                               'label'         => __( 'Display Breadcrumb' , 'customizr' ),
-                              'control'     =>  'TC_controls' ,
+                              'control'     =>  'CZR_controls' ,
                               'section'       => 'breadcrumb_sec' ,
                               'type'          => 'checkbox' ,
                               'priority'      => 1,
               ),
               'tc_show_breadcrumb_home'  =>  array(
                                 'default'       => 0,
-                                'control'     => 'TC_controls' ,
+                                'control'     => 'CZR_controls' ,
                                 'label'         => __( "Display the breadcrumb on home page" , "customizr" ),
                                 'section'       => 'breadcrumb_sec' ,
                                 'type'          => 'checkbox' ,
@@ -1562,7 +1562,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_show_breadcrumb_in_pages'  =>  array(
                                 'default'       => 1,
-                                'control'     => 'TC_controls' ,
+                                'control'     => 'CZR_controls' ,
                                 'label'         => __( "Display the breadcrumb in pages" , "customizr" ),
                                 'section'       => 'breadcrumb_sec' ,
                                 'type'          => 'checkbox' ,
@@ -1571,7 +1571,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_show_breadcrumb_in_single_posts'  =>  array(
                                 'default'       => 1,
-                                'control'     => 'TC_controls' ,
+                                'control'     => 'CZR_controls' ,
                                 'label'         => __( "Display the breadcrumb in single posts" , "customizr" ),
                                 'section'       => 'breadcrumb_sec' ,
                                 'type'          => 'checkbox' ,
@@ -1580,7 +1580,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_show_breadcrumb_in_post_lists'  =>  array(
                                 'default'       => 1,
-                                'control'     => 'TC_controls' ,
+                                'control'     => 'CZR_controls' ,
                                 'label'         => __( "Display the breadcrumb in posts lists : blog page, archives, search results..." , "customizr" ),
                                 'section'       => 'breadcrumb_sec' ,
                                 'type'          => 'checkbox' ,
@@ -1599,7 +1599,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
       return array(
               'tc_show_post_metas'  =>  array(
                                 'default'       => 1,
-                                'control'     => 'TC_controls' ,
+                                'control'     => 'CZR_controls' ,
                                 'label'         => __( "Display posts metas" , "customizr" ),
                                 'section'       => 'post_metas_sec' ,
                                 'type'          => 'checkbox',
@@ -1608,8 +1608,8 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
                                 'transport'   => 'postMessage'
               ),
               'tc_post_metas_design'  =>  array(
-                                'default'       => TC_utils::$inst -> tc_user_started_before_version( '3.3.2' , '1.0.11' ) ? 'buttons' : 'no-buttons',
-                                'control'     => 'TC_controls' ,
+                                'default'       => CZR_utils::$inst -> tc_user_started_before_version( '3.3.2' , '1.0.11' ) ? 'buttons' : 'no-buttons',
+                                'control'     => 'CZR_controls' ,
                                 'title'         => __( 'Metas Design' , 'customizr' ),
                                 'label'         => __( "Select a design for the post metas" , "customizr" ),
                                 'section'       => 'post_metas_sec' ,
@@ -1622,7 +1622,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_show_post_metas_home'  =>  array(
                                 'default'       => 0,
-                                'control'     => 'TC_controls' ,
+                                'control'     => 'CZR_controls' ,
                                 'title'         => __( 'Select the contexts' , 'customizr' ),
                                 'label'         => __( "Display posts metas on home" , "customizr" ),
                                 'section'       => 'post_metas_sec' ,
@@ -1632,7 +1632,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_show_post_metas_single_post'  =>  array(
                                 'default'       => 1,
-                                'control'     => 'TC_controls' ,
+                                'control'     => 'CZR_controls' ,
                                 'label'         => __( "Display posts metas for single posts" , "customizr" ),
                                 'section'       => 'post_metas_sec' ,
                                 'type'          => 'checkbox',
@@ -1641,7 +1641,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_show_post_metas_post_lists'  =>  array(
                                 'default'       => 1,
-                                'control'     => 'TC_controls' ,
+                                'control'     => 'CZR_controls' ,
                                 'label'         => __( "Display posts metas in post lists (archives, blog page)" , "customizr" ),
                                 'section'       => 'post_metas_sec' ,
                                 'type'          => 'checkbox',
@@ -1651,7 +1651,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
 
               'tc_show_post_metas_categories'  =>  array(
                                 'default'       => 1,
-                                'control'     => 'TC_controls',
+                                'control'     => 'CZR_controls',
                                 'title'         => __( 'Select the metas to display' , 'customizr' ),
                                 'label'         => __( "Display hierarchical taxonomies (like categories)" , "customizr" ),
                                 'section'       => 'post_metas_sec',
@@ -1661,7 +1661,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
 
               'tc_show_post_metas_tags'  =>  array(
                                 'default'       => 1,
-                                'control'     => 'TC_controls',
+                                'control'     => 'CZR_controls',
                                 'label'         => __( "Display non-hierarchical taxonomies (like tags)" , "customizr" ),
                                 'section'       => 'post_metas_sec',
                                 'type'          => 'checkbox',
@@ -1670,7 +1670,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
 
               'tc_show_post_metas_publication_date'  =>  array(
                                 'default'       => 1,
-                                'control'     => 'TC_controls',
+                                'control'     => 'CZR_controls',
                                 'label'         => __( "Display the publication date" , "customizr" ),
                                 'section'       => 'post_metas_sec',
                                 'type'          => 'checkbox',
@@ -1678,7 +1678,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_show_post_metas_author'  =>  array(
                                 'default'       => 1,
-                                'control'     => 'TC_controls',
+                                'control'     => 'CZR_controls',
                                 'label'         => __( "Display the author" , "customizr" ),
                                 'section'       => 'post_metas_sec',
                                 'type'          => 'checkbox',
@@ -1686,7 +1686,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_show_post_metas_update_date'  =>  array(
                                 'default'       => 0,
-                                'control'     => 'TC_controls',
+                                'control'     => 'CZR_controls',
                                 'label'         => __( "Display the update date" , "customizr" ),
                                 'section'       => 'post_metas_sec',
                                 'type'          => 'checkbox',
@@ -1696,7 +1696,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
 
               'tc_post_metas_update_date_format'  =>  array(
                                 'default'       => 'days',
-                                'control'       => 'TC_controls',
+                                'control'       => 'CZR_controls',
                                 'label'         => __( "Select the last update format" , "customizr" ),
                                 'section'       => 'post_metas_sec',
                                 'type'          =>  'select' ,
@@ -1708,8 +1708,8 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
 
               'tc_post_metas_update_notice_in_title'  =>  array(
-                                'default'       => TC_utils::$inst -> tc_user_started_before_version( '3.3.2' , '1.0.11' ) ? 1 : 0,
-                                'control'       => 'TC_controls',
+                                'default'       => CZR_utils::$inst -> tc_user_started_before_version( '3.3.2' , '1.0.11' ) ? 1 : 0,
+                                'control'       => 'CZR_controls',
                                 'title'         => __( 'Recent update notice after post titles' , 'customizr' ),
                                 'label'         => __( "Display a recent update notice" , "customizr" ),
                                 'section'       => 'post_metas_sec',
@@ -1719,7 +1719,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_post_metas_update_notice_interval'  =>  array(
                                 'default'       => 10,
-                                'control'       => 'TC_controls',
+                                'control'       => 'CZR_controls',
                                 'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
                                 'label'         => __( "Display the notice if the last update is less (strictly) than n days old" , "customizr" ),
                                 'section'       => 'post_metas_sec',
@@ -1731,7 +1731,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_post_metas_update_notice_text'  =>  array(
                                 'default'       => __( "Recently updated !" , "customizr" ),
-                                'control'       => 'TC_controls',
+                                'control'       => 'CZR_controls',
                                 'label'         => __( "Update notice text" , "customizr" ),
                                 'section'       => 'post_metas_sec',
                                 'type'          => 'text',
@@ -1740,7 +1740,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_post_metas_update_notice_format'  =>  array(
                                 'default'       => 'label-default',
-                                'control'       => 'TC_controls',
+                                'control'       => 'CZR_controls',
                                 'label'         => __( "Update notice style" , "customizr" ),
                                 'section'       => 'post_metas_sec',
                                 'type'          =>  'select' ,
@@ -1767,7 +1767,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_enable_gallery'  =>  array(
                                 'default'       => 1,
                                 'label'         => __('Enable Customizr galleries' , 'customizr'),
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'notice'         => __( "Apply Customizr effects to galleries images" , "customizr" ),
                                 'section'       => 'galleries_sec' ,
                                 'type'          => 'checkbox',
@@ -1776,7 +1776,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_gallery_fancybox'=>  array(
                                 'default'       => 1,
                                 'label'         => __('Enable Lightbox effect in galleries' , 'customizr'),
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'notice'         => __( "Apply lightbox effects to galleries images" , "customizr" ),
                                 'section'       => 'galleries_sec' ,
                                 'type'          => 'checkbox',
@@ -1785,7 +1785,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_gallery_style'=>  array(
                                 'default'       => 1,
                                 'label'         => __('Enable Customizr effects on hover' , 'customizr'),
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'notice'         => __( "Apply nice on hover expansion effect to the galleries images" , "customizr" ),
                                 'section'       => 'galleries_sec' ,
                                 'type'          => 'checkbox',
@@ -1806,7 +1806,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
                                 'default'       => 0,
                                 'title'         => __( 'Drop caps', 'customizr'),
                                 'label'         => __('Enable drop caps' , 'customizr'),
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'notice'         => __( "Apply a drop cap to the first paragraph of your post / page content" , "customizr" ),
                                 'section'       => 'paragraphs_sec' ,
                                 'type'          => 'checkbox',
@@ -1815,7 +1815,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_dropcap_minwords'  =>  array(
                                 'default'       => 50,
                                 'sanitize_callback' => array( $this , 'tc_sanitize_number' ),
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( "Apply a drop cap when the paragraph includes at least the following number of words :" , "customizr" ),
                                 'notice'         => __( "(number of words)" , "customizr" ),
                                 'section'       => 'paragraphs_sec' ,
@@ -1826,7 +1826,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_dropcap_design' => array(
                                 'default'     => 'skin-shadow',
-                                'control'     => 'TC_controls',
+                                'control'     => 'CZR_controls',
                                 'label'       => __( 'Drop cap style' , 'customizr' ),
                                 'section'     => 'paragraphs_sec',
                                 'type'      =>  'select' ,
@@ -1839,7 +1839,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_post_dropcap'  =>  array(
                                 'default'       => 0,
                                 'label'         => __('Enable drop caps in posts' , 'customizr'),
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'notice'         => __( "Apply a drop cap to the first paragraph of your single posts content" , "customizr" ),
                                 'section'       => 'paragraphs_sec' ,
                                 'type'          => 'checkbox',
@@ -1848,7 +1848,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_page_dropcap'  =>  array(
                                 'default'       => 0,
                                 'label'         => __('Enable drop caps in pages' , 'customizr'),
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'notice'         => __( "Apply a drop cap to the first paragraph of your pages" , "customizr" ),
                                 'section'       => 'paragraphs_sec' ,
                                 'type'          => 'checkbox',
@@ -1867,7 +1867,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_comment_show_bubble'  =>  array(
                                 'default'       => 1,
                                 'title'         => __('Comments bubbles' , 'customizr'),
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( "Display the number of comments in a bubble next to the post title" , "customizr" ),
                                 'section'       => 'comments_sec' ,
                                 'type'          => 'checkbox',
@@ -1876,7 +1876,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
 
               'tc_comment_bubble_shape' => array(
                                 'default'     => 'default',
-                                'control'     => 'TC_controls',
+                                'control'     => 'CZR_controls',
                                 'label'       => __( 'Comments bubble shape' , 'customizr' ),
                                 'section'     => 'comments_sec',
                                 'type'      =>  'select' ,
@@ -1888,8 +1888,8 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
 
               'tc_comment_bubble_color_type' => array(
-                                'default'     => TC_utils::$inst -> tc_user_started_before_version( '3.3.2' , '1.0.11' ) ? 'custom' : 'skin',
-                                'control'     => 'TC_controls',
+                                'default'     => CZR_utils::$inst -> tc_user_started_before_version( '3.3.2' , '1.0.11' ) ? 'custom' : 'skin',
+                                'control'     => 'CZR_controls',
                                 'label'       => __( 'Comments bubble color' , 'customizr' ),
                                 'section'     => 'comments_sec',
                                 'type'      =>  'select' ,
@@ -1900,7 +1900,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
                                 'priority'    => 20,
               ),
               'tc_comment_bubble_color' => array(
-                                'default'     => TC_utils::$inst -> tc_user_started_before_version( '3.3.2' , '1.0.11' ) ? '#F00' : TC_utils::$inst -> tc_get_skin_color(),
+                                'default'     => CZR_utils::$inst -> tc_user_started_before_version( '3.3.2' , '1.0.11' ) ? '#F00' : CZR_utils::$inst -> tc_get_skin_color(),
                                 'control'     => 'WP_Customize_Color_Control',
                                 'label'       => __( 'Comments bubble color' , 'customizr' ),
                                 'section'     => 'comments_sec',
@@ -1912,7 +1912,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_page_comments'  =>  array(
                                 'default'     => 0,
-                                'control'     => 'TC_controls',
+                                'control'     => 'CZR_controls',
                                 'title'       => __( 'Other comments settings' , 'customizr'),
                                 'label'       => __( 'Enable comments on pages' , 'customizr' ),
                                 'section'     => 'comments_sec',
@@ -1927,7 +1927,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_post_comments'  =>  array(
                                 'default'     => 1,
-                                'control'     => 'TC_controls',
+                                'control'     => 'CZR_controls',
                                 'label'       => __( 'Enable comments on posts' , 'customizr' ),
                                 'section'     => 'comments_sec',
                                 'type'        => 'checkbox',
@@ -1943,7 +1943,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_show_comment_list'  =>  array(
                                 'default'     => 1,
-                                'control'     => 'TC_controls',
+                                'control'     => 'CZR_controls',
                                 'label'       => __( 'Display the comment list' , 'customizr' ),
                                 'section'     => 'comments_sec',
                                 'type'        => 'checkbox',
@@ -1962,7 +1962,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
       return array(
               'tc_show_post_navigation'  =>  array(
                                 'default'       => 1,
-                                'control'     => 'TC_controls' ,
+                                'control'     => 'CZR_controls' ,
                                 'label'         => __( "Display posts navigation" , "customizr" ),
                                 'section'       => 'post_navigation_sec' ,
                                 'type'          => 'checkbox',
@@ -1973,7 +1973,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
 
               'tc_show_post_navigation_page'  =>  array(
                                 'default'       => 0,
-                                'control'     => 'TC_controls' ,
+                                'control'     => 'CZR_controls' ,
                                 'title'         => __( 'Select the contexts' , 'customizr' ),
                                 'label'         => __( "Display navigation in pages" , "customizr" ),
                                 'section'       => 'post_navigation_sec' ,
@@ -1983,7 +1983,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_show_post_navigation_single'  =>  array(
                                 'default'       => 1,
-                                'control'     => 'TC_controls' ,
+                                'control'     => 'CZR_controls' ,
                                 'label'         => __( "Display posts navigation in single posts" , "customizr" ),
                                 'section'       => 'post_navigation_sec' ,
                                 'type'          => 'checkbox',
@@ -1992,7 +1992,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_show_post_navigation_archive'  =>  array(
                                 'default'       => 1,
-                                'control'     => 'TC_controls' ,
+                                'control'     => 'CZR_controls' ,
                                 'label'         => __( "Display posts navigation in post lists (archives, blog page, categories, search results ..)" , "customizr" ),
                                 'section'       => 'post_navigation_sec' ,
                                 'type'          => 'checkbox',
@@ -2016,7 +2016,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_social_in_left-sidebar' =>  array(
                                 'default'       => 0,
                                 'label'       => __( 'Social links in left sidebar' , 'customizr' ),
-                                'control'   =>  'TC_controls' ,
+                                'control'   =>  'CZR_controls' ,
                                 'section'     => 'sidebar_socials_sec',
                                 'type'        => 'checkbox' ,
                                 'priority'       => 20,
@@ -2026,7 +2026,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_social_in_right-sidebar'  =>  array(
                                 'default'       => 0,
                                 'label'       => __( 'Social links in right sidebar' , 'customizr' ),
-                                'control'   =>  'TC_controls' ,
+                                'control'   =>  'CZR_controls' ,
                                 'section'     => 'sidebar_socials_sec',
                                 'type'        => 'checkbox' ,
                                 'priority'       => 25,
@@ -2035,7 +2035,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_social_in_sidebar_title'  =>  array(
                                 'default'       => __( 'Social links' , 'customizr' ),
                                 'label'       => __( 'Social link title in sidebars' , 'customizr' ),
-                                'control'   =>  'TC_controls' ,
+                                'control'   =>  'CZR_controls' ,
                                 'section'     => 'sidebar_socials_sec',
                                 'type'        => 'text' ,
                                 'priority'       => 30,
@@ -2060,15 +2060,15 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_social_in_footer' =>  array(
                                 'default'       => 1,
                                 'label'       => __( 'Social links in footer' , 'customizr' ),
-                                'control'   =>  'TC_controls' ,
+                                'control'   =>  'CZR_controls' ,
                                 'section'     => 'footer_global_sec' ,
                                 'type'        => 'checkbox' ,
                                 'priority'       => 0,
                                 'transport'   => 'postMessage'
               ),
               'tc_sticky_footer'  =>  array(
-                                'default'       => TC_utils::$inst -> tc_user_started_before_version( '3.4.0' , '1.1.14' ) ? 0 : 1,
-                                'control'       => 'TC_controls' ,
+                                'default'       => CZR_utils::$inst -> tc_user_started_before_version( '3.4.0' , '1.1.14' ) ? 0 : 1,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( "Stick the footer to the bottom of the page", "customizr" ),
                                 'section'       => 'footer_global_sec' ,
                                 'type'          => 'checkbox',
@@ -2077,7 +2077,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_show_back_to_top'  =>  array(
                                 'default'       => 1,
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( "Display a back to top arrow on scroll" , "customizr" ),
                                 'section'       => 'footer_global_sec' ,
                                 'type'          => 'checkbox',
@@ -2085,7 +2085,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
                             ),
               'tc_back_to_top_position'  =>  array(
                                 'default'       => 'right',
-                                'control'       => 'TC_controls' ,
+                                'control'       => 'CZR_controls' ,
                                 'label'         => __( "Display a back to top arrow on scroll" , "customizr" ),
                                 'section'       => 'footer_global_sec' ,
                                 'type'          => 'select',
@@ -2117,7 +2117,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_custom_css' =>  array(
                                 'sanitize_callback' => 'wp_filter_nohtml_kses',
                                 'sanitize_js_callback' => 'wp_filter_nohtml_kses',
-                                'control'   => 'TC_controls' ,
+                                'control'   => 'CZR_controls' ,
                                 'label'       => __( 'Add your custom css here and design live! (for advanced users)' , 'customizr' ),
                                 'section'     => 'custom_sec' ,
                                 'type'        => 'textarea' ,
@@ -2125,7 +2125,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
                                     __( "Use this field to test small chunks of CSS code. For important CSS customizations, you'll want to modify the style.css file of a" , 'customizr' ),
                                     __( 'child theme.' , 'customizr'),
                                     __( 'How to create and use a child theme ?' , 'customizr'),
-                                    TC_WEBSITE
+                                    CZR_WEBSITE
                                 ),
                                 'transport'   => 'postMessage'
               ),
@@ -2140,7 +2140,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
       return array(
               'tc_minified_skin'  =>  array(
                                 'default'       => 1,
-                                'control'   => 'TC_controls' ,
+                                'control'   => 'CZR_controls' ,
                                 'label'       => __( "Performance : use the minified CSS stylesheets", 'customizr' ),
                                 'section'     => 'performances_sec' ,
                                 'type'        => 'checkbox' ,
@@ -2149,7 +2149,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               'tc_img_smart_load'  =>  array(
                                 'default'       => 0,
                                 'label'       => __( 'Load images on scroll' , 'customizr' ),
-                                'control'     =>  'TC_controls',
+                                'control'     =>  'CZR_controls',
                                 'section'     => 'performances_sec',
                                 'type'        => 'checkbox',
                                 'priority'    => 20,
@@ -2165,7 +2165,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
       return array(
               'tc_display_front_help'  =>  array(
                                 'default'       => 1,
-                                'control'   => 'TC_controls',
+                                'control'   => 'CZR_controls',
                                 'label'       => __( "Display help notices on front-end for logged in users.", 'customizr' ),
                                 'section'     => 'placeholder_sec',
                                 'type'        => 'checkbox',
@@ -2181,7 +2181,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
       return array(
               'tc_font_awesome_icons'  =>  array(
                                 'default'       => 1,
-                                'control'   => 'TC_controls',
+                                'control'   => 'CZR_controls',
                                 'label'       => __( "Load Font Awesome set of icons", 'customizr' ),
                                 'section'     => 'extresources_sec',
                                 'type'        => 'checkbox',
@@ -2192,7 +2192,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
               ),
               'tc_font_awesome_css'  =>  array(
                                 'default'       => 0,
-                                'control'   => 'TC_controls',
+                                'control'   => 'CZR_controls',
                                 'label'       => __( "Load Font Awesome CSS", 'customizr' ),
                                 'section'     => 'extresources_sec',
                                 'type'        => 'checkbox',
@@ -2290,7 +2290,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
       //=> because once the preview is ready, a postMessage is sent to the panel frame to refresh the sections and panels
       //Do nothing if WP version under 4.2
       global $wp_version;
-      if ( TC___::$instance -> tc_is_customize_preview_frame() || ! version_compare( $wp_version, '4.2', '>=') )
+      if ( CZR___::$instance -> tc_is_customize_preview_frame() || ! version_compare( $wp_version, '4.2', '>=') )
         return $_sections;
 
       //when user access the theme switcher from the admin bar
@@ -2595,7 +2595,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
       $fp_setting_control = array();
 
       //gets the featured pages id from init
-      $fp_ids       = apply_filters( 'tc_featured_pages_ids' , TC_init::$instance -> fp_ids);
+      $fp_ids       = apply_filters( 'tc_featured_pages_ids' , CZR_init::$instance -> fp_ids);
 
       //dropdown field generator
       foreach ( $fp_ids as $id ) {
@@ -2616,7 +2616,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
         $fp_setting_control['tc_featured_text_' . $id]   = array(
                       'sanitize_callback' => array( $this , 'tc_sanitize_textarea' ),
                       'transport'   => 'postMessage',
-                      'control'   => 'TC_controls' ,
+                      'control'   => 'CZR_controls' ,
                       'label'       => isset($default['text'][$id]) ? $default['text'][$id] : sprintf( __('Featured text %1$s (200 char. max)' , 'customizr' ) , $id ),
                       'section'     => 'frontpage_sec' ,
                       'type'        => 'textarea' ,
@@ -2642,7 +2642,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
     */
     function tc_generates_socials( $_original_map ) {
       //gets the social network array
-      $socials      = apply_filters( 'tc_default_socials' , TC_init::$instance -> socials );
+      $socials      = apply_filters( 'tc_default_socials' , CZR_init::$instance -> socials );
 
       //declares some loop's vars and the settings array
       $priority     = 50;//start priority
@@ -2656,7 +2656,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
         $_new_map[$key]  = array(
                       'default'       => ( isset($data['default']) && !is_null($data['default']) ) ? $data['default'] : null,
                       'sanitize_callback' => array( $this , 'tc_sanitize_' . $type ),
-                      'control'       => 'TC_controls' ,
+                      'control'       => 'CZR_controls' ,
                       'label'         => ( isset($data['option_label']) ) ? call_user_func( '__' , $data['option_label'] , 'customizr' ) : $key,
                       'section'       => 'socials_sec' ,
                       'type'          => $type,
@@ -2684,7 +2684,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
         return;
 
       //gets the skins from init
-      $default_skin_list    = TC_init::$instance -> skins;
+      $default_skin_list    = CZR_init::$instance -> skins;
 
       //declares the skin list array
       $skin_list        = array();
@@ -2727,7 +2727,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
     * @since Customizr 3.1.0
     */
     private function tc_layout_choices() {
-        $global_layout  = apply_filters( 'tc_global_layout' , TC_init::$instance -> global_layout );
+        $global_layout  = apply_filters( 'tc_global_layout' , CZR_init::$instance -> global_layout );
         $layout_choices = array();
         foreach ($global_layout as $key => $value) {
           $layout_choices[$key]   = ( $value['customizer'] ) ? call_user_func(  '__' , $value['customizer'] , 'customizr' ) : null ;
@@ -2768,7 +2768,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
     */
     private function tc_build_skin_list() {
         $parent_skins   = $this -> tc_get_skins(TC_BASE .'inc/assets/css');
-        $child_skins    = ( TC___::$instance -> tc_is_child() && file_exists(TC_BASE_CHILD .'inc/assets/css') ) ? $this -> tc_get_skins(TC_BASE_CHILD .'inc/assets/css') : array();
+        $child_skins    = ( CZR___::$instance -> tc_is_child() && file_exists(TC_BASE_CHILD .'inc/assets/css') ) ? $this -> tc_get_skins(TC_BASE_CHILD .'inc/assets/css') : array();
         $skin_list      = array_merge( $parent_skins , $child_skins );
 
       return apply_filters( 'tc_skin_list', $skin_list );

--- a/inc/class-fire-utils_settings_map.php
+++ b/inc/class-fire-utils_settings_map.php
@@ -34,24 +34,24 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     * @package Customizr
     * @since Customizr 3.0
     */
-    public function czr_get_customizer_map( $get_default = null ) {
+    public function czr_fn_get_customizer_map( $get_default = null ) {
       if ( ! empty( $this -> customizer_map ) )
         return $this -> customizer_map;
 
       //POPULATE THE MAP WITH DEFAULT CUSTOMIZR SETTINGS
-      add_filter( 'tc_add_panel_map'        , array( $this, 'czr_popul_panels_map'));
-      add_filter( 'tc_remove_section_map'   , array( $this, 'czr_popul_remove_section_map'));
+      add_filter( 'tc_add_panel_map'        , array( $this, 'czr_fn_popul_panels_map'));
+      add_filter( 'tc_remove_section_map'   , array( $this, 'czr_fn_popul_remove_section_map'));
       //theme switcher's enabled when user opened the customizer from the theme's page
-      add_filter( 'tc_remove_section_map'   , array( $this, 'czr_set_theme_switcher_visibility'));
-      add_filter( 'tc_add_section_map'      , array( $this, 'czr_popul_section_map' ));
+      add_filter( 'tc_remove_section_map'   , array( $this, 'czr_fn_set_theme_switcher_visibility'));
+      add_filter( 'tc_add_section_map'      , array( $this, 'czr_fn_popul_section_map' ));
       //add controls to the map
-      add_filter( 'tc_add_setting_control_map' , array( $this , 'czr_popul_setting_control_map' ), 10, 2 );
+      add_filter( 'tc_add_setting_control_map' , array( $this , 'czr_fn_popul_setting_control_map' ), 10, 2 );
       //$this -> tc_populate_setting_control_map();
 
       //FILTER SPECIFIC SETTING-CONTROL MAPS
       //ADDS SETTING / CONTROLS TO THE RELEVANT SECTIONS
-      add_filter( 'czr_social_option_map'     , array( $this, 'czr_generates_socials' ));
-      add_filter( 'czr_front_page_option_map' , array( $this, 'czr_generates_featured_pages' ));
+      add_filter( 'czr_fn_social_option_map'     , array( $this, 'czr_fn_generates_socials' ));
+      add_filter( 'czr_fn_front_page_option_map' , array( $this, 'czr_fn_generates_featured_pages' ));
 
       //CACHE THE GLOBAL CUSTOMIZER MAP
       $this -> customizer_map = array_merge(
@@ -74,43 +74,43 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    function czr_popul_setting_control_map( $_map, $get_default = null ) {
+    function czr_fn_popul_setting_control_map( $_map, $get_default = null ) {
       $_new_map = array();
       $_settings_sections = array(
         //GLOBAL SETTINGS
-        'czr_logo_favicon_option_map',
-        'czr_skin_option_map',
-        'czr_fonts_option_map',
-        'czr_social_option_map',
-        'czr_icons_option_map',
-        'czr_links_option_map',
-        'czr_images_option_map',
-        'czr_responsive_option_map',
-        'czr_authors_option_map',
-        'czr_smoothscroll_option_map',
+        'czr_fn_logo_favicon_option_map',
+        'czr_fn_skin_option_map',
+        'czr_fn_fonts_option_map',
+        'czr_fn_social_option_map',
+        'czr_fn_icons_option_map',
+        'czr_fn_links_option_map',
+        'czr_fn_images_option_map',
+        'czr_fn_responsive_option_map',
+        'czr_fn_authors_option_map',
+        'czr_fn_smoothscroll_option_map',
         //HEADER
-        'czr_header_design_option_map',
-        'czr_navigation_option_map',
+        'czr_fn_header_design_option_map',
+        'czr_fn_navigation_option_map',
         //CONTENT
-        'czr_front_page_option_map',
-        'czr_layout_option_map',
-        'czr_comment_option_map',
-        'czr_breadcrumb_option_map',
-        'czr_post_metas_option_map',
-        'czr_post_list_option_map',
-        'czr_single_post_option_map',
-        'czr_gallery_option_map',
-        'czr_paragraph_option_map',
-        'czr_post_navigation_option_map',
+        'czr_fn_front_page_option_map',
+        'czr_fn_layout_option_map',
+        'czr_fn_comment_option_map',
+        'czr_fn_breadcrumb_option_map',
+        'czr_fn_post_metas_option_map',
+        'czr_fn_post_list_option_map',
+        'czr_fn_single_post_option_map',
+        'czr_fn_gallery_option_map',
+        'czr_fn_paragraph_option_map',
+        'czr_fn_post_navigation_option_map',
         //SIDEBARS
-        'czr_sidebars_option_map',
+        'czr_fn_sidebars_option_map',
         //FOOTER
-        'czr_footer_global_settings_option_map',
+        'czr_fn_footer_global_settings_option_map',
         //ADVANCED OPTIONS
-        'czr_custom_css_option_map',
-        'czr_performance_option_map',
-        'czr_placeholders_notice_map',
-        'czr_external_resources_option_map'
+        'czr_fn_custom_css_option_map',
+        'czr_fn_performance_option_map',
+        'czr_fn_placeholders_notice_map',
+        'czr_fn_external_resources_option_map'
       );
 
       foreach ( $_settings_sections as $_section_cb ) {
@@ -141,7 +141,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    LOGO & FAVICON SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function czr_logo_favicon_option_map( $get_default = null ) {
+    function czr_fn_logo_favicon_option_map( $get_default = null ) {
       global $wp_version;
       return array(
               'tc_logo_upload'  => array(
@@ -149,7 +149,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'label'     =>  __( 'Logo Upload (supported formats : .jpg, .png, .gif, svg, svgz)' , 'customizr' ),
                                 'title'     => __( 'LOGO' , 'customizr'),
                                 'section'   => 'logo_sec',
-                                'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
+                                'sanitize_callback' => array( $this , 'czr_fn_sanitize_number' ),
                                 //we can define suggested cropping area and allow it to be flexible (def 150x150 and not flexible)
                                 'width'     => 250,
                                 'height'    => 100,
@@ -172,7 +172,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'control'   =>  version_compare( $wp_version, '4.3', '>=' ) ? 'CZR_Customize_Cropped_Image_Control' : 'CZR_Customize_Upload_Control',
                                 'label'     =>  __( 'Sticky Logo Upload (supported formats : .jpg, .png, .gif, svg, svgz)' , 'customizr' ),
                                 'section'   =>  'logo_sec' ,
-                                'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
+                                'sanitize_callback' => array( $this , 'czr_fn_sanitize_number' ),
                         //we can define suggested cropping area and allow it to be flexible (def 150x150 and not flexible)
                                 'width'     => 75,
                                 'height'    => 30,
@@ -191,7 +191,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'title'     => __( 'FAVICON' , 'customizr'),
                                 'section'   =>  'logo_sec' ,
                                 'type'      => 'tc_upload',
-                                'sanitize_callback' => array( $this , 'czr_sanitize_number'),
+                                'sanitize_callback' => array( $this , 'czr_fn_sanitize_number'),
               )
       );
     }
@@ -199,7 +199,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                       SKIN SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function czr_skin_option_map( $get_default = null ) {
+    function czr_fn_skin_option_map( $get_default = null ) {
       return array(
               //skin select
               'tc_skin'     => array(
@@ -208,7 +208,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'label'     =>  __( 'Choose a predefined skin' , 'customizr' ),
                                 'section'   =>  'skins_sec' ,
                                 'type'      =>  'select' ,
-                                'choices'    =>  $this -> czr_build_skin_list(),
+                                'choices'    =>  $this -> czr_fn_build_skin_list(),
                                 'transport'   =>  'postMessage',
                                 'notice'    => __( 'Disabled if the random option is on.' , 'customizr' )
               ),
@@ -228,22 +228,22 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                      FONT SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function czr_fonts_option_map( $get_default = null ) {
+    function czr_fn_fonts_option_map( $get_default = null ) {
       return array(
               'tc_fonts'      => array(
-                                'default'       => CZR_utils::$inst -> czr_user_started_before_version( '3.2.9' , '1.0.1') ? 'helvetica_arial' : '_g_fjalla_cantarell',
+                                'default'       => CZR_utils::$inst -> czr_fn_user_started_before_version( '3.2.9' , '1.0.1') ? 'helvetica_arial' : '_g_fjalla_cantarell',
                                 'label'         => __( 'Select a beautiful font pair (headings &amp; default fonts) or single font for your website.' , 'customizr' ),
                                 'control'       =>  'CZR_controls',
                                 'section'       => 'fonts_sec',
                                 'type'          => 'select' ,
-                                'choices'       => CZR_utils::$inst -> czr_get_font( 'list' , 'name' ),
+                                'choices'       => CZR_utils::$inst -> czr_fn_get_font( 'list' , 'name' ),
                                 'priority'      => 10,
                                 'transport'     => 'postMessage',
                                 'notice'        => __( "This font picker allows you to preview and select among a handy selection of font pairs and single fonts. If you choose a pair, the first font will be applied to the site main headings : site name, site description, titles h1, h2, h3., while the second will be the default font of your website for any texts or paragraphs." , 'customizr' )
               ),
               'tc_body_font_size'      => array(
-                                'default'       => CZR_utils::$inst -> czr_user_started_before_version( '3.2.9', '1.0.1' ) ? 14 : 15,
-                                'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
+                                'default'       => CZR_utils::$inst -> czr_fn_user_started_before_version( '3.2.9', '1.0.1' ) ? 14 : 15,
+                                'sanitize_callback' => array( $this , 'czr_fn_sanitize_number' ),
                                 'label'         => __( 'Set your website default font size in pixels.' , 'customizr' ),
                                 'control'       =>  'CZR_controls',
                                 'section'       => 'fonts_sec',
@@ -261,7 +261,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                              SOCIAL NETWORKS + POSITION SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function czr_social_option_map( $get_default = null ) {
+    function czr_fn_social_option_map( $get_default = null ) {
       return array();//end of social layout map
     }
 
@@ -269,7 +269,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    LINKS SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function czr_links_option_map( $get_default = null ) {
+    function czr_fn_links_option_map( $get_default = null ) {
       return array(
               'tc_link_scroll'  =>  array(
                                 'default'       => 0,
@@ -318,7 +318,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    ICONS SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function czr_icons_option_map( $get_default = null ) {
+    function czr_fn_icons_option_map( $get_default = null ) {
       return array(
               'tc_show_title_icon'  =>  array(
                                 'default'       => 1,
@@ -331,7 +331,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'transport'   => 'postMessage'
               ),
               'tc_show_page_title_icon'  =>  array(
-                                'default'       => CZR_utils::$inst -> czr_user_started_before_version( '3.3.0', '1.0.11' ) ? 1 : 0,
+                                'default'       => CZR_utils::$inst -> czr_fn_user_started_before_version( '3.3.0', '1.0.11' ) ? 1 : 0,
                                 'control'       => 'CZR_controls' ,
                                 'label'         => __( "Display a page icon next to the page title" , "customizr" ),
                                 'section'       => 'titles_icons_sec' ,
@@ -340,7 +340,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'transport'   => 'postMessage'
               ),
               'tc_show_post_title_icon'  =>  array(
-                                'default'       => CZR_utils::$inst -> czr_user_started_before_version( '3.3.0', '1.0.11' ) ? 1 : 0,
+                                'default'       => CZR_utils::$inst -> czr_fn_user_started_before_version( '3.3.0', '1.0.11' ) ? 1 : 0,
                                 'control'     => 'CZR_controls' ,
                                 'label'         => __( "Display a post icon next to the single post title" , "customizr" ),
                                 'section'       => 'titles_icons_sec' ,
@@ -359,7 +359,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'transport'   => 'postMessage'
               ),
               'tc_show_post_list_title_icon'  =>  array(
-                                'default'       => CZR_utils::$inst -> czr_user_started_before_version( '3.3.0' , '1.0.11' ) ? 1 : 0,
+                                'default'       => CZR_utils::$inst -> czr_fn_user_started_before_version( '3.3.0' , '1.0.11' ) ? 1 : 0,
                                 'control'     => 'CZR_controls' ,
                                 'label'         => __( "Display an icon next to each post title in an archive page" , "customizr" ),
                                 'section'       => 'titles_icons_sec' ,
@@ -393,7 +393,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    IMAGE SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function czr_images_option_map( $get_default = null ) {
+    function czr_fn_images_option_map( $get_default = null ) {
       global $wp_version;
 
       $_image_options =  array(
@@ -496,7 +496,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                   RESPONSIVE SETTINGS SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function czr_responsive_option_map( $get_default = null ) {
+    function czr_fn_responsive_option_map( $get_default = null ) {
       return array(
               'tc_block_reorder'  =>  array(
                                 'default'       => 1,
@@ -514,7 +514,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                   AUTHORS SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function czr_authors_option_map( $get_default = null ) {
+    function czr_fn_authors_option_map( $get_default = null ) {
       return array(
               'tc_show_author_info'  =>  array(
                                 'default'       => 1,
@@ -533,7 +533,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                   SMOOTH SCROLL SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function czr_smoothscroll_option_map( $get_default = null ) {
+    function czr_fn_smoothscroll_option_map( $get_default = null ) {
       return array(
               'tc_smoothscroll'  =>  array(
                                 'default'       => 1,
@@ -558,7 +558,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    HEADER DESIGN AND LAYOUT
     ------------------------------------------------------------------------------------------------------*/
-    function czr_header_design_option_map( $get_default = null ) {
+    function czr_fn_header_design_option_map( $get_default = null ) {
       return array(
               'tc_header_layout'  =>  array(
                               'default'       => 'left',
@@ -614,7 +614,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'transport'   => 'postMessage'
               ),
               'tc_display_boxed_navbar'  =>  array(
-                                'default'       => CZR_utils::$inst -> czr_user_started_before_version( '3.3.13', '1.0.18' ) ? 1 : 0,
+                                'default'       => CZR_utils::$inst -> czr_fn_user_started_before_version( '3.3.13', '1.0.18' ) ? 1 : 0,
                                 'control'       => 'CZR_controls' ,
                                 'label'         => __( "Display menu in a box" , "customizr" ),
                                 'section'       => 'header_layout_sec' ,
@@ -694,7 +694,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
               'tc_sticky_z_index'  =>  array(
                                 'default'       => 100,
                                 'control'       => 'CZR_controls' ,
-                                'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
+                                'sanitize_callback' => array( $this , 'czr_fn_sanitize_number' ),
                                 'label'         => __( "Set the header z-index" , "customizr" ),
                                 'section'       => 'header_layout_sec' ,
                                 'type'          => 'number' ,
@@ -718,7 +718,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                         NAVIGATION SECTION
     ------------------------------------------------------------------------------------------------------*/
     //NOTE : priorities 10 and 20 are "used" bu menus main and secondary
-    function czr_navigation_option_map( $get_default = null ) {
+    function czr_fn_navigation_option_map( $get_default = null ) {
       return array(
               'tc_display_second_menu'  =>  array(
                                 'default'       => 0,
@@ -730,7 +730,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'notice'        => __( "When you've set your main menu as a vertical side navigation, you can check this option to display a complementary horizontal menu in the header." , 'customizr' ),
               ),
               'tc_menu_style'  =>  array(
-                              'default'       => CZR_utils::$inst -> czr_user_started_before_version( '3.4.0', '1.2.0' ) ? 'navbar' : 'aside',
+                              'default'       => CZR_utils::$inst -> czr_fn_user_started_before_version( '3.4.0', '1.2.0' ) ? 'navbar' : 'aside',
                               'control'       => 'CZR_controls' ,
                               'title'         => __( 'Main menu design' , 'customizr'),
                               'label'         => __( 'Select a design : side menu (vertical) or regular (horizontal)' , 'customizr' ),
@@ -761,7 +761,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'notice'        => __( 'Note : the label is hidden on mobile devices.' , 'customizr' ),
               ),
               'tc_menu_position'  =>  array(
-                                'default'       => CZR_utils::$inst -> czr_user_started_before_version( '3.4.0', '1.2.0' ) ? 'pull-menu-left' : 'pull-menu-right',
+                                'default'       => CZR_utils::$inst -> czr_fn_user_started_before_version( '3.4.0', '1.2.0' ) ? 'pull-menu-left' : 'pull-menu-right',
                                 'control'       => 'CZR_controls' ,
                                 'label'         => __( 'Menu position (for "main" menu)' , "customizr" ),
                                 'section'       => 'nav' ,
@@ -801,7 +801,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
               //The hover menu type has been introduced in v3.1.0.
               //For users already using the theme (no theme's option set), the default choice is click, for new users, it is hover.
               'tc_menu_type'  => array(
-                                'default'   =>  CZR_utils::$inst -> czr_user_started_before_version( '3.1.0' , '1.0.0' ) ? 'click' : 'hover',
+                                'default'   =>  CZR_utils::$inst -> czr_fn_user_started_before_version( '3.1.0' , '1.0.0' ) ? 'click' : 'hover',
                                 'control'   =>  'CZR_controls' ,
                                 'label'     =>  __( 'Select a submenu expansion option' , 'customizr' ),
                                 'section'   =>  'nav' ,
@@ -871,7 +871,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    FRONT PAGE SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function czr_front_page_option_map( $get_default = null ) {
+    function czr_fn_front_page_option_map( $get_default = null ) {
       //prepare the cat picker notice
       global $wp_version;
       $_cat_picker_notice = sprintf( '%1$s <a href="%2$s" target="_blank">%3$s<span style="font-size: 17px;" class="dashicons dashicons-external"></span></a>' ,
@@ -962,7 +962,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'section'     => 'frontpage_sec' ,
                                 'control'     => 'CZR_controls' ,
                                 'type'        => 'select' ,
-                                'choices'     => $this -> czr_layout_choices(),
+                                'choices'     => $this -> czr_fn_layout_choices(),
                                 'priority'    => 2,
               ),
 
@@ -975,7 +975,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'section'     => 'frontpage_sec' ,
                                 'type'        => 'select' ,
                                 //!important
-                                'choices'     => ( true == $get_default ) ? null : $this -> czr_slider_choices(),
+                                'choices'     => ( true == $get_default ) ? null : $this -> czr_fn_slider_choices(),
                                 'priority'    => 20
               ),
               //posts slider
@@ -1055,7 +1055,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
               //Delay between each slides
               'tc_slider_delay' => array(
                                 'default'       => 5000,
-                                'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
+                                'sanitize_callback' => array( $this , 'czr_fn_sanitize_number' ),
                                 'control'   => 'CZR_controls' ,
                                 'label'       => __( 'Delay between each slides' , 'customizr' ),
                                 'section'     => 'frontpage_sec' ,
@@ -1067,7 +1067,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
               ),
               'tc_slider_default_height' => array(
                                 'default'       => 500,
-                                'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
+                                'sanitize_callback' => array( $this , 'czr_fn_sanitize_number' ),
                                 'control'   => 'CZR_controls' ,
                                 'label'       => __( "Set slider's height in pixels" , 'customizr' ),
                                 'section'     => 'frontpage_sec' ,
@@ -1145,7 +1145,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    PAGES AND POST LAYOUT SETTINGS
     ------------------------------------------------------------------------------------------------------*/
-    function czr_layout_option_map( $get_default = null ) {
+    function czr_fn_layout_option_map( $get_default = null ) {
       return array(
               //Global sidebar layout
               'tc_sidebar_global_layout' => array(
@@ -1153,7 +1153,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                               'label'         => __( 'Choose the global default layout' , 'customizr' ),
                               'section'     => 'post_layout_sec' ,
                               'type'          => 'select' ,
-                              'choices'     => $this -> czr_layout_choices(),
+                              'choices'     => $this -> czr_fn_layout_choices(),
                               'notice'      => __( 'Note : the home page layout has to be set in the home page section' , 'customizr' ),
                               'priority'      => 10
                ),
@@ -1175,14 +1175,14 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                               'label'       => __( 'Choose the posts default layout' , 'customizr' ),
                               'section'     => 'post_layout_sec' ,
                               'type'        => 'select' ,
-                              'choices'   => $this -> czr_layout_choices(),
+                              'choices'   => $this -> czr_fn_layout_choices(),
                               'priority'      => 30
               ),
 
               //Post per page
               'posts_per_page'  =>  array(
                               'default'     => get_option( 'posts_per_page' ),
-                              'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
+                              'sanitize_callback' => array( $this , 'czr_fn_sanitize_number' ),
                               'control'     => 'CZR_controls' ,
                               'title'         => __( 'Global Post Lists Settings' , 'customizr' ),
                               'label'         => __( 'Maximum number of posts per page' , 'customizr' ),
@@ -1212,7 +1212,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'label'       => __( 'Choose the pages default layout' , 'customizr' ),
                                 'section'     => 'post_layout_sec' ,
                                 'type'        => 'select' ,
-                                'choices'   => $this -> czr_layout_choices(),
+                                'choices'   => $this -> czr_fn_layout_choices(),
                                 'priority'       => 40,
                                 'notice'    => sprintf('<br/> %s<br/>%s',
                                     sprintf( __("The above layout options will set your layout globally for your post and pages. But you can also define the layout for each post and page individually. Learn how in the %s.", "customizr"),
@@ -1231,12 +1231,12 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                   POST LISTS SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function czr_post_list_option_map( $get_default = null ) {
+    function czr_fn_post_list_option_map( $get_default = null ) {
       global $wp_version;
       return array(
               'tc_post_list_excerpt_length'  =>  array(
                                 'default'       => 50,
-                                'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
+                                'sanitize_callback' => array( $this , 'czr_fn_sanitize_number' ),
                                 'control'       => 'CZR_controls' ,
                                 'label'         => __( "Set the excerpt length (in number of words) " , "customizr" ),
                                 'section'       => 'post_lists_sec' ,
@@ -1268,7 +1268,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'control'   =>  version_compare( $wp_version, '4.3', '>=' ) ? 'CZR_Customize_Cropped_Image_Control' : 'CZR_Customize_Upload_Control',
                                 'label'         => __( 'Upload a default thumbnail' , 'customizr' ),
                                 'section'   =>  'post_lists_sec' ,
-                                'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
+                                'sanitize_callback' => array( $this , 'czr_fn_sanitize_number' ),
                         //we can define suggested cropping area and allow it to be flexible (def 150x150 and not flexible)
                                 'width'         => 570,
                                 'height'        => 350,
@@ -1301,7 +1301,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
               ),
               'tc_post_list_thumb_height' => array(
                                 'default'       => 250,
-                                'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
+                                'sanitize_callback' => array( $this , 'czr_fn_sanitize_number' ),
                                 'control'   => 'CZR_controls' ,
                                 'label'       => __( "Set the thumbnail's max height in pixels" , 'customizr' ),
                                 'section'     => 'post_lists_sec' ,
@@ -1375,7 +1375,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
               ),
 
               'tc_post_list_grid'  =>  array(
-                                'default'       => CZR_utils::$inst -> czr_user_started_before_version( '3.2.18', '1.0.13' ) ? 'alternate' : 'grid',
+                                'default'       => CZR_utils::$inst -> czr_fn_user_started_before_version( '3.2.18', '1.0.13' ) ? 'alternate' : 'grid',
                                 'control'       => 'CZR_controls' ,
                                 'title'         => __( 'Post List Design' , 'customizr' ),
                                 'label'         => __( 'Select a Layout' , "customizr" ),
@@ -1465,7 +1465,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                ),
               'tc_grid_num_words'  =>  array(
                                 'default'       => 10,
-                                'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
+                                'sanitize_callback' => array( $this , 'czr_fn_sanitize_number' ),
                                 'control'       => 'CZR_controls' ,
                                 'label'         => __( 'Max. length for post titles (in words)' , "customizr" ),
                                 'section'       => 'post_lists_sec' ,
@@ -1476,7 +1476,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
               ),
               'tc_grid_thumb_height' => array(
                                 'default'       => 350,
-                                'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
+                                'sanitize_callback' => array( $this , 'czr_fn_sanitize_number' ),
                                 'control'       => 'CZR_controls' ,
                                 'title'         => __( 'Thumbnails max height for the grid layout' , 'customizr' ),
                                 'label'         => __( "Set the post grid thumbnail's max height in pixels" , 'customizr' ),
@@ -1495,7 +1495,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    SINGLE POSTS SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function czr_single_post_option_map( $get_default = null ) {
+    function czr_fn_single_post_option_map( $get_default = null ) {
       return array(
           'tc_single_post_thumb_location'  =>  array(
                             'default'       => 'hide',
@@ -1519,7 +1519,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
           ),
           'tc_single_post_thumb_height' => array(
                             'default'       => 250,
-                            'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
+                            'sanitize_callback' => array( $this , 'czr_fn_sanitize_number' ),
                             'control'   => 'CZR_controls' ,
                             'label'       => __( "Set the thumbnail's max height in pixels" , 'customizr' ),
                             'section'     => 'single_posts_sec' ,
@@ -1542,7 +1542,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    BREADCRUMB SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function czr_breadcrumb_option_map( $get_default = null ) {
+    function czr_fn_breadcrumb_option_map( $get_default = null ) {
         return array(
               'tc_breadcrumb' => array(
                               'default'       => 1,//Breadcrumb is checked by default
@@ -1595,7 +1595,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                   POST METAS SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function czr_post_metas_option_map( $get_default = null ){
+    function czr_fn_post_metas_option_map( $get_default = null ){
       return array(
               'tc_show_post_metas'  =>  array(
                                 'default'       => 1,
@@ -1608,7 +1608,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'transport'   => 'postMessage'
               ),
               'tc_post_metas_design'  =>  array(
-                                'default'       => CZR_utils::$inst -> czr_user_started_before_version( '3.3.2' , '1.0.11' ) ? 'buttons' : 'no-buttons',
+                                'default'       => CZR_utils::$inst -> czr_fn_user_started_before_version( '3.3.2' , '1.0.11' ) ? 'buttons' : 'no-buttons',
                                 'control'     => 'CZR_controls' ,
                                 'title'         => __( 'Metas Design' , 'customizr' ),
                                 'label'         => __( "Select a design for the post metas" , "customizr" ),
@@ -1708,7 +1708,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
               ),
 
               'tc_post_metas_update_notice_in_title'  =>  array(
-                                'default'       => CZR_utils::$inst -> czr_user_started_before_version( '3.3.2' , '1.0.11' ) ? 1 : 0,
+                                'default'       => CZR_utils::$inst -> czr_fn_user_started_before_version( '3.3.2' , '1.0.11' ) ? 1 : 0,
                                 'control'       => 'CZR_controls',
                                 'title'         => __( 'Recent update notice after post titles' , 'customizr' ),
                                 'label'         => __( "Display a recent update notice" , "customizr" ),
@@ -1720,7 +1720,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
               'tc_post_metas_update_notice_interval'  =>  array(
                                 'default'       => 10,
                                 'control'       => 'CZR_controls',
-                                'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
+                                'sanitize_callback' => array( $this , 'czr_fn_sanitize_number' ),
                                 'label'         => __( "Display the notice if the last update is less (strictly) than n days old" , "customizr" ),
                                 'section'       => 'post_metas_sec',
                                 'type'          => 'number' ,
@@ -1762,7 +1762,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    GALLERY SECTION
     -----------------------------------------------------------------------------------------------------*/
-    function czr_gallery_option_map( $get_default = null ){
+    function czr_fn_gallery_option_map( $get_default = null ){
       return array(
               'tc_enable_gallery'  =>  array(
                                 'default'       => 1,
@@ -1800,7 +1800,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    PARAGRAPHS SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function czr_paragraph_option_map( $get_default = null ){
+    function czr_fn_paragraph_option_map( $get_default = null ){
       return array(
               'tc_enable_dropcap'  =>  array(
                                 'default'       => 0,
@@ -1814,7 +1814,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
               ),
               'tc_dropcap_minwords'  =>  array(
                                 'default'       => 50,
-                                'sanitize_callback' => array( $this , 'czr_sanitize_number' ),
+                                'sanitize_callback' => array( $this , 'czr_fn_sanitize_number' ),
                                 'control'       => 'CZR_controls' ,
                                 'label'         => __( "Apply a drop cap when the paragraph includes at least the following number of words :" , "customizr" ),
                                 'notice'         => __( "(number of words)" , "customizr" ),
@@ -1862,7 +1862,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    COMMENTS SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function czr_comment_option_map( $get_default = null ) {
+    function czr_fn_comment_option_map( $get_default = null ) {
       return array(
               'tc_comment_show_bubble'  =>  array(
                                 'default'       => 1,
@@ -1888,7 +1888,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
               ),
 
               'tc_comment_bubble_color_type' => array(
-                                'default'     => CZR_utils::$inst -> czr_user_started_before_version( '3.3.2' , '1.0.11' ) ? 'custom' : 'skin',
+                                'default'     => CZR_utils::$inst -> czr_fn_user_started_before_version( '3.3.2' , '1.0.11' ) ? 'custom' : 'skin',
                                 'control'     => 'CZR_controls',
                                 'label'       => __( 'Comments bubble color' , 'customizr' ),
                                 'section'     => 'comments_sec',
@@ -1900,13 +1900,13 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'priority'    => 20,
               ),
               'tc_comment_bubble_color' => array(
-                                'default'     => CZR_utils::$inst -> czr_user_started_before_version( '3.3.2' , '1.0.11' ) ? '#F00' : CZR_utils::$inst -> czr_get_skin_color(),
+                                'default'     => CZR_utils::$inst -> czr_fn_user_started_before_version( '3.3.2' , '1.0.11' ) ? '#F00' : CZR_utils::$inst -> czr_fn_get_skin_color(),
                                 'control'     => 'WP_Customize_Color_Control',
                                 'label'       => __( 'Comments bubble color' , 'customizr' ),
                                 'section'     => 'comments_sec',
                                 'type'        =>  'color' ,
                                 'priority'    => 30,
-                                'sanitize_callback'    => array( $this, 'czr_sanitize_hex_color' ),
+                                'sanitize_callback'    => array( $this, 'czr_fn_sanitize_hex_color' ),
                                 'sanitize_js_callback' => 'maybe_hash_hex_color',
                                 'transport'   => 'postMessage'
               ),
@@ -1958,7 +1958,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    POST NAVIGATION SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function czr_post_navigation_option_map( $get_default = null ) {
+    function czr_fn_post_navigation_option_map( $get_default = null ) {
       return array(
               'tc_show_post_navigation'  =>  array(
                                 'default'       => 1,
@@ -2011,7 +2011,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    SIDEBAR SOCIAL LINKS SETTINGS SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function czr_sidebars_option_map( $get_default = null ) {
+    function czr_fn_sidebars_option_map( $get_default = null ) {
       return array(
               'tc_social_in_left-sidebar' =>  array(
                                 'default'       => 0,
@@ -2055,7 +2055,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    FOOTER GLOBAL SETTINGS SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function czr_footer_global_settings_option_map( $get_default = null ) {
+    function czr_fn_footer_global_settings_option_map( $get_default = null ) {
       return array(
               'tc_social_in_footer' =>  array(
                                 'default'       => 1,
@@ -2067,7 +2067,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
                                 'transport'   => 'postMessage'
               ),
               'tc_sticky_footer'  =>  array(
-                                'default'       => CZR_utils::$inst -> czr_user_started_before_version( '3.4.0' , '1.1.14' ) ? 0 : 1,
+                                'default'       => CZR_utils::$inst -> czr_fn_user_started_before_version( '3.4.0' , '1.1.14' ) ? 0 : 1,
                                 'control'       => 'CZR_controls' ,
                                 'label'         => __( "Stick the footer to the bottom of the page", "customizr" ),
                                 'section'       => 'footer_global_sec' ,
@@ -2112,7 +2112,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                                    CUSTOM CSS SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function czr_custom_css_option_map( $get_default = null ) {
+    function czr_fn_custom_css_option_map( $get_default = null ) {
       return array(
               'tc_custom_css' =>  array(
                                 'sanitize_callback' => 'wp_filter_nohtml_kses',
@@ -2136,7 +2136,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                               WEBSITE PERFORMANCES SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function czr_performance_option_map( $get_default = null ) {
+    function czr_fn_performance_option_map( $get_default = null ) {
       return array(
               'tc_minified_skin'  =>  array(
                                 'default'       => 1,
@@ -2161,7 +2161,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                               FRONT END NOTICES AND PLACEHOLDERS SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function czr_placeholders_notice_map( $get_default = null ) {
+    function czr_fn_placeholders_notice_map( $get_default = null ) {
       return array(
               'tc_display_front_help'  =>  array(
                                 'default'       => 1,
@@ -2177,7 +2177,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /*-----------------------------------------------------------------------------------------------------
                               FRONT END EXTERNAL RESOURCES SECTION
     ------------------------------------------------------------------------------------------------------*/
-    function czr_external_resources_option_map( $get_default = null ) {
+    function czr_fn_external_resources_option_map( $get_default = null ) {
       return array(
               'tc_font_awesome_icons'  =>  array(
                                 'default'       => 1,
@@ -2214,7 +2214,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     * hook : tc_add_panel_map
     * @return  associative array of customizer panels
     */
-    function czr_popul_panels_map( $panel_map ) {
+    function czr_fn_popul_panels_map( $panel_map ) {
       $_new_panels = array(
         'tc-global-panel' => array(
                   'priority'       => 10,
@@ -2266,7 +2266,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /**
      * hook : tc_remove_section_map
      */
-    function czr_popul_remove_section_map( $_sections ) {
+    function czr_fn_popul_remove_section_map( $_sections ) {
       //customizer option array
       $remove_section = array(
         'static_front_page' ,
@@ -2285,12 +2285,12 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     * Print the themes section (themes switcher) when previewing the themes from wp-admin/themes.php
     * hook : tc_remove_section_map
     */
-    function czr_set_theme_switcher_visibility( $_sections) {
+    function czr_fn_set_theme_switcher_visibility( $_sections) {
       //Don't do anything is in preview frame
       //=> because once the preview is ready, a postMessage is sent to the panel frame to refresh the sections and panels
       //Do nothing if WP version under 4.2
       global $wp_version;
-      if ( CZR___::$instance -> czr_is_customize_preview_frame() || ! version_compare( $wp_version, '4.2', '>=') )
+      if ( CZR___::$instance -> czr_fn_is_customize_preview_frame() || ! version_compare( $wp_version, '4.2', '>=') )
         return $_sections;
 
       //when user access the theme switcher from the admin bar
@@ -2318,7 +2318,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     /**
     * hook : tc_add_section_map
     */
-    function czr_popul_section_map( $_sections ) {
+    function czr_fn_popul_section_map( $_sections ) {
       //For nav menus option
       $locations      = get_registered_nav_menus();
       $menus          = wp_get_nav_menus();
@@ -2575,7 +2575,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     * @since Customizr 3.0.15
     *
     */
-    function czr_generates_featured_pages( $_original_map ) {
+    function czr_fn_generates_featured_pages( $_original_map ) {
       $default = array(
         'dropdown'  =>  array(
               'one'   => __( 'Home featured page one' , 'customizr' ),
@@ -2614,7 +2614,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
       foreach ( $fp_ids as $id ) {
         $priority = $priority + $incr;
         $fp_setting_control['tc_featured_text_' . $id]   = array(
-                      'sanitize_callback' => array( $this , 'czr_sanitize_textarea' ),
+                      'sanitize_callback' => array( $this , 'czr_fn_sanitize_textarea' ),
                       'transport'   => 'postMessage',
                       'control'   => 'CZR_controls' ,
                       'label'       => isset($default['text'][$id]) ? $default['text'][$id] : sprintf( __('Featured text %1$s (200 char. max)' , 'customizr' ) , $id ),
@@ -2640,7 +2640,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     * @since Customizr 3.0.15
     *
     */
-    function czr_generates_socials( $_original_map ) {
+    function czr_fn_generates_socials( $_original_map ) {
       //gets the social network array
       $socials      = apply_filters( 'tc_default_socials' , CZR_init::$instance -> socials );
 
@@ -2655,7 +2655,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
 
         $_new_map[$key]  = array(
                       'default'       => ( isset($data['default']) && !is_null($data['default']) ) ? $data['default'] : null,
-                      'sanitize_callback' => array( $this , 'czr_sanitize_' . $type ),
+                      'sanitize_callback' => array( $this , 'czr_fn_sanitize_' . $type ),
                       'control'       => 'CZR_controls' ,
                       'label'         => ( isset($data['option_label']) ) ? call_user_func( '__' , $data['option_label'] , 'customizr' ) : $key,
                       'section'       => 'socials_sec' ,
@@ -2678,7 +2678,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     * @since Customizr 3.0.15
     *
     */
-    private function czr_get_skins($path) {
+    private function czr_fn_get_skins($path) {
       //checks if path exists
       if ( !file_exists($path) )
         return;
@@ -2726,7 +2726,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     * @package Customizr
     * @since Customizr 3.1.0
     */
-    private function czr_layout_choices() {
+    private function czr_fn_layout_choices() {
         $global_layout  = apply_filters( 'tc_global_layout' , CZR_init::$instance -> global_layout );
         $layout_choices = array();
         foreach ($global_layout as $key => $value) {
@@ -2741,7 +2741,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     * @package Customizr
     * @since Customizr 3.0.1
     */
-    private function czr_slider_choices() {
+    private function czr_fn_slider_choices() {
       $__options    =   get_option('tc_theme_options');
       $slider_names   =   isset($__options['tc_sliders']) ? $__options['tc_sliders'] : array();
 
@@ -2766,9 +2766,9 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     * @since Customizr 3.0.11
     * @updated Customizr 3.0.15
     */
-    private function czr_build_skin_list() {
-        $parent_skins   = $this -> czr_get_skins(TC_BASE .'inc/assets/css');
-        $child_skins    = ( CZR___::$instance -> czr_is_child() && file_exists(TC_BASE_CHILD .'inc/assets/css') ) ? $this -> czr_get_skins(TC_BASE_CHILD .'inc/assets/css') : array();
+    private function czr_fn_build_skin_list() {
+        $parent_skins   = $this -> czr_fn_get_skins(TC_BASE .'inc/assets/css');
+        $child_skins    = ( CZR___::$instance -> czr_fn_is_child() && file_exists(TC_BASE_CHILD .'inc/assets/css') ) ? $this -> czr_fn_get_skins(TC_BASE_CHILD .'inc/assets/css') : array();
         $skin_list      = array_merge( $parent_skins , $child_skins );
 
       return apply_filters( 'tc_skin_list', $skin_list );
@@ -2784,7 +2784,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
      * @package Customizr
      * @since Customizr 1.1.4
      */
-    function czr_sanitize_textarea( $value) {
+    function czr_fn_sanitize_textarea( $value) {
       $value = esc_html( $value);
       return $value;
     }
@@ -2796,7 +2796,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
      * @package Customizr
      * @since Customizr 1.1.4
      */
-    function czr_sanitize_number( $value) {
+    function czr_fn_sanitize_number( $value) {
       if ( ! $value || is_null($value) )
         return $value;
       $value = esc_attr( $value); // clean input
@@ -2809,7 +2809,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
      * @package Customizr
      * @since Customizr 1.1.4
      */
-    function czr_sanitize_url( $value) {
+    function czr_fn_sanitize_url( $value) {
       $value = esc_url( $value);
       return $value;
     }
@@ -2819,7 +2819,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
      * @package Customizr
      * @since Customizr 3.4.11
      */
-    function czr_sanitize_email( $value) {
+    function czr_fn_sanitize_email( $value) {
       return sanitize_email( $value );
     }
 
@@ -2828,7 +2828,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
      * @package Customizr
      * @since Customizr 1.1.4
      */
-    function czr_sanitize_hex_color( $color ) {
+    function czr_fn_sanitize_hex_color( $color ) {
       if ( $unhashed = sanitize_hex_color_no_hash( $color ) )
         return '#' . $unhashed;
 
@@ -2841,7 +2841,7 @@ if ( ! class_exists( 'CZR_utils_settings_map' ) ) :
     * @package Customizr
     * @since Customizr 3.1.11
     */
-    function czr_sanitize_uploads( $url ) {
+    function czr_fn_sanitize_uploads( $url ) {
       $upload_dir = wp_upload_dir();
       return str_replace($upload_dir['baseurl'], '', $url);
     }

--- a/inc/class-fire-widgets.php
+++ b/inc/class-fire-widgets.php
@@ -21,7 +21,7 @@ if ( ! class_exists( 'CZR_widgets' ) ) :
     function __construct () {
       self::$instance =& $this;
       //widgets actions
-      add_action( 'widgets_init'                    , array( $this , 'tc_widgets_factory' ) );
+      add_action( 'widgets_init'                    , array( $this , 'czr_widgets_factory' ) );
     }
 
     /******************************************

--- a/inc/class-fire-widgets.php
+++ b/inc/class-fire-widgets.php
@@ -1,9 +1,9 @@
 <?php
 /**
 * Widgets factory : registered the different widgetized areas
-* The default widget areas are defined as properties of the TC_utils class in class-fire-utils.php
-* TC_utils::$inst -> sidebar_widgets for left and right sidebars
-* TC_utils::$inst -> footer_widgets for the footer
+* The default widget areas are defined as properties of the CZR_utils class in class-fire-utils.php
+* CZR_utils::$inst -> sidebar_widgets for left and right sidebars
+* CZR_utils::$inst -> footer_widgets for the footer
 * The widget area are then fired in the class below
 *
 * @package      Customizr
@@ -14,8 +14,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_widgets' ) ) :
-  class TC_widgets {
+if ( ! class_exists( 'CZR_widgets' ) ) :
+  class CZR_widgets {
     //Access any method or var of the class with classname::$instance -> var or method():
     static $instance;
     function __construct () {
@@ -50,8 +50,8 @@ if ( ! class_exists( 'TC_widgets' ) ) :
       );
 
       //gets the filtered default values
-      $footer_widgets           = apply_filters( 'tc_footer_widgets'  , TC_init::$instance -> footer_widgets );
-      $sidebar_widgets          = apply_filters( 'tc_sidebar_widgets' , TC_init::$instance -> sidebar_widgets );
+      $footer_widgets           = apply_filters( 'tc_footer_widgets'  , CZR_init::$instance -> footer_widgets );
+      $sidebar_widgets          = apply_filters( 'tc_sidebar_widgets' , CZR_init::$instance -> sidebar_widgets );
       $widgets                  = apply_filters( 'tc_default_widgets' , array_merge( $sidebar_widgets , $footer_widgets ) );
 
       //declares the arguments array

--- a/inc/class-fire-widgets.php
+++ b/inc/class-fire-widgets.php
@@ -34,7 +34,7 @@ if ( ! class_exists( 'CZR_widgets' ) ) :
     * @package Customizr
     * @since Customizr 3.0
     */
-    function tc_widgets_factory() {
+    function czr_widgets_factory() {
       //default Customizr filtered args
       $default                  = apply_filters( 'tc_default_widget_args' ,
                                 array(

--- a/inc/class-fire-widgets.php
+++ b/inc/class-fire-widgets.php
@@ -21,7 +21,7 @@ if ( ! class_exists( 'CZR_widgets' ) ) :
     function __construct () {
       self::$instance =& $this;
       //widgets actions
-      add_action( 'widgets_init'                    , array( $this , 'czr_widgets_factory' ) );
+      add_action( 'widgets_init'                    , array( $this , 'czr_fn_widgets_factory' ) );
     }
 
     /******************************************
@@ -34,7 +34,7 @@ if ( ! class_exists( 'CZR_widgets' ) ) :
     * @package Customizr
     * @since Customizr 3.0
     */
-    function czr_widgets_factory() {
+    function czr_fn_widgets_factory() {
       //default Customizr filtered args
       $default                  = apply_filters( 'tc_default_widget_args' ,
                                 array(

--- a/inc/init-pro.php
+++ b/inc/init-pro.php
@@ -12,8 +12,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_init_pro' ) ) :
-  class TC_init_pro {
+if ( ! class_exists( 'CZR_init_pro' ) ) :
+  class CZR_init_pro {
     //Access any method or var of the class with classname::$instance -> var or method():
     static $instance;
     public $_pro_classes;
@@ -56,7 +56,7 @@ if ( ! class_exists( 'TC_init_pro' ) ) :
 
         $_args = isset( $params[1] ) ? $params[1] : null;
         //instantiates only for the following classes, the other are instantiated in their respective files.
-        if ( 'TC_activation_key' == $name || 'TC_theme_check_updates' == $name )
+        if ( 'CZR_activation_key' == $name || 'CZR_theme_check_updates' == $name )
             new $name( $_args );
       }
     }
@@ -71,7 +71,7 @@ if ( ! class_exists( 'TC_init_pro' ) ) :
     * @since  Customizr 3.3+
     */
     function tc_set_files_to_load_pro($_to_load) {
-      if ( ! is_admin() || ( is_admin() && TC___::$instance -> tc_is_customizing() ) ) {
+      if ( ! is_admin() || ( is_admin() && CZR___::$instance -> tc_is_customizing() ) ) {
           unset($_to_load['TC_activation_key']);
           unset($_to_load['TC_theme_updater']);
           unset($_to_load['TC_theme_check_updates']);
@@ -84,5 +84,5 @@ if ( ! class_exists( 'TC_init_pro' ) ) :
 endif;
 
 //may be load pro
-if ( TC___::tc_is_pro() )
-  new TC_init_pro(TC___::$theme_name );
+if ( CZR___::tc_is_pro() )
+  new CZR_init_pro(CZR___::$theme_name );

--- a/inc/init-pro.php
+++ b/inc/init-pro.php
@@ -29,9 +29,9 @@ if ( ! class_exists( 'CZR_init_pro' ) ) :
           'PC_pro_bundle'              => array('/addons/bundle/pc-pro-bundle.php')
         );
         //set files to load according to the context : admin / front / customize
-        add_filter( 'tc_get_files_to_load_pro' , array( $this , 'czr_set_files_to_load_pro' ) );
+        add_filter( 'tc_get_files_to_load_pro' , array( $this , 'czr_fn_set_files_to_load_pro' ) );
         //load
-        $this -> czr_pro_load();
+        $this -> czr_fn_pro_load();
     }//end of __construct()
 
 
@@ -40,7 +40,7 @@ if ( ! class_exists( 'CZR_init_pro' ) ) :
     * @return void()
     *
     */
-    private function czr_pro_load() {
+    private function czr_fn_pro_load() {
       $_classes = apply_filters( 'tc_get_files_to_load_pro' , $this -> _pro_classes );
 
       //loads and instantiates the activation / updates classes
@@ -70,8 +70,8 @@ if ( ! class_exists( 'CZR_init_pro' ) ) :
     * @return boolean
     * @since  Customizr 3.3+
     */
-    function czr_set_files_to_load_pro($_to_load) {
-      if ( ! is_admin() || ( is_admin() && CZR___::$instance -> czr_is_customizing() ) ) {
+    function czr_fn_set_files_to_load_pro($_to_load) {
+      if ( ! is_admin() || ( is_admin() && CZR___::$instance -> czr_fn_is_customizing() ) ) {
           unset($_to_load['TC_activation_key']);
           unset($_to_load['TC_theme_updater']);
           unset($_to_load['TC_theme_check_updates']);
@@ -84,5 +84,5 @@ if ( ! class_exists( 'CZR_init_pro' ) ) :
 endif;
 
 //may be load pro
-if ( CZR___::czr_is_pro() )
+if ( CZR___::czr_fn_is_pro() )
   new CZR_init_pro(CZR___::$theme_name );

--- a/inc/init-pro.php
+++ b/inc/init-pro.php
@@ -29,7 +29,7 @@ if ( ! class_exists( 'CZR_init_pro' ) ) :
           'PC_pro_bundle'              => array('/addons/bundle/pc-pro-bundle.php')
         );
         //set files to load according to the context : admin / front / customize
-        add_filter( 'tc_get_files_to_load_pro' , array( $this , 'tc_set_files_to_load_pro' ) );
+        add_filter( 'tc_get_files_to_load_pro' , array( $this , 'czr_set_files_to_load_pro' ) );
         //load
         $this -> czr_pro_load();
     }//end of __construct()

--- a/inc/init-pro.php
+++ b/inc/init-pro.php
@@ -40,7 +40,7 @@ if ( ! class_exists( 'CZR_init_pro' ) ) :
     * @return void()
     *
     */
-    private function tc_pro_load() {
+    private function czr_pro_load() {
       $_classes = apply_filters( 'tc_get_files_to_load_pro' , $this -> _pro_classes );
 
       //loads and instantiates the activation / updates classes
@@ -70,7 +70,7 @@ if ( ! class_exists( 'CZR_init_pro' ) ) :
     * @return boolean
     * @since  Customizr 3.3+
     */
-    function tc_set_files_to_load_pro($_to_load) {
+    function czr_set_files_to_load_pro($_to_load) {
       if ( ! is_admin() || ( is_admin() && CZR___::$instance -> tc_is_customizing() ) ) {
           unset($_to_load['TC_activation_key']);
           unset($_to_load['TC_theme_updater']);

--- a/inc/init-pro.php
+++ b/inc/init-pro.php
@@ -31,7 +31,7 @@ if ( ! class_exists( 'CZR_init_pro' ) ) :
         //set files to load according to the context : admin / front / customize
         add_filter( 'tc_get_files_to_load_pro' , array( $this , 'tc_set_files_to_load_pro' ) );
         //load
-        $this -> tc_pro_load();
+        $this -> czr_pro_load();
     }//end of __construct()
 
 
@@ -71,7 +71,7 @@ if ( ! class_exists( 'CZR_init_pro' ) ) :
     * @since  Customizr 3.3+
     */
     function czr_set_files_to_load_pro($_to_load) {
-      if ( ! is_admin() || ( is_admin() && CZR___::$instance -> tc_is_customizing() ) ) {
+      if ( ! is_admin() || ( is_admin() && CZR___::$instance -> czr_is_customizing() ) ) {
           unset($_to_load['TC_activation_key']);
           unset($_to_load['TC_theme_updater']);
           unset($_to_load['TC_theme_check_updates']);
@@ -84,5 +84,5 @@ if ( ! class_exists( 'CZR_init_pro' ) ) :
 endif;
 
 //may be load pro
-if ( CZR___::tc_is_pro() )
+if ( CZR___::czr_is_pro() )
   new CZR_init_pro(CZR___::$theme_name );

--- a/inc/init.php
+++ b/inc/init.php
@@ -1,19 +1,19 @@
 <?php
 /**
-* The czr__f() function is an extension of WP built-in apply_filters() where the $value param becomes optional.
+* The czr_fn__f() function is an extension of WP built-in apply_filters() where the $value param becomes optional.
 * It is shorter than the original apply_filters() and only used on already defined filters.
 *
 * By convention in Customizr, filter hooks are used as follow :
 * 1) declared with add_filters in class constructors (mainly) to hook on WP built-in callbacks or create "getters" used everywhere
 * 2) declared with apply_filters in methods to make the code extensible for developers
-* 3) accessed with czr__f() to return values (while front end content is handled with action hooks)
+* 3) accessed with czr_fn__f() to return values (while front end content is handled with action hooks)
 *
 * Used everywhere in Customizr. Can pass up to five variables to the filter callback.
 *
 * @since Customizr 3.0
 */
-if( ! function_exists( 'czr__f' ) ) :
-    function czr__f ( $tag , $value = null , $arg_one = null , $arg_two = null , $arg_three = null , $arg_four = null , $arg_five = null) {
+if( ! function_exists( 'czr_fn__f' ) ) :
+    function czr_fn__f ( $tag , $value = null , $arg_one = null , $arg_two = null , $arg_three = null , $arg_four = null , $arg_five = null) {
        return apply_filters( $tag , $value , $arg_one , $arg_two , $arg_three , $arg_four , $arg_five );
     }
 endif;
@@ -133,16 +133,16 @@ if ( ! class_exists( 'CZR___' ) ) :
       );//end of filter
 
       //check the context
-      if ( $this -> czr_is_pro() )
+      if ( $this -> czr_fn_is_pro() )
         require_once( sprintf( '%sinc/init-pro.php' , TC_BASE ) );
 
       self::$tc_option_group = 'tc_theme_options';
 
       //set files to load according to the context : admin / front / customize
-      add_filter( 'tc_get_files_to_load' , array( $this , 'czr_set_files_to_load' ) );
+      add_filter( 'tc_get_files_to_load' , array( $this , 'czr_fn_set_files_to_load' ) );
 
       //theme class groups instanciation
-      $this -> czr__();
+      $this -> czr_fn__();
     }//end of __construct()
 
 
@@ -157,7 +157,7 @@ if ( ! class_exists( 'CZR___' ) ) :
     *
     * @since Customizr 3.0
     */
-    function czr__( $_to_load = array(), $_no_filter = false ) {
+    function czr_fn__( $_to_load = array(), $_no_filter = false ) {
       static $instances;
       //do we apply a filter ? optional boolean can force no filter
       $_to_load = $_no_filter ? $_to_load : apply_filters( 'tc_get_files_to_load' , $_to_load );
@@ -167,7 +167,7 @@ if ( ! class_exists( 'CZR___' ) ) :
       foreach ( $_to_load as $group => $files ) {
         foreach ($files as $path_suffix ) {
           //checks if a child theme is used and if the required file has to be overriden
-          if ( $this -> czr_is_child() && file_exists( TC_BASE_CHILD . $path_suffix[0] . '/class-' . $group . '-' .$path_suffix[1] .'.php') ) {
+          if ( $this -> czr_fn_is_child() && file_exists( TC_BASE_CHILD . $path_suffix[0] . '/class-' . $group . '-' .$path_suffix[1] .'.php') ) {
               require_once ( TC_BASE_CHILD . $path_suffix[0] . '/class-' . $group . '-' .$path_suffix[1] .'.php') ;
           }
           else {
@@ -199,10 +199,10 @@ if ( ! class_exists( 'CZR___' ) ) :
     *
     * @since  Customizr 3.3+
     */
-    function czr_set_files_to_load( $_to_load ) {
+    function czr_fn_set_files_to_load( $_to_load ) {
       $_to_load = empty($_to_load) ? $this -> tc_core : $_to_load;
       //Not customizing
-      //1) IS NOT CUSTOMIZING : czr_is_customize_left_panel() || czr_is_customize_preview_frame() || czr_doing_customizer_ajax()
+      //1) IS NOT CUSTOMIZING : czr_fn_is_customize_left_panel() || czr_fn_is_customize_preview_frame() || czr_fn_doing_customizer_ajax()
       //---1.1) IS ADMIN
       //-------1.1.a) Doing AJAX
       //-------1.1.b) Not Doing AJAX
@@ -210,33 +210,33 @@ if ( ! class_exists( 'CZR___' ) ) :
       //2) IS CUSTOMIZING
       //---2.1) IS LEFT PANEL => customizer controls
       //---2.2) IS RIGHT PANEL => preview
-      if ( ! $this -> czr_is_customizing() )
+      if ( ! $this -> czr_fn_is_customizing() )
         {
           if ( is_admin() ) {
             //if doing ajax, we must not exclude the placeholders
             //because ajax actions are fired by admin_ajax.php where is_admin===true.
             if ( defined( 'DOING_AJAX' ) )
-              $_to_load = $this -> czr_unset_core_classes( $_to_load, array( 'header' , 'content' , 'footer' ), array( 'admin|inc/admin|customize' ) );
+              $_to_load = $this -> czr_fn_unset_core_classes( $_to_load, array( 'header' , 'content' , 'footer' ), array( 'admin|inc/admin|customize' ) );
             else
-              $_to_load = $this -> czr_unset_core_classes( $_to_load, array( 'header' , 'content' , 'footer' ), array( 'admin|inc/admin|customize', 'fire|inc|placeholders' ) );
+              $_to_load = $this -> czr_fn_unset_core_classes( $_to_load, array( 'header' , 'content' , 'footer' ), array( 'admin|inc/admin|customize', 'fire|inc|placeholders' ) );
           }
           else
             //Skips all admin classes
-            $_to_load = $this -> czr_unset_core_classes( $_to_load, array( 'admin' ), array( 'fire|inc/admin|admin_init', 'fire|inc/admin|admin_page') );
+            $_to_load = $this -> czr_fn_unset_core_classes( $_to_load, array( 'admin' ), array( 'fire|inc/admin|admin_init', 'fire|inc/admin|admin_page') );
         }
       //Customizing
       else
         {
           //left panel => skip all front end classes
-          if ( $this -> czr_is_customize_left_panel() ) {
-            $_to_load = $this -> czr_unset_core_classes(
+          if ( $this -> czr_fn_is_customize_left_panel() ) {
+            $_to_load = $this -> czr_fn_unset_core_classes(
               $_to_load,
               array( 'header' , 'content' , 'footer' ),
               array( 'fire|inc|resources' , 'fire|inc/admin|admin_page' , 'admin|inc/admin|meta_boxes' )
             );
           }
-          if ( $this -> czr_is_customize_preview_frame() ) {
-            $_to_load = $this -> czr_unset_core_classes(
+          if ( $this -> czr_fn_is_customize_preview_frame() ) {
+            $_to_load = $this -> czr_fn_unset_core_classes(
               $_to_load,
               array(),
               array( 'fire|inc/admin|admin_init', 'fire|inc/admin|admin_page' , 'admin|inc/admin|meta_boxes' )
@@ -261,7 +261,7 @@ if ( ! class_exists( 'CZR___' ) ) :
     *
     * @since  Customizr 3.0.11
     */
-    public function czr_unset_core_classes( $_tree, $_groups = array(), $_files = array() ) {
+    public function czr_fn_unset_core_classes( $_tree, $_groups = array(), $_files = array() ) {
       if ( empty($_tree) )
         return array();
       if ( ! empty($_groups) ) {
@@ -300,7 +300,7 @@ if ( ! class_exists( 'CZR___' ) ) :
     *
     * @since  Customizr 3.0.11
     */
-    function czr_is_child() {
+    function czr_fn_is_child() {
       // get themedata version wp 3.4+
       if ( function_exists( 'wp_get_theme' ) ) {
         //get WP_Theme object of customizr
@@ -323,12 +323,12 @@ if ( ! class_exists( 'CZR___' ) ) :
     * @return  bool
     * @since  3.2.9
     */
-    function czr_is_customizing() {
+    function czr_fn_is_customizing() {
       //checks if is customizing : two contexts, admin and front (preview frame)
       return in_array( 1, array(
-        $this -> czr_is_customize_left_panel(),
-        $this -> czr_is_customize_preview_frame(),
-        $this -> czr_doing_customizer_ajax()
+        $this -> czr_fn_is_customize_left_panel(),
+        $this -> czr_fn_is_customize_preview_frame(),
+        $this -> czr_fn_doing_customizer_ajax()
       ) );
     }
 
@@ -338,7 +338,7 @@ if ( ! class_exists( 'CZR___' ) ) :
     * @return  boolean
     * @since  3.3+
     */
-    function czr_is_customize_left_panel() {
+    function czr_fn_is_customize_left_panel() {
       global $pagenow;
       return is_admin() && isset( $pagenow ) && 'customize.php' == $pagenow;
     }
@@ -349,7 +349,7 @@ if ( ! class_exists( 'CZR___' ) ) :
     * @return  boolean
     * @since  3.3+
     */
-    function czr_is_customize_preview_frame() {
+    function czr_fn_is_customize_preview_frame() {
       return ! is_admin() && isset($_REQUEST['wp_customize']);
     }
 
@@ -362,7 +362,7 @@ if ( ! class_exists( 'CZR___' ) ) :
     * @return boolean
     * @since  3.3.2
     */
-    function czr_doing_customizer_ajax() {
+    function czr_fn_doing_customizer_ajax() {
       $_is_ajaxing_from_customizer = isset( $_POST['customized'] ) || isset( $_POST['wp_customize'] );
       return $_is_ajaxing_from_customizer && ( defined( 'DOING_AJAX' ) && DOING_AJAX );
     }
@@ -372,7 +372,7 @@ if ( ! class_exists( 'CZR___' ) ) :
     * @return  boolean
     * @since  3.4+
     */
-    static function czr_is_pro() {
+    static function czr_fn_is_pro() {
       return file_exists( sprintf( '%sinc/init-pro.php' , TC_BASE ) ) && "customizr-pro" == self::$theme_name;
     }
   }//end of class

--- a/inc/init.php
+++ b/inc/init.php
@@ -13,7 +13,7 @@
 * @since Customizr 3.0
 */
 if( ! function_exists( 'tc__f' ) ) :
-    function tc__f ( $tag , $value = null , $arg_one = null , $arg_two = null , $arg_three = null , $arg_four = null , $arg_five = null) {
+    function czr__f ( $tag , $value = null , $arg_one = null , $arg_two = null , $arg_three = null , $arg_four = null , $arg_five = null) {
        return apply_filters( $tag , $value , $arg_one , $arg_two , $arg_three , $arg_four , $arg_five );
     }
 endif;
@@ -157,7 +157,7 @@ if ( ! class_exists( 'CZR___' ) ) :
     *
     * @since Customizr 3.0
     */
-    function tc__( $_to_load = array(), $_no_filter = false ) {
+    function czr__( $_to_load = array(), $_no_filter = false ) {
       static $instances;
       //do we apply a filter ? optional boolean can force no filter
       $_to_load = $_no_filter ? $_to_load : apply_filters( 'tc_get_files_to_load' , $_to_load );
@@ -199,7 +199,7 @@ if ( ! class_exists( 'CZR___' ) ) :
     *
     * @since  Customizr 3.3+
     */
-    function tc_set_files_to_load( $_to_load ) {
+    function czr_set_files_to_load( $_to_load ) {
       $_to_load = empty($_to_load) ? $this -> tc_core : $_to_load;
       //Not customizing
       //1) IS NOT CUSTOMIZING : tc_is_customize_left_panel() || tc_is_customize_preview_frame() || tc_doing_customizer_ajax()
@@ -261,7 +261,7 @@ if ( ! class_exists( 'CZR___' ) ) :
     *
     * @since  Customizr 3.0.11
     */
-    public function tc_unset_core_classes( $_tree, $_groups = array(), $_files = array() ) {
+    public function czr_unset_core_classes( $_tree, $_groups = array(), $_files = array() ) {
       if ( empty($_tree) )
         return array();
       if ( ! empty($_groups) ) {
@@ -300,7 +300,7 @@ if ( ! class_exists( 'CZR___' ) ) :
     *
     * @since  Customizr 3.0.11
     */
-    function tc_is_child() {
+    function czr_is_child() {
       // get themedata version wp 3.4+
       if ( function_exists( 'wp_get_theme' ) ) {
         //get WP_Theme object of customizr
@@ -323,7 +323,7 @@ if ( ! class_exists( 'CZR___' ) ) :
     * @return  bool
     * @since  3.2.9
     */
-    function tc_is_customizing() {
+    function czr_is_customizing() {
       //checks if is customizing : two contexts, admin and front (preview frame)
       return in_array( 1, array(
         $this -> tc_is_customize_left_panel(),
@@ -338,7 +338,7 @@ if ( ! class_exists( 'CZR___' ) ) :
     * @return  boolean
     * @since  3.3+
     */
-    function tc_is_customize_left_panel() {
+    function czr_is_customize_left_panel() {
       global $pagenow;
       return is_admin() && isset( $pagenow ) && 'customize.php' == $pagenow;
     }
@@ -349,7 +349,7 @@ if ( ! class_exists( 'CZR___' ) ) :
     * @return  boolean
     * @since  3.3+
     */
-    function tc_is_customize_preview_frame() {
+    function czr_is_customize_preview_frame() {
       return ! is_admin() && isset($_REQUEST['wp_customize']);
     }
 
@@ -362,7 +362,7 @@ if ( ! class_exists( 'CZR___' ) ) :
     * @return boolean
     * @since  3.3.2
     */
-    function tc_doing_customizer_ajax() {
+    function czr_doing_customizer_ajax() {
       $_is_ajaxing_from_customizer = isset( $_POST['customized'] ) || isset( $_POST['wp_customize'] );
       return $_is_ajaxing_from_customizer && ( defined( 'DOING_AJAX' ) && DOING_AJAX );
     }
@@ -372,7 +372,7 @@ if ( ! class_exists( 'CZR___' ) ) :
     * @return  boolean
     * @since  3.4+
     */
-    static function tc_is_pro() {
+    static function czr_is_pro() {
       return file_exists( sprintf( '%sinc/init-pro.php' , TC_BASE ) ) && "customizr-pro" == self::$theme_name;
     }
   }//end of class

--- a/inc/init.php
+++ b/inc/init.php
@@ -1,6 +1,6 @@
 <?php
 /**
-* The tc__f() function is an extension of WP built-in apply_filters() where the $value param becomes optional.
+* The czr__f() function is an extension of WP built-in apply_filters() where the $value param becomes optional.
 * It is shorter than the original apply_filters() and only used on already defined filters.
 *
 * By convention in Customizr, filter hooks are used as follow :
@@ -133,7 +133,7 @@ if ( ! class_exists( 'CZR___' ) ) :
       );//end of filter
 
       //check the context
-      if ( $this -> tc_is_pro() )
+      if ( $this -> czr_is_pro() )
         require_once( sprintf( '%sinc/init-pro.php' , TC_BASE ) );
 
       self::$tc_option_group = 'tc_theme_options';
@@ -142,7 +142,7 @@ if ( ! class_exists( 'CZR___' ) ) :
       add_filter( 'tc_get_files_to_load' , array( $this , 'tc_set_files_to_load' ) );
 
       //theme class groups instanciation
-      $this -> tc__();
+      $this -> czr__();
     }//end of __construct()
 
 
@@ -167,7 +167,7 @@ if ( ! class_exists( 'CZR___' ) ) :
       foreach ( $_to_load as $group => $files ) {
         foreach ($files as $path_suffix ) {
           //checks if a child theme is used and if the required file has to be overriden
-          if ( $this -> tc_is_child() && file_exists( TC_BASE_CHILD . $path_suffix[0] . '/class-' . $group . '-' .$path_suffix[1] .'.php') ) {
+          if ( $this -> czr_is_child() && file_exists( TC_BASE_CHILD . $path_suffix[0] . '/class-' . $group . '-' .$path_suffix[1] .'.php') ) {
               require_once ( TC_BASE_CHILD . $path_suffix[0] . '/class-' . $group . '-' .$path_suffix[1] .'.php') ;
           }
           else {
@@ -202,7 +202,7 @@ if ( ! class_exists( 'CZR___' ) ) :
     function czr_set_files_to_load( $_to_load ) {
       $_to_load = empty($_to_load) ? $this -> tc_core : $_to_load;
       //Not customizing
-      //1) IS NOT CUSTOMIZING : tc_is_customize_left_panel() || tc_is_customize_preview_frame() || tc_doing_customizer_ajax()
+      //1) IS NOT CUSTOMIZING : czr_is_customize_left_panel() || czr_is_customize_preview_frame() || czr_doing_customizer_ajax()
       //---1.1) IS ADMIN
       //-------1.1.a) Doing AJAX
       //-------1.1.b) Not Doing AJAX
@@ -210,33 +210,33 @@ if ( ! class_exists( 'CZR___' ) ) :
       //2) IS CUSTOMIZING
       //---2.1) IS LEFT PANEL => customizer controls
       //---2.2) IS RIGHT PANEL => preview
-      if ( ! $this -> tc_is_customizing() )
+      if ( ! $this -> czr_is_customizing() )
         {
           if ( is_admin() ) {
             //if doing ajax, we must not exclude the placeholders
             //because ajax actions are fired by admin_ajax.php where is_admin===true.
             if ( defined( 'DOING_AJAX' ) )
-              $_to_load = $this -> tc_unset_core_classes( $_to_load, array( 'header' , 'content' , 'footer' ), array( 'admin|inc/admin|customize' ) );
+              $_to_load = $this -> czr_unset_core_classes( $_to_load, array( 'header' , 'content' , 'footer' ), array( 'admin|inc/admin|customize' ) );
             else
-              $_to_load = $this -> tc_unset_core_classes( $_to_load, array( 'header' , 'content' , 'footer' ), array( 'admin|inc/admin|customize', 'fire|inc|placeholders' ) );
+              $_to_load = $this -> czr_unset_core_classes( $_to_load, array( 'header' , 'content' , 'footer' ), array( 'admin|inc/admin|customize', 'fire|inc|placeholders' ) );
           }
           else
             //Skips all admin classes
-            $_to_load = $this -> tc_unset_core_classes( $_to_load, array( 'admin' ), array( 'fire|inc/admin|admin_init', 'fire|inc/admin|admin_page') );
+            $_to_load = $this -> czr_unset_core_classes( $_to_load, array( 'admin' ), array( 'fire|inc/admin|admin_init', 'fire|inc/admin|admin_page') );
         }
       //Customizing
       else
         {
           //left panel => skip all front end classes
-          if ( $this -> tc_is_customize_left_panel() ) {
-            $_to_load = $this -> tc_unset_core_classes(
+          if ( $this -> czr_is_customize_left_panel() ) {
+            $_to_load = $this -> czr_unset_core_classes(
               $_to_load,
               array( 'header' , 'content' , 'footer' ),
               array( 'fire|inc|resources' , 'fire|inc/admin|admin_page' , 'admin|inc/admin|meta_boxes' )
             );
           }
-          if ( $this -> tc_is_customize_preview_frame() ) {
-            $_to_load = $this -> tc_unset_core_classes(
+          if ( $this -> czr_is_customize_preview_frame() ) {
+            $_to_load = $this -> czr_unset_core_classes(
               $_to_load,
               array(),
               array( 'fire|inc/admin|admin_init', 'fire|inc/admin|admin_page' , 'admin|inc/admin|meta_boxes' )
@@ -326,9 +326,9 @@ if ( ! class_exists( 'CZR___' ) ) :
     function czr_is_customizing() {
       //checks if is customizing : two contexts, admin and front (preview frame)
       return in_array( 1, array(
-        $this -> tc_is_customize_left_panel(),
-        $this -> tc_is_customize_preview_frame(),
-        $this -> tc_doing_customizer_ajax()
+        $this -> czr_is_customize_left_panel(),
+        $this -> czr_is_customize_preview_frame(),
+        $this -> czr_doing_customizer_ajax()
       ) );
     }
 

--- a/inc/init.php
+++ b/inc/init.php
@@ -6,13 +6,13 @@
 * By convention in Customizr, filter hooks are used as follow :
 * 1) declared with add_filters in class constructors (mainly) to hook on WP built-in callbacks or create "getters" used everywhere
 * 2) declared with apply_filters in methods to make the code extensible for developers
-* 3) accessed with tc__f() to return values (while front end content is handled with action hooks)
+* 3) accessed with czr__f() to return values (while front end content is handled with action hooks)
 *
 * Used everywhere in Customizr. Can pass up to five variables to the filter callback.
 *
 * @since Customizr 3.0
 */
-if( ! function_exists( 'tc__f' ) ) :
+if( ! function_exists( 'czr__f' ) ) :
     function czr__f ( $tag , $value = null , $arg_one = null , $arg_two = null , $arg_three = null , $arg_four = null , $arg_five = null) {
        return apply_filters( $tag , $value , $arg_one , $arg_two , $arg_three , $arg_four , $arg_five );
     }

--- a/inc/init.php
+++ b/inc/init.php
@@ -139,7 +139,7 @@ if ( ! class_exists( 'CZR___' ) ) :
       self::$tc_option_group = 'tc_theme_options';
 
       //set files to load according to the context : admin / front / customize
-      add_filter( 'tc_get_files_to_load' , array( $this , 'tc_set_files_to_load' ) );
+      add_filter( 'tc_get_files_to_load' , array( $this , 'czr_set_files_to_load' ) );
 
       //theme class groups instanciation
       $this -> czr__();

--- a/inc/init.php
+++ b/inc/init.php
@@ -32,8 +32,8 @@ endif;
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC___' ) ) :
-  class TC___ {
+if ( ! class_exists( 'CZR___' ) ) :
+  class CZR___ {
     //Access any method or var of the class with classname::$instance -> var or method():
     static $instance;
     public $tc_core;
@@ -78,8 +78,8 @@ if ( ! class_exists( 'TC___' ) ) :
       if( ! defined( 'TC_BASE_URL_CHILD' ) )  define( 'TC_BASE_URL_CHILD' , get_stylesheet_directory_uri() . '/' );
       //THEMENAME contains the Name of the currently loaded theme
       if( ! defined( 'THEMENAME' ) )          define( 'THEMENAME' , $tc_base_data['title'] );
-      //TC_WEBSITE is the home website of Customizr
-      if( ! defined( 'TC_WEBSITE' ) )         define( 'TC_WEBSITE' , $tc_base_data['authoruri'] );
+      //CZR_WEBSITE is the home website of Customizr
+      if( ! defined( 'CZR_WEBSITE' ) )         define( 'CZR_WEBSITE' , $tc_base_data['authoruri'] );
 
 
       //this is the structure of the Customizr code : groups => ('path' , 'class_suffix')
@@ -174,10 +174,10 @@ if ( ! class_exists( 'TC___' ) ) :
               require_once ( TC_BASE . $path_suffix[0] . '/class-' . $group . '-' .$path_suffix[1] .'.php') ;
           }
 
-          $classname = 'TC_' . $path_suffix[1];
+          $classname = 'CZR_' . $path_suffix[1];
           if( ! isset( $instances[ $classname ] ) )  {
             //check if the classname can be instantiated here
-            if ( in_array( $classname, apply_filters( 'tc_dont_instantiate_in_init', array( 'TC_nav_walker') ) ) )
+            if ( in_array( $classname, apply_filters( 'tc_dont_instantiate_in_init', array( 'CZR_nav_walker') ) ) )
               continue;
             //instantiates
             $instances[ $classname ] = class_exists($classname)  ? new $classname : '';
@@ -379,4 +379,4 @@ if ( ! class_exists( 'TC___' ) ) :
 endif;
 
 //Creates a new instance
-new TC___;
+new CZR___;

--- a/inc/parts/class-content-404.php
+++ b/inc/parts/class-content-404.php
@@ -31,7 +31,7 @@ if ( ! class_exists( 'CZR_404' ) ) :
        * @package Customizr
        * @since Customizr 3.0
        */
-      function tc_404_content() {
+      function czr_404_content() {
           if ( !is_404() )
               return;
 

--- a/inc/parts/class-content-404.php
+++ b/inc/parts/class-content-404.php
@@ -11,8 +11,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_404' ) ) :
-  class TC_404 {
+if ( ! class_exists( 'CZR_404' ) ) :
+  class CZR_404 {
 
       //Access any method or var of the class with classname::$instance -> var or method():
       static $instance;
@@ -35,7 +35,7 @@ if ( ! class_exists( 'TC_404' ) ) :
           if ( !is_404() )
               return;
 
-          $content_404    = apply_filters( 'tc_404', TC_init::$instance -> content_404 );
+          $content_404    = apply_filters( 'tc_404', CZR_init::$instance -> content_404 );
 
           echo apply_filters( 'tc_404_content',
               sprintf('<div class="%1$s"><div class="entry-content %2$s">%3$s</div>%4$s</div>',

--- a/inc/parts/class-content-404.php
+++ b/inc/parts/class-content-404.php
@@ -20,7 +20,7 @@ if ( ! class_exists( 'CZR_404' ) ) :
       function __construct () {
           self::$instance =& $this;
           //404 content
-          add_action  ( '__loop'                      , array( $this , 'tc_404_content' ));
+          add_action  ( '__loop'                      , array( $this , 'czr_404_content' ));
       }
 
 

--- a/inc/parts/class-content-404.php
+++ b/inc/parts/class-content-404.php
@@ -20,7 +20,7 @@ if ( ! class_exists( 'CZR_404' ) ) :
       function __construct () {
           self::$instance =& $this;
           //404 content
-          add_action  ( '__loop'                      , array( $this , 'czr_404_content' ));
+          add_action  ( '__loop'                      , array( $this , 'czr_fn_404_content' ));
       }
 
 
@@ -31,7 +31,7 @@ if ( ! class_exists( 'CZR_404' ) ) :
        * @package Customizr
        * @since Customizr 3.0
        */
-      function czr_404_content() {
+      function czr_fn_404_content() {
           if ( !is_404() )
               return;
 

--- a/inc/parts/class-content-attachment.php
+++ b/inc/parts/class-content-attachment.php
@@ -16,7 +16,7 @@ if ( ! class_exists( 'CZR_attachment' ) ) :
         static $instance;
         function __construct () {
             self::$instance =& $this;
-            add_action  ( '__loop'			              , array( $this , 'tc_attachment_content' ));
+            add_action  ( '__loop'			              , array( $this , 'czr_attachment_content' ));
         }
 
 
@@ -147,7 +147,7 @@ if ( ! class_exists( 'CZR_attachment' ) ) :
             <?php
             $html = ob_get_contents();
             if ($html) ob_end_clean();
-            echo apply_filters( 'tc_attachment_content', $html );
+            echo apply_filters( 'czr_attachment_content', $html );
 
         }//end of function
     }//end of class

--- a/inc/parts/class-content-attachment.php
+++ b/inc/parts/class-content-attachment.php
@@ -52,7 +52,7 @@ if ( ! class_exists( 'CZR_attachment' ) ) :
                         $attachments = array_values( get_children( array( 'post_parent' => $post->post_parent, 'post_status' => 'inherit' , 'post_type' => 'attachment' , 'post_mime_type' => 'image' , 'order' => 'ASC' , 'orderby' => 'menu_order ID' ) ) );
 
                         //did we activate the fancy box in customizer?
-                        $tc_fancybox = esc_attr( CZR_utils::$inst->tc_opt( 'tc_fancybox' ) );
+                        $tc_fancybox = esc_attr( CZR_utils::$inst->czr_opt( 'tc_fancybox' ) );
 
                         ?>
 

--- a/inc/parts/class-content-attachment.php
+++ b/inc/parts/class-content-attachment.php
@@ -11,8 +11,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_attachment' ) ) :
-    class TC_attachment {
+if ( ! class_exists( 'CZR_attachment' ) ) :
+    class CZR_attachment {
         static $instance;
         function __construct () {
             self::$instance =& $this;
@@ -52,7 +52,7 @@ if ( ! class_exists( 'TC_attachment' ) ) :
                         $attachments = array_values( get_children( array( 'post_parent' => $post->post_parent, 'post_status' => 'inherit' , 'post_type' => 'attachment' , 'post_mime_type' => 'image' , 'order' => 'ASC' , 'orderby' => 'menu_order ID' ) ) );
 
                         //did we activate the fancy box in customizer?
-                        $tc_fancybox = esc_attr( TC_utils::$inst->tc_opt( 'tc_fancybox' ) );
+                        $tc_fancybox = esc_attr( CZR_utils::$inst->tc_opt( 'tc_fancybox' ) );
 
                         ?>
 

--- a/inc/parts/class-content-attachment.php
+++ b/inc/parts/class-content-attachment.php
@@ -147,7 +147,7 @@ if ( ! class_exists( 'CZR_attachment' ) ) :
             <?php
             $html = ob_get_contents();
             if ($html) ob_end_clean();
-            echo apply_filters( 'czr_fn_attachment_content', $html );
+            echo apply_filters( 'tc_attachment_content', $html );
 
         }//end of function
     }//end of class

--- a/inc/parts/class-content-attachment.php
+++ b/inc/parts/class-content-attachment.php
@@ -16,7 +16,7 @@ if ( ! class_exists( 'CZR_attachment' ) ) :
         static $instance;
         function __construct () {
             self::$instance =& $this;
-            add_action  ( '__loop'			              , array( $this , 'czr_attachment_content' ));
+            add_action  ( '__loop'			              , array( $this , 'czr_fn_attachment_content' ));
         }
 
 
@@ -28,7 +28,7 @@ if ( ! class_exists( 'CZR_attachment' ) ) :
          * @package Customizr
          * @since Customizr 3.0
          */
-        function czr_attachment_content() {
+        function czr_fn_attachment_content() {
             //check conditional tags
             global $post;
             if ( ! isset($post) || empty($post) || 'attachment' != $post -> post_type || !is_singular() )
@@ -52,7 +52,7 @@ if ( ! class_exists( 'CZR_attachment' ) ) :
                         $attachments = array_values( get_children( array( 'post_parent' => $post->post_parent, 'post_status' => 'inherit' , 'post_type' => 'attachment' , 'post_mime_type' => 'image' , 'order' => 'ASC' , 'orderby' => 'menu_order ID' ) ) );
 
                         //did we activate the fancy box in customizer?
-                        $tc_fancybox = esc_attr( CZR_utils::$inst->czr_opt( 'tc_fancybox' ) );
+                        $tc_fancybox = esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_fancybox' ) );
 
                         ?>
 
@@ -147,7 +147,7 @@ if ( ! class_exists( 'CZR_attachment' ) ) :
             <?php
             $html = ob_get_contents();
             if ($html) ob_end_clean();
-            echo apply_filters( 'czr_attachment_content', $html );
+            echo apply_filters( 'czr_fn_attachment_content', $html );
 
         }//end of function
     }//end of class

--- a/inc/parts/class-content-attachment.php
+++ b/inc/parts/class-content-attachment.php
@@ -28,7 +28,7 @@ if ( ! class_exists( 'CZR_attachment' ) ) :
          * @package Customizr
          * @since Customizr 3.0
          */
-        function tc_attachment_content() {
+        function czr_attachment_content() {
             //check conditional tags
             global $post;
             if ( ! isset($post) || empty($post) || 'attachment' != $post -> post_type || !is_singular() )

--- a/inc/parts/class-content-breadcrumb.php
+++ b/inc/parts/class-content-breadcrumb.php
@@ -22,9 +22,9 @@ class CZR_breadcrumb {
 
     function __construct () {
         self::$instance =& $this;
-        add_action( '__before_main_container'			, array( $this , 'czr_breadcrumb_display' ), 20 );
+        add_action( '__before_main_container'			, array( $this , 'czr_fn_breadcrumb_display' ), 20 );
         //since v3.2.0, customizer option
-        add_filter( 'tc_show_breadcrumb_in_context' 	, array( $this , 'czr_set_breadcrumb_display_in_context' ) );
+        add_filter( 'tc_show_breadcrumb_in_context' 	, array( $this , 'czr_fn_set_breadcrumb_display_in_context' ) );
     }
 
 
@@ -64,15 +64,15 @@ class CZR_breadcrumb {
 
 
 
-    function czr_set_breadcrumb_display_in_context( $_bool ) {
-    	if ( czr__f('__is_home') )
-	  		return 1 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_breadcrumb_home' ) ) ? false : true;
+    function czr_fn_set_breadcrumb_display_in_context( $_bool ) {
+    	if ( czr_fn__f('__is_home') )
+	  		return 1 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_breadcrumb_home' ) ) ? false : true;
 	  	else {
-		  	if ( is_page() && 1 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_breadcrumb_in_pages' ) ) )
+		  	if ( is_page() && 1 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_breadcrumb_in_pages' ) ) )
 		  		return false;
-		  	if ( is_single() && 1 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_breadcrumb_in_single_posts' ) ) )
+		  	if ( is_single() && 1 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_breadcrumb_in_single_posts' ) ) )
 		  		return false;
-		  	if ( ! is_page() && ! is_single() && 1 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_breadcrumb_in_post_lists' ) ) )
+		  	if ( ! is_page() && ! is_single() && 1 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_breadcrumb_in_post_lists' ) ) )
 		  		return false;
 		}
 		return $_bool;
@@ -84,24 +84,24 @@ class CZR_breadcrumb {
     * @package Customizr
     * @since Customizr 1.0
     */
-    function czr_breadcrumb_display() {
-	  	if ( ! apply_filters( 'tc_show_breadcrumb' , 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_breadcrumb') ) ) )
+    function czr_fn_breadcrumb_display() {
+	  	if ( ! apply_filters( 'tc_show_breadcrumb' , 1 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_breadcrumb') ) ) )
 	      return;
 
 	  	if ( ! apply_filters( 'tc_show_breadcrumb_in_context' , true ) )
 	      return;
 
-	  	if ( czr__f('__is_home')  && 1 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_breadcrumb_home' ) ) )
+	  	if ( czr_fn__f('__is_home')  && 1 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_breadcrumb_home' ) ) )
 	  		return;
 
 	  	//set the args properties
         $this -> args = $this -> _get_args();
 
 	  	echo apply_filters(
-	  			'czr_breadcrumb_display' ,
+	  			'czr_fn_breadcrumb_display' ,
 				sprintf('<div class="tc-hot-crumble container" role="navigation"><div class="row"><div class="%1$s">%2$s</div></div></div>',
 					apply_filters( 'tc_breadcrumb_class', 'span12' ),
-					$this -> czr_breadcrumb_trail( $this -> args )
+					$this -> czr_fn_breadcrumb_trail( $this -> args )
 				)
 	  	);
     }
@@ -139,13 +139,13 @@ class CZR_breadcrumb {
 	 * @return string Output of the breadcrumb menu.
 	 */
 
-	function czr_breadcrumb_trail( $args = array() ) {
+	function czr_fn_breadcrumb_trail( $args = array() ) {
 
 		/* Create an empty variable for the breadcrumb. */
 		$breadcrumb = '';
 
 		/* Get the trail items. */
-		$trail = apply_filters( 'czr_breadcrumb_trail' , $this -> czr_breadcrumb_trail_get_items( $args ) );
+		$trail = apply_filters( 'czr_fn_breadcrumb_trail' , $this -> czr_fn_breadcrumb_trail_get_items( $args ) );
 
 		/* Connect the breadcrumb trail if there are items in the trail. */
 		if ( !empty( $trail ) && is_array( $trail ) ) {
@@ -198,7 +198,7 @@ class CZR_breadcrumb {
 	 * @param array $args Mixed arguments for the menu.
 	 * @return array List of items to be shown in the trail.
 	 */
-	function czr_breadcrumb_trail_get_items( $args = array() ) {
+	function czr_fn_breadcrumb_trail_get_items( $args = array() ) {
 		global $wp_rewrite;
 
 		/* Set up an empty trail array and empty path. */
@@ -221,11 +221,11 @@ class CZR_breadcrumb {
 
 		/* If bbPress is installed and we're on a bbPress page. */
 		if ( function_exists( 'is_bbpress' ) && is_bbpress() ) {
-			$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_bbpress_items() );
+			$trail = array_merge( $trail, $this -> czr_fn_breadcrumb_trail_get_bbpress_items() );
 		}
 		/* If WooCommerce is installed and we're on a WooCommerce page. */
         elseif ( function_exists( 'is_woocommerce' ) && is_woocommerce() ) {
-			$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_woocommerce_items() );
+			$trail = array_merge( $trail, $this -> czr_fn_breadcrumb_trail_get_woocommerce_items() );
 		}
 		/* If viewing the front page of the site. */
 		elseif ( is_front_page() ) {
@@ -255,7 +255,7 @@ class CZR_breadcrumb {
 		elseif ( is_home() ) {
 			$home_page = get_page( get_queried_object_id() );
 
-			$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( $home_page->post_parent, '' ) );
+			$trail = array_merge( $trail, $this -> czr_fn_breadcrumb_trail_get_parents( $home_page->post_parent, '' ) );
 
 			if ( is_paged() )
 				$trail[]  = '<a href="' . get_permalink( $home_page->ID ) . '" title="' . esc_attr( strip_tags( get_the_title( $home_page->ID ) ) ). '">' . get_the_title( $home_page->ID ) . '</a>';
@@ -283,12 +283,12 @@ class CZR_breadcrumb {
 
 				/* If there's a path, check for parents. */
 				if ( !empty( $path ) && !$page_for_posts )
-					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( '' , $path ) );
+					$trail = array_merge( $trail, $this -> czr_fn_breadcrumb_trail_get_parents( '' , $path ) );
 				else if ( $page_for_posts )
-					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( $page_for_posts , $path ) );
+					$trail = array_merge( $trail, $this -> czr_fn_breadcrumb_trail_get_parents( $page_for_posts , $path ) );
 
 				/* Map the permalink structure tags to actual links. */
-				/*$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_map_rewrite_tags( $post_id, get_option( 'permalink_structure' ), $args ) );*/
+				/*$trail = array_merge( $trail, $this -> czr_fn_breadcrumb_trail_map_rewrite_tags( $post_id, get_option( 'permalink_structure' ), $args ) );*/
 			}
 
 			/* If viewing a singular 'attachment'. */
@@ -311,10 +311,10 @@ class CZR_breadcrumb {
 
 						/* If there's a path, check for parents. */
 						if ( !empty( $path ) )
-							$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( '' , $path ) );
+							$trail = array_merge( $trail, $this -> czr_fn_breadcrumb_trail_get_parents( '' , $path ) );
 
 						/* Map the post (parent) permalink structure tags to actual links. */
-						$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_map_rewrite_tags( $post->post_parent, get_option( 'permalink_structure' ), $args ) );
+						$trail = array_merge( $trail, $this -> czr_fn_breadcrumb_trail_map_rewrite_tags( $post->post_parent, get_option( 'permalink_structure' ), $args ) );
 					}
 
 					/* Custom post types. */
@@ -332,7 +332,7 @@ class CZR_breadcrumb {
 
 						/* If there's a path, check for parents. */
 						if ( !empty( $path ) )
-							$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( '' , $path ) );
+							$trail = array_merge( $trail, $this -> czr_fn_breadcrumb_trail_get_parents( '' , $path ) );
 
 						/* If there's an archive page, add it to the trail. */
 						if ( !empty( $parent_post_type_object->has_archive ) ) {
@@ -359,7 +359,7 @@ class CZR_breadcrumb {
 
 				/* If there's a path, check for parents. */
 				if ( !empty( $path ) )
-					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( '' , $path ) );
+					$trail = array_merge( $trail, $this -> czr_fn_breadcrumb_trail_get_parents( '' , $path ) );
 
 				/* If there's an archive page, add it to the trail. */
 				if ( !empty( $post_type_object->has_archive ) ) {
@@ -373,16 +373,16 @@ class CZR_breadcrumb {
 
 			/* If the post type path returns nothing and there is a parent, get its parents. */
 			if ( ( empty( $path ) && 0 !== $parent ) || ( 'attachment' == $post_type ) )
-				$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( $parent, '' ) );
+				$trail = array_merge( $trail, $this -> czr_fn_breadcrumb_trail_get_parents( $parent, '' ) );
 
 			/* Or, if the post type is hierarchical and there's a parent, get its parents. */
 			elseif ( 0 !== $parent && is_post_type_hierarchical( $post_type ) )
-				$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( $parent, '' ) );
+				$trail = array_merge( $trail, $this -> czr_fn_breadcrumb_trail_get_parents( $parent, '' ) );
 
 			/* Display terms for specific post type taxonomy if requested. */
 			if (  isset($args["singular_breadcrumb_taxonomy"]) && $args["singular_breadcrumb_taxonomy"] )
 				//If post has parent, then don't add the taxonomy trail part
-				$trail 	= ( 1 < count($this -> czr_breadcrumb_trail_get_parents($post_id) ) ) ? $trail : $this -> czr_add_first_term_from_hierarchical_taxinomy( $trail , $post_id );
+				$trail 	= ( 1 < count($this -> czr_fn_breadcrumb_trail_get_parents($post_id) ) ) ? $trail : $this -> czr_fn_add_first_term_from_hierarchical_taxinomy( $trail , $post_id );
 
 			/* End with the post title. */
 			$post_title = single_post_title( '' , false );
@@ -417,9 +417,9 @@ class CZR_breadcrumb {
 
 				/* Get parent pages by path if they exist. */
 				if ( $path && ! $page_for_posts)
-					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( '' , $path ) );
+					$trail = array_merge( $trail, $this -> czr_fn_breadcrumb_trail_get_parents( '' , $path ) );
 				else if ( $page_for_posts && ( is_category() || is_tag() ) )
-					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( $page_for_posts , $path ) );
+					$trail = array_merge( $trail, $this -> czr_fn_breadcrumb_trail_get_parents( $page_for_posts , $path ) );
 
 				/* Add post type archive if its 'has_archive' matches the taxonomy rewrite 'slug'. */
 				if ( $taxonomy->rewrite['slug'] ) {
@@ -453,7 +453,7 @@ class CZR_breadcrumb {
 
 				/* If the taxonomy is hierarchical, list its parent terms. */
 				if ( is_taxonomy_hierarchical( $term->taxonomy ) && $term->parent )
-					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_term_parents( $term->parent, $term->taxonomy ) );
+					$trail = array_merge( $trail, $this -> czr_fn_breadcrumb_trail_get_term_parents( $term->parent, $term->taxonomy ) );
 
 				/* Add the term name to the trail end. */
 				if ( is_paged() )
@@ -478,7 +478,7 @@ class CZR_breadcrumb {
 
 				/* If there's a path, check for parents. */
 				if ( !empty( $path ) )
-					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( '' , $path ) );
+					$trail = array_merge( $trail, $this -> czr_fn_breadcrumb_trail_get_parents( '' , $path ) );
 
 				/* Add the post type [plural] name to the trail end. */
 				if ( is_paged() )
@@ -503,9 +503,9 @@ class CZR_breadcrumb {
 
 				/* If there's a path, check for parents. */
 				if ( !empty( $path ) && !$page_for_posts )
-					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( '' , $path ) );
+					$trail = array_merge( $trail, $this -> czr_fn_breadcrumb_trail_get_parents( '' , $path ) );
 				else if ( $page_for_posts )
-					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( $page_for_posts , $path ) );
+					$trail = array_merge( $trail, $this -> czr_fn_breadcrumb_trail_get_parents( $page_for_posts , $path ) );
 
 				/* Add the author's display name to the trail end. */
 				if ( is_paged() )
@@ -519,9 +519,9 @@ class CZR_breadcrumb {
 
 				/* If there's a path, check for parents. */
 				if ( !empty( $path ) && !$page_for_posts )
-					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( '' , $path ) );
+					$trail = array_merge( $trail, $this -> czr_fn_breadcrumb_trail_get_parents( '' , $path ) );
 				else if ( $page_for_posts )
-					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( $page_for_posts , $path ) );
+					$trail = array_merge( $trail, $this -> czr_fn_breadcrumb_trail_get_parents( $page_for_posts , $path ) );
 
 				if ( get_query_var( 'minute' ) && get_query_var( 'hour' ) )
 					$trail[] = get_the_time( __( 'g:i a' , 'customizr' ) );
@@ -537,13 +537,13 @@ class CZR_breadcrumb {
 			elseif ( is_date() ) {
 				/* If there's a path, check for parents. */
 				if ( !empty( $path ) && !$page_for_posts )
-					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( '' , $path ) );
+					$trail = array_merge( $trail, $this -> czr_fn_breadcrumb_trail_get_parents( '' , $path ) );
 				else if ( $page_for_posts )
-					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( $page_for_posts , $path ) );
+					$trail = array_merge( $trail, $this -> czr_fn_breadcrumb_trail_get_parents( $page_for_posts , $path ) );
 
 				/* If $front has been set, check for parent pages. */
 				if ( $wp_rewrite->front )
-					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( '' , $wp_rewrite->front ) );
+					$trail = array_merge( $trail, $this -> czr_fn_breadcrumb_trail_get_parents( '' , $wp_rewrite->front ) );
 
 				if ( is_day() ) {
 					$trail[] = '<a href="' . get_year_link( get_the_time( 'Y' ) ) . '" title="' . get_the_time( esc_attr__( 'Y' , 'customizr' ) ) . '">' . get_the_time( __( 'Y' , 'customizr' ) ) . '</a>';
@@ -615,7 +615,7 @@ class CZR_breadcrumb {
 	 * @param array $args Mixed arguments for the menu.
 	 * @return array List of items to be shown in the trail.
 	 */
-	function czr_breadcrumb_trail_get_bbpress_items( $args = array() ) {
+	function czr_fn_breadcrumb_trail_get_bbpress_items( $args = array() ) {
 
 		/* Set up a new trail items array. */
 		$trail = array();
@@ -660,7 +660,7 @@ class CZR_breadcrumb {
 			$topic_id = get_queried_object_id();
 
 			/* Get the parent items for the topic, which would be its forum (and possibly forum grandparents). */
-			$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( bbp_get_topic_forum_id( $topic_id ) ) );
+			$trail = array_merge( $trail, $this -> czr_fn_breadcrumb_trail_get_parents( bbp_get_topic_forum_id( $topic_id ) ) );
 
 			/* If viewing a split, merge, or edit topic page, show the link back to the topic.  Else, display topic title. */
 			if ( bbp_is_topic_split() || bbp_is_topic_merge() || bbp_is_topic_edit() )
@@ -688,7 +688,7 @@ class CZR_breadcrumb {
 			$reply_id = get_queried_object_id();
 
 			/* Get the parent items for the reply, which should be its topic. */
-			$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( bbp_get_reply_topic_id( $reply_id ) ) );
+			$trail = array_merge( $trail, $this -> czr_fn_breadcrumb_trail_get_parents( bbp_get_reply_topic_id( $reply_id ) ) );
 
 			/* If viewing a reply edit page, link back to the reply. Else, display the reply title. */
 			if ( bbp_is_reply_edit() ) {
@@ -710,7 +710,7 @@ class CZR_breadcrumb {
 
 			/* If the forum has a parent forum, get its parent(s). */
 			if ( 0 !== $forum_parent_id)
-				$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( $forum_parent_id ) );
+				$trail = array_merge( $trail, $this -> czr_fn_breadcrumb_trail_get_parents( $forum_parent_id ) );
 
 			/* Add the forum title to the end of the trail. */
 			$trail[] = bbp_get_forum_title( $forum_id );
@@ -741,7 +741,7 @@ class CZR_breadcrumb {
 	* @param array $args Mixed arguments for the menu.
 	* @return array List of items to be shown in the trail.
 	*/
-    function czr_breadcrumb_trail_get_woocommerce_items( $args = array() ) {
+    function czr_fn_breadcrumb_trail_get_woocommerce_items( $args = array() ) {
       $trail = array();
 
       if ( ! method_exists( 'WC_Breadcrumb', 'generate' ) )
@@ -788,7 +788,7 @@ class CZR_breadcrumb {
 	 * @param array $args Mixed arguments for the menu.
 	 * @return array $trail Array of links to the post breadcrumb.
 	 */
-	function czr_breadcrumb_trail_map_rewrite_tags( $post_id = '' , $path = '' , $args = array() ) {
+	function czr_fn_breadcrumb_trail_map_rewrite_tags( $post_id = '' , $path = '' , $args = array() ) {
 
 		/* Set up an empty $trail array. */
 		$trail = array();
@@ -838,7 +838,7 @@ class CZR_breadcrumb {
 				/* If using the %category% tag, add a link to the first category archive to match permalinks. */
 				/*elseif ( '%category%' == $tag && isset($args["singular_breadcrumb_taxonomy"]) && $args["singular_breadcrumb_taxonomy"] ) {
 
-					$trail 	= $this -> czr_add_first_term_from_hierarchical_taxinomy( $trail , $post_id );
+					$trail 	= $this -> czr_fn_add_first_term_from_hierarchical_taxinomy( $trail , $post_id );
 				}*/
 			}
 		}
@@ -858,7 +858,7 @@ class CZR_breadcrumb {
 	 * @param string $path Path of a potential parent page.
 	 * @return array $trail Array of parent page links.
 	 */
-	function czr_breadcrumb_trail_get_parents( $post_id = '' , $path = '' ) {
+	function czr_fn_breadcrumb_trail_get_parents( $post_id = '' , $path = '' ) {
 		/* Set up an empty trail array. */
 		$trail = array();
 
@@ -942,7 +942,7 @@ class CZR_breadcrumb {
 		$args				= $this -> args;
 
 		/*if (  isset($args["singular_breadcrumb_taxonomy"]) && $args["singular_breadcrumb_taxonomy"] )
-			$trail 	= $this -> czr_add_first_term_from_hierarchical_taxinomy( $trail , $parent_key );*/
+			$trail 	= $this -> czr_fn_add_first_term_from_hierarchical_taxinomy( $trail , $parent_key );*/
 
 		foreach (array_reverse($parents) as $key => $value)
 			$trail[] = $value;
@@ -963,7 +963,7 @@ class CZR_breadcrumb {
 	 * @param object|string $taxonomy The taxonomy of the term whose parents we want.
 	 * @return array $trail Array of links to parent terms.
 	 */
-	function czr_breadcrumb_trail_get_term_parents( $parent_id = '' , $taxonomy = '' ) {
+	function czr_fn_breadcrumb_trail_get_term_parents( $parent_id = '' , $taxonomy = '' ) {
 
 		/* Set up some default arrays. */
 		$trail = array();
@@ -995,7 +995,7 @@ class CZR_breadcrumb {
 	}
 
 
-	function czr_add_first_term_from_hierarchical_taxinomy( $trail , $post_id ) {
+	function czr_fn_add_first_term_from_hierarchical_taxinomy( $trail , $post_id ) {
 		// get post by post id
 	  	$post = get_post( $post_id );
 
@@ -1029,7 +1029,7 @@ class CZR_breadcrumb {
 
 		// If the taxonomy term has a parent, add the hierarchy to the trail.
 		if ( 0 !== $first_term -> parent )
-			$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_term_parents( $first_term -> parent , $first_hierarchical_tax -> name ) );
+			$trail = array_merge( $trail, $this -> czr_fn_breadcrumb_trail_get_term_parents( $first_term -> parent , $first_hierarchical_tax -> name ) );
 
 		//Add the taxonomy term archive link to the trail.
 		$trail[] = '<a href="' . get_term_link( $first_term,  $first_hierarchical_tax -> name ) . '" title="' . esc_attr( $first_term->name ) . '">' . $first_term->name . '</a>';

--- a/inc/parts/class-content-breadcrumb.php
+++ b/inc/parts/class-content-breadcrumb.php
@@ -98,7 +98,7 @@ class CZR_breadcrumb {
         $this -> args = $this -> _get_args();
 
 	  	echo apply_filters(
-	  			'czr_fn_breadcrumb_display' ,
+	  			'tc_breadcrumb_display' ,
 				sprintf('<div class="tc-hot-crumble container" role="navigation"><div class="row"><div class="%1$s">%2$s</div></div></div>',
 					apply_filters( 'tc_breadcrumb_class', 'span12' ),
 					$this -> czr_fn_breadcrumb_trail( $this -> args )
@@ -145,7 +145,7 @@ class CZR_breadcrumb {
 		$breadcrumb = '';
 
 		/* Get the trail items. */
-		$trail = apply_filters( 'czr_fn_breadcrumb_trail' , $this -> czr_fn_breadcrumb_trail_get_items( $args ) );
+		$trail = apply_filters( 'tc_breadcrumb_trail' , $this -> czr_fn_breadcrumb_trail_get_items( $args ) );
 
 		/* Connect the breadcrumb trail if there are items in the trail. */
 		if ( !empty( $trail ) && is_array( $trail ) ) {

--- a/inc/parts/class-content-breadcrumb.php
+++ b/inc/parts/class-content-breadcrumb.php
@@ -22,9 +22,9 @@ class CZR_breadcrumb {
 
     function __construct () {
         self::$instance =& $this;
-        add_action( '__before_main_container'			, array( $this , 'tc_breadcrumb_display' ), 20 );
+        add_action( '__before_main_container'			, array( $this , 'czr_breadcrumb_display' ), 20 );
         //since v3.2.0, customizer option
-        add_filter( 'tc_show_breadcrumb_in_context' 	, array( $this , 'tc_set_breadcrumb_display_in_context' ) );
+        add_filter( 'tc_show_breadcrumb_in_context' 	, array( $this , 'czr_set_breadcrumb_display_in_context' ) );
     }
 
 
@@ -98,7 +98,7 @@ class CZR_breadcrumb {
         $this -> args = $this -> _get_args();
 
 	  	echo apply_filters(
-	  			'tc_breadcrumb_display' ,
+	  			'czr_breadcrumb_display' ,
 				sprintf('<div class="tc-hot-crumble container" role="navigation"><div class="row"><div class="%1$s">%2$s</div></div></div>',
 					apply_filters( 'tc_breadcrumb_class', 'span12' ),
 					$this -> czr_breadcrumb_trail( $this -> args )
@@ -145,7 +145,7 @@ class CZR_breadcrumb {
 		$breadcrumb = '';
 
 		/* Get the trail items. */
-		$trail = apply_filters( 'tc_breadcrumb_trail' , $this -> czr_breadcrumb_trail_get_items( $args ) );
+		$trail = apply_filters( 'czr_breadcrumb_trail' , $this -> czr_breadcrumb_trail_get_items( $args ) );
 
 		/* Connect the breadcrumb trail if there are items in the trail. */
 		if ( !empty( $trail ) && is_array( $trail ) ) {

--- a/inc/parts/class-content-breadcrumb.php
+++ b/inc/parts/class-content-breadcrumb.php
@@ -65,14 +65,14 @@ class CZR_breadcrumb {
 
 
     function czr_set_breadcrumb_display_in_context( $_bool ) {
-    	if ( tc__f('__is_home') )
-	  		return 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_breadcrumb_home' ) ) ? false : true;
+    	if ( czr__f('__is_home') )
+	  		return 1 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_breadcrumb_home' ) ) ? false : true;
 	  	else {
-		  	if ( is_page() && 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_breadcrumb_in_pages' ) ) )
+		  	if ( is_page() && 1 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_breadcrumb_in_pages' ) ) )
 		  		return false;
-		  	if ( is_single() && 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_breadcrumb_in_single_posts' ) ) )
+		  	if ( is_single() && 1 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_breadcrumb_in_single_posts' ) ) )
 		  		return false;
-		  	if ( ! is_page() && ! is_single() && 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_breadcrumb_in_post_lists' ) ) )
+		  	if ( ! is_page() && ! is_single() && 1 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_breadcrumb_in_post_lists' ) ) )
 		  		return false;
 		}
 		return $_bool;
@@ -85,13 +85,13 @@ class CZR_breadcrumb {
     * @since Customizr 1.0
     */
     function czr_breadcrumb_display() {
-	  	if ( ! apply_filters( 'tc_show_breadcrumb' , 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_breadcrumb') ) ) )
+	  	if ( ! apply_filters( 'tc_show_breadcrumb' , 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_breadcrumb') ) ) )
 	      return;
 
 	  	if ( ! apply_filters( 'tc_show_breadcrumb_in_context' , true ) )
 	      return;
 
-	  	if ( tc__f('__is_home')  && 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_breadcrumb_home' ) ) )
+	  	if ( czr__f('__is_home')  && 1 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_breadcrumb_home' ) ) )
 	  		return;
 
 	  	//set the args properties
@@ -101,7 +101,7 @@ class CZR_breadcrumb {
 	  			'tc_breadcrumb_display' ,
 				sprintf('<div class="tc-hot-crumble container" role="navigation"><div class="row"><div class="%1$s">%2$s</div></div></div>',
 					apply_filters( 'tc_breadcrumb_class', 'span12' ),
-					$this -> tc_breadcrumb_trail( $this -> args )
+					$this -> czr_breadcrumb_trail( $this -> args )
 				)
 	  	);
     }
@@ -145,7 +145,7 @@ class CZR_breadcrumb {
 		$breadcrumb = '';
 
 		/* Get the trail items. */
-		$trail = apply_filters( 'tc_breadcrumb_trail' , $this -> tc_breadcrumb_trail_get_items( $args ) );
+		$trail = apply_filters( 'tc_breadcrumb_trail' , $this -> czr_breadcrumb_trail_get_items( $args ) );
 
 		/* Connect the breadcrumb trail if there are items in the trail. */
 		if ( !empty( $trail ) && is_array( $trail ) ) {
@@ -221,11 +221,11 @@ class CZR_breadcrumb {
 
 		/* If bbPress is installed and we're on a bbPress page. */
 		if ( function_exists( 'is_bbpress' ) && is_bbpress() ) {
-			$trail = array_merge( $trail, $this -> tc_breadcrumb_trail_get_bbpress_items() );
+			$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_bbpress_items() );
 		}
 		/* If WooCommerce is installed and we're on a WooCommerce page. */
         elseif ( function_exists( 'is_woocommerce' ) && is_woocommerce() ) {
-			$trail = array_merge( $trail, $this -> tc_breadcrumb_trail_get_woocommerce_items() );
+			$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_woocommerce_items() );
 		}
 		/* If viewing the front page of the site. */
 		elseif ( is_front_page() ) {
@@ -255,7 +255,7 @@ class CZR_breadcrumb {
 		elseif ( is_home() ) {
 			$home_page = get_page( get_queried_object_id() );
 
-			$trail = array_merge( $trail, $this -> tc_breadcrumb_trail_get_parents( $home_page->post_parent, '' ) );
+			$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( $home_page->post_parent, '' ) );
 
 			if ( is_paged() )
 				$trail[]  = '<a href="' . get_permalink( $home_page->ID ) . '" title="' . esc_attr( strip_tags( get_the_title( $home_page->ID ) ) ). '">' . get_the_title( $home_page->ID ) . '</a>';
@@ -283,12 +283,12 @@ class CZR_breadcrumb {
 
 				/* If there's a path, check for parents. */
 				if ( !empty( $path ) && !$page_for_posts )
-					$trail = array_merge( $trail, $this -> tc_breadcrumb_trail_get_parents( '' , $path ) );
+					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( '' , $path ) );
 				else if ( $page_for_posts )
-					$trail = array_merge( $trail, $this -> tc_breadcrumb_trail_get_parents( $page_for_posts , $path ) );
+					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( $page_for_posts , $path ) );
 
 				/* Map the permalink structure tags to actual links. */
-				/*$trail = array_merge( $trail, $this -> tc_breadcrumb_trail_map_rewrite_tags( $post_id, get_option( 'permalink_structure' ), $args ) );*/
+				/*$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_map_rewrite_tags( $post_id, get_option( 'permalink_structure' ), $args ) );*/
 			}
 
 			/* If viewing a singular 'attachment'. */
@@ -311,10 +311,10 @@ class CZR_breadcrumb {
 
 						/* If there's a path, check for parents. */
 						if ( !empty( $path ) )
-							$trail = array_merge( $trail, $this -> tc_breadcrumb_trail_get_parents( '' , $path ) );
+							$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( '' , $path ) );
 
 						/* Map the post (parent) permalink structure tags to actual links. */
-						$trail = array_merge( $trail, $this -> tc_breadcrumb_trail_map_rewrite_tags( $post->post_parent, get_option( 'permalink_structure' ), $args ) );
+						$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_map_rewrite_tags( $post->post_parent, get_option( 'permalink_structure' ), $args ) );
 					}
 
 					/* Custom post types. */
@@ -332,7 +332,7 @@ class CZR_breadcrumb {
 
 						/* If there's a path, check for parents. */
 						if ( !empty( $path ) )
-							$trail = array_merge( $trail, $this -> tc_breadcrumb_trail_get_parents( '' , $path ) );
+							$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( '' , $path ) );
 
 						/* If there's an archive page, add it to the trail. */
 						if ( !empty( $parent_post_type_object->has_archive ) ) {
@@ -359,7 +359,7 @@ class CZR_breadcrumb {
 
 				/* If there's a path, check for parents. */
 				if ( !empty( $path ) )
-					$trail = array_merge( $trail, $this -> tc_breadcrumb_trail_get_parents( '' , $path ) );
+					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( '' , $path ) );
 
 				/* If there's an archive page, add it to the trail. */
 				if ( !empty( $post_type_object->has_archive ) ) {
@@ -373,16 +373,16 @@ class CZR_breadcrumb {
 
 			/* If the post type path returns nothing and there is a parent, get its parents. */
 			if ( ( empty( $path ) && 0 !== $parent ) || ( 'attachment' == $post_type ) )
-				$trail = array_merge( $trail, $this -> tc_breadcrumb_trail_get_parents( $parent, '' ) );
+				$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( $parent, '' ) );
 
 			/* Or, if the post type is hierarchical and there's a parent, get its parents. */
 			elseif ( 0 !== $parent && is_post_type_hierarchical( $post_type ) )
-				$trail = array_merge( $trail, $this -> tc_breadcrumb_trail_get_parents( $parent, '' ) );
+				$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( $parent, '' ) );
 
 			/* Display terms for specific post type taxonomy if requested. */
 			if (  isset($args["singular_breadcrumb_taxonomy"]) && $args["singular_breadcrumb_taxonomy"] )
 				//If post has parent, then don't add the taxonomy trail part
-				$trail 	= ( 1 < count($this -> tc_breadcrumb_trail_get_parents($post_id) ) ) ? $trail : $this -> tc_add_first_term_from_hierarchical_taxinomy( $trail , $post_id );
+				$trail 	= ( 1 < count($this -> czr_breadcrumb_trail_get_parents($post_id) ) ) ? $trail : $this -> czr_add_first_term_from_hierarchical_taxinomy( $trail , $post_id );
 
 			/* End with the post title. */
 			$post_title = single_post_title( '' , false );
@@ -417,9 +417,9 @@ class CZR_breadcrumb {
 
 				/* Get parent pages by path if they exist. */
 				if ( $path && ! $page_for_posts)
-					$trail = array_merge( $trail, $this -> tc_breadcrumb_trail_get_parents( '' , $path ) );
+					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( '' , $path ) );
 				else if ( $page_for_posts && ( is_category() || is_tag() ) )
-					$trail = array_merge( $trail, $this -> tc_breadcrumb_trail_get_parents( $page_for_posts , $path ) );
+					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( $page_for_posts , $path ) );
 
 				/* Add post type archive if its 'has_archive' matches the taxonomy rewrite 'slug'. */
 				if ( $taxonomy->rewrite['slug'] ) {
@@ -453,7 +453,7 @@ class CZR_breadcrumb {
 
 				/* If the taxonomy is hierarchical, list its parent terms. */
 				if ( is_taxonomy_hierarchical( $term->taxonomy ) && $term->parent )
-					$trail = array_merge( $trail, $this -> tc_breadcrumb_trail_get_term_parents( $term->parent, $term->taxonomy ) );
+					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_term_parents( $term->parent, $term->taxonomy ) );
 
 				/* Add the term name to the trail end. */
 				if ( is_paged() )
@@ -478,7 +478,7 @@ class CZR_breadcrumb {
 
 				/* If there's a path, check for parents. */
 				if ( !empty( $path ) )
-					$trail = array_merge( $trail, $this -> tc_breadcrumb_trail_get_parents( '' , $path ) );
+					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( '' , $path ) );
 
 				/* Add the post type [plural] name to the trail end. */
 				if ( is_paged() )
@@ -503,9 +503,9 @@ class CZR_breadcrumb {
 
 				/* If there's a path, check for parents. */
 				if ( !empty( $path ) && !$page_for_posts )
-					$trail = array_merge( $trail, $this -> tc_breadcrumb_trail_get_parents( '' , $path ) );
+					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( '' , $path ) );
 				else if ( $page_for_posts )
-					$trail = array_merge( $trail, $this -> tc_breadcrumb_trail_get_parents( $page_for_posts , $path ) );
+					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( $page_for_posts , $path ) );
 
 				/* Add the author's display name to the trail end. */
 				if ( is_paged() )
@@ -519,9 +519,9 @@ class CZR_breadcrumb {
 
 				/* If there's a path, check for parents. */
 				if ( !empty( $path ) && !$page_for_posts )
-					$trail = array_merge( $trail, $this -> tc_breadcrumb_trail_get_parents( '' , $path ) );
+					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( '' , $path ) );
 				else if ( $page_for_posts )
-					$trail = array_merge( $trail, $this -> tc_breadcrumb_trail_get_parents( $page_for_posts , $path ) );
+					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( $page_for_posts , $path ) );
 
 				if ( get_query_var( 'minute' ) && get_query_var( 'hour' ) )
 					$trail[] = get_the_time( __( 'g:i a' , 'customizr' ) );
@@ -537,13 +537,13 @@ class CZR_breadcrumb {
 			elseif ( is_date() ) {
 				/* If there's a path, check for parents. */
 				if ( !empty( $path ) && !$page_for_posts )
-					$trail = array_merge( $trail, $this -> tc_breadcrumb_trail_get_parents( '' , $path ) );
+					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( '' , $path ) );
 				else if ( $page_for_posts )
-					$trail = array_merge( $trail, $this -> tc_breadcrumb_trail_get_parents( $page_for_posts , $path ) );
+					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( $page_for_posts , $path ) );
 
 				/* If $front has been set, check for parent pages. */
 				if ( $wp_rewrite->front )
-					$trail = array_merge( $trail, $this -> tc_breadcrumb_trail_get_parents( '' , $wp_rewrite->front ) );
+					$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( '' , $wp_rewrite->front ) );
 
 				if ( is_day() ) {
 					$trail[] = '<a href="' . get_year_link( get_the_time( 'Y' ) ) . '" title="' . get_the_time( esc_attr__( 'Y' , 'customizr' ) ) . '">' . get_the_time( __( 'Y' , 'customizr' ) ) . '</a>';
@@ -660,7 +660,7 @@ class CZR_breadcrumb {
 			$topic_id = get_queried_object_id();
 
 			/* Get the parent items for the topic, which would be its forum (and possibly forum grandparents). */
-			$trail = array_merge( $trail, $this -> tc_breadcrumb_trail_get_parents( bbp_get_topic_forum_id( $topic_id ) ) );
+			$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( bbp_get_topic_forum_id( $topic_id ) ) );
 
 			/* If viewing a split, merge, or edit topic page, show the link back to the topic.  Else, display topic title. */
 			if ( bbp_is_topic_split() || bbp_is_topic_merge() || bbp_is_topic_edit() )
@@ -688,7 +688,7 @@ class CZR_breadcrumb {
 			$reply_id = get_queried_object_id();
 
 			/* Get the parent items for the reply, which should be its topic. */
-			$trail = array_merge( $trail, $this -> tc_breadcrumb_trail_get_parents( bbp_get_reply_topic_id( $reply_id ) ) );
+			$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( bbp_get_reply_topic_id( $reply_id ) ) );
 
 			/* If viewing a reply edit page, link back to the reply. Else, display the reply title. */
 			if ( bbp_is_reply_edit() ) {
@@ -710,7 +710,7 @@ class CZR_breadcrumb {
 
 			/* If the forum has a parent forum, get its parent(s). */
 			if ( 0 !== $forum_parent_id)
-				$trail = array_merge( $trail, $this -> tc_breadcrumb_trail_get_parents( $forum_parent_id ) );
+				$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_parents( $forum_parent_id ) );
 
 			/* Add the forum title to the end of the trail. */
 			$trail[] = bbp_get_forum_title( $forum_id );
@@ -838,7 +838,7 @@ class CZR_breadcrumb {
 				/* If using the %category% tag, add a link to the first category archive to match permalinks. */
 				/*elseif ( '%category%' == $tag && isset($args["singular_breadcrumb_taxonomy"]) && $args["singular_breadcrumb_taxonomy"] ) {
 
-					$trail 	= $this -> tc_add_first_term_from_hierarchical_taxinomy( $trail , $post_id );
+					$trail 	= $this -> czr_add_first_term_from_hierarchical_taxinomy( $trail , $post_id );
 				}*/
 			}
 		}
@@ -942,7 +942,7 @@ class CZR_breadcrumb {
 		$args				= $this -> args;
 
 		/*if (  isset($args["singular_breadcrumb_taxonomy"]) && $args["singular_breadcrumb_taxonomy"] )
-			$trail 	= $this -> tc_add_first_term_from_hierarchical_taxinomy( $trail , $parent_key );*/
+			$trail 	= $this -> czr_add_first_term_from_hierarchical_taxinomy( $trail , $parent_key );*/
 
 		foreach (array_reverse($parents) as $key => $value)
 			$trail[] = $value;
@@ -1029,7 +1029,7 @@ class CZR_breadcrumb {
 
 		// If the taxonomy term has a parent, add the hierarchy to the trail.
 		if ( 0 !== $first_term -> parent )
-			$trail = array_merge( $trail, $this -> tc_breadcrumb_trail_get_term_parents( $first_term -> parent , $first_hierarchical_tax -> name ) );
+			$trail = array_merge( $trail, $this -> czr_breadcrumb_trail_get_term_parents( $first_term -> parent , $first_hierarchical_tax -> name ) );
 
 		//Add the taxonomy term archive link to the trail.
 		$trail[] = '<a href="' . get_term_link( $first_term,  $first_hierarchical_tax -> name ) . '" title="' . esc_attr( $first_term->name ) . '">' . $first_term->name . '</a>';

--- a/inc/parts/class-content-breadcrumb.php
+++ b/inc/parts/class-content-breadcrumb.php
@@ -14,7 +14,7 @@
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 
-class TC_breadcrumb {
+class CZR_breadcrumb {
 
     //Access any method or var of the class with classname::$instance -> var or method():
     static $instance;
@@ -66,13 +66,13 @@ class TC_breadcrumb {
 
     function tc_set_breadcrumb_display_in_context( $_bool ) {
     	if ( tc__f('__is_home') )
-	  		return 1 != esc_attr( TC_utils::$inst->tc_opt( 'tc_show_breadcrumb_home' ) ) ? false : true;
+	  		return 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_breadcrumb_home' ) ) ? false : true;
 	  	else {
-		  	if ( is_page() && 1 != esc_attr( TC_utils::$inst->tc_opt( 'tc_show_breadcrumb_in_pages' ) ) )
+		  	if ( is_page() && 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_breadcrumb_in_pages' ) ) )
 		  		return false;
-		  	if ( is_single() && 1 != esc_attr( TC_utils::$inst->tc_opt( 'tc_show_breadcrumb_in_single_posts' ) ) )
+		  	if ( is_single() && 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_breadcrumb_in_single_posts' ) ) )
 		  		return false;
-		  	if ( ! is_page() && ! is_single() && 1 != esc_attr( TC_utils::$inst->tc_opt( 'tc_show_breadcrumb_in_post_lists' ) ) )
+		  	if ( ! is_page() && ! is_single() && 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_breadcrumb_in_post_lists' ) ) )
 		  		return false;
 		}
 		return $_bool;
@@ -85,13 +85,13 @@ class TC_breadcrumb {
     * @since Customizr 1.0
     */
     function tc_breadcrumb_display() {
-	  	if ( ! apply_filters( 'tc_show_breadcrumb' , 1 == esc_attr( TC_utils::$inst->tc_opt( 'tc_breadcrumb') ) ) )
+	  	if ( ! apply_filters( 'tc_show_breadcrumb' , 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_breadcrumb') ) ) )
 	      return;
 
 	  	if ( ! apply_filters( 'tc_show_breadcrumb_in_context' , true ) )
 	      return;
 
-	  	if ( tc__f('__is_home')  && 1 != esc_attr( TC_utils::$inst->tc_opt( 'tc_show_breadcrumb_home' ) ) )
+	  	if ( tc__f('__is_home')  && 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_breadcrumb_home' ) ) )
 	  		return;
 
 	  	//set the args properties

--- a/inc/parts/class-content-breadcrumb.php
+++ b/inc/parts/class-content-breadcrumb.php
@@ -64,7 +64,7 @@ class CZR_breadcrumb {
 
 
 
-    function tc_set_breadcrumb_display_in_context( $_bool ) {
+    function czr_set_breadcrumb_display_in_context( $_bool ) {
     	if ( tc__f('__is_home') )
 	  		return 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_breadcrumb_home' ) ) ? false : true;
 	  	else {
@@ -84,7 +84,7 @@ class CZR_breadcrumb {
     * @package Customizr
     * @since Customizr 1.0
     */
-    function tc_breadcrumb_display() {
+    function czr_breadcrumb_display() {
 	  	if ( ! apply_filters( 'tc_show_breadcrumb' , 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_breadcrumb') ) ) )
 	      return;
 
@@ -139,7 +139,7 @@ class CZR_breadcrumb {
 	 * @return string Output of the breadcrumb menu.
 	 */
 
-	function tc_breadcrumb_trail( $args = array() ) {
+	function czr_breadcrumb_trail( $args = array() ) {
 
 		/* Create an empty variable for the breadcrumb. */
 		$breadcrumb = '';
@@ -198,7 +198,7 @@ class CZR_breadcrumb {
 	 * @param array $args Mixed arguments for the menu.
 	 * @return array List of items to be shown in the trail.
 	 */
-	function tc_breadcrumb_trail_get_items( $args = array() ) {
+	function czr_breadcrumb_trail_get_items( $args = array() ) {
 		global $wp_rewrite;
 
 		/* Set up an empty trail array and empty path. */
@@ -615,7 +615,7 @@ class CZR_breadcrumb {
 	 * @param array $args Mixed arguments for the menu.
 	 * @return array List of items to be shown in the trail.
 	 */
-	function tc_breadcrumb_trail_get_bbpress_items( $args = array() ) {
+	function czr_breadcrumb_trail_get_bbpress_items( $args = array() ) {
 
 		/* Set up a new trail items array. */
 		$trail = array();
@@ -741,7 +741,7 @@ class CZR_breadcrumb {
 	* @param array $args Mixed arguments for the menu.
 	* @return array List of items to be shown in the trail.
 	*/
-    function tc_breadcrumb_trail_get_woocommerce_items( $args = array() ) {
+    function czr_breadcrumb_trail_get_woocommerce_items( $args = array() ) {
       $trail = array();
 
       if ( ! method_exists( 'WC_Breadcrumb', 'generate' ) )
@@ -788,7 +788,7 @@ class CZR_breadcrumb {
 	 * @param array $args Mixed arguments for the menu.
 	 * @return array $trail Array of links to the post breadcrumb.
 	 */
-	function tc_breadcrumb_trail_map_rewrite_tags( $post_id = '' , $path = '' , $args = array() ) {
+	function czr_breadcrumb_trail_map_rewrite_tags( $post_id = '' , $path = '' , $args = array() ) {
 
 		/* Set up an empty $trail array. */
 		$trail = array();
@@ -858,7 +858,7 @@ class CZR_breadcrumb {
 	 * @param string $path Path of a potential parent page.
 	 * @return array $trail Array of parent page links.
 	 */
-	function tc_breadcrumb_trail_get_parents( $post_id = '' , $path = '' ) {
+	function czr_breadcrumb_trail_get_parents( $post_id = '' , $path = '' ) {
 		/* Set up an empty trail array. */
 		$trail = array();
 
@@ -963,7 +963,7 @@ class CZR_breadcrumb {
 	 * @param object|string $taxonomy The taxonomy of the term whose parents we want.
 	 * @return array $trail Array of links to parent terms.
 	 */
-	function tc_breadcrumb_trail_get_term_parents( $parent_id = '' , $taxonomy = '' ) {
+	function czr_breadcrumb_trail_get_term_parents( $parent_id = '' , $taxonomy = '' ) {
 
 		/* Set up some default arrays. */
 		$trail = array();
@@ -995,7 +995,7 @@ class CZR_breadcrumb {
 	}
 
 
-	function tc_add_first_term_from_hierarchical_taxinomy( $trail , $post_id ) {
+	function czr_add_first_term_from_hierarchical_taxinomy( $trail , $post_id ) {
 		// get post by post id
 	  	$post = get_post( $post_id );
 

--- a/inc/parts/class-content-comments.php
+++ b/inc/parts/class-content-comments.php
@@ -37,7 +37,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
       * @package Customizr
       * @since Customizr 3.3.2
       */
-      function tc_comments_set_hooks() {
+      function czr_comments_set_hooks() {
         //Maybe fires the comment's template
         add_action ( '__after_loop'           , array( $this , 'tc_comments' ), 10 );
 
@@ -70,7 +70,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
       * @package Customizr
       * @since Customizr 3.0.10
      */
-      function tc_comments() {
+      function czr_comments() {
         if ( ! $this -> tc_are_comments_enabled() )
           return;
         do_action('tc_before_comments_template');
@@ -88,7 +88,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
         * @package Customizr
         * @since Customizr 3.0
        */
-        function tc_comment_title() {
+        function czr_comment_title() {
           if ( 1 == get_comments_number() ) {
             $_title = __( 'One thought on', 'customizr' );
           } else {
@@ -111,7 +111,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
         * @package Customizr
         * @since Customizr 3.0
        */
-        function tc_comment_list() {
+        function czr_comment_list() {
           $_args = apply_filters( 'tc_list_comments_args' , array( 'callback' => array ( $this , 'tc_comment_callback' ) , 'style' => 'ul' ) );
           ob_start();
             ?>
@@ -136,7 +136,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
         * @package Customizr
         * @since Customizr 1.0
         */
-       function tc_comment_callback( $comment, $args, $depth ) {
+       function czr_comment_callback( $comment, $args, $depth ) {
 
         $GLOBALS['comment'] = $comment;
         //get user defined max comment depth
@@ -234,7 +234,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
     * @package Customizr
     * @since Customizr 3.0
    */
-    function tc_comment_navigation () {
+    function czr_comment_navigation () {
       if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) : // are there comments to navigate through
 
         ob_start();
@@ -280,7 +280,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
     * @package Customizr
     * @since Customizr 3.0
     */
-    function tc_comment_close() {
+    function czr_comment_close() {
       /* If there are no comments and comments are closed, let's leave a note.
        * But we only want the note on posts and pages that had comments in the first place.
        */
@@ -309,7 +309,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    function tc_set_comment_list_display() {
+    function czr_set_comment_list_display() {
       return (bool) esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_comment_list' ) );
     }
 
@@ -321,7 +321,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
     * @package Customizr
     * @since Customizr 3.2.0
     */
-    function tc_set_comment_title($_defaults) {
+    function czr_set_comment_title($_defaults) {
       $_defaults['title_reply'] =  __( 'Leave a comment' , 'customizr' );
       return $_defaults;
     }
@@ -335,7 +335,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
     * @package Customizr
     * @since Customizr 3.2.6
     */
-    function tc_display_comment_bubble( $_title = null ) {
+    function czr_display_comment_bubble( $_title = null ) {
       if ( ! $this -> tc_is_bubble_enabled() )
         return $_title;
 
@@ -360,7 +360,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
     * @package Customizr
     * @since Customizr 3.2.6
     */
-    function tc_custom_bubble_comment( $_html , $_opt ) {
+    function czr_custom_bubble_comment( $_html , $_opt ) {
       return sprintf('%4$s<span class="tc-comment-bubble %1$s">%2$s %3$s</span>',
         'default' == $_opt ? "default-bubble" : $_opt,
         get_comments_number(),
@@ -379,7 +379,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
     * @package Customizr
     * @since Customizr 3.3.2
     */
-    function tc_comment_bubble_inline_css( $_css ) {
+    function czr_comment_bubble_inline_css( $_css ) {
       if ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_comment_show_bubble' ) ) )
         return $_css;
 
@@ -456,7 +456,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    private function tc_are_comments_enabled() {
+    private function czr_are_comments_enabled() {
       global $post;
       // 1) By default not displayed on home, for protected posts, and if no comments for page option is checked
       if ( isset( $post ) ) {
@@ -495,7 +495,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    private function tc_is_bubble_enabled() {
+    private function czr_is_bubble_enabled() {
       $_bool_arr = array(
         in_the_loop(),
         (bool) esc_attr( CZR_utils::$inst->tc_opt( 'tc_comment_show_bubble' ) ),

--- a/inc/parts/class-content-comments.php
+++ b/inc/parts/class-content-comments.php
@@ -17,13 +17,13 @@ if ( ! class_exists( 'CZR_comments' ) ) :
       function __construct () {
         self::$instance =& $this;
         //wp hook => wp_query is built
-        add_action ( 'wp'                     , array( $this , 'czr_comments_set_hooks' ) );
+        add_action ( 'wp'                     , array( $this , 'czr_fn_comments_set_hooks' ) );
 
         //! tc_user_options_style filter is shared by several classes => must always check the local context inside the callback before appending new css
         //fired on hook : wp_enqueue_scripts
         //Set thumbnail specific design based on user options
         //Set user defined various inline stylings
-        add_filter( 'tc_user_options_style'   , array( $this , 'czr_comment_bubble_inline_css' ) );
+        add_filter( 'tc_user_options_style'   , array( $this , 'czr_fn_comment_bubble_inline_css' ) );
       }
 
 
@@ -37,25 +37,25 @@ if ( ! class_exists( 'CZR_comments' ) ) :
       * @package Customizr
       * @since Customizr 3.3.2
       */
-      function czr_comments_set_hooks() {
+      function czr_fn_comments_set_hooks() {
         //Maybe fires the comment's template
-        add_action ( '__after_loop'           , array( $this , 'czr_comments' ), 10 );
+        add_action ( '__after_loop'           , array( $this , 'czr_fn_comments' ), 10 );
 
         //Apply a filter on the comment list ( comment list user defined option )
         //the filter tc_display_comment_list is fired in the comments.php template
-        add_filter( 'tc_display_comment_list' , array( $this , 'czr_set_comment_list_display' ) );
+        add_filter( 'tc_display_comment_list' , array( $this , 'czr_fn_set_comment_list_display' ) );
 
         //Add actions in the comment's template
-        add_action ( '__comment'              , array( $this , 'czr_comment_title' ), 10 );
-        add_action ( '__comment'              , array( $this , 'czr_comment_list' ), 20 );
-        add_action ( '__comment'              , array( $this , 'czr_comment_navigation' ), 30 );
-        add_action ( '__comment'              , array( $this , 'czr_comment_close' ), 40 );
-        add_filter ( 'comment_form_defaults'  , array( $this , 'czr_set_comment_title') );
+        add_action ( '__comment'              , array( $this , 'czr_fn_comment_title' ), 10 );
+        add_action ( '__comment'              , array( $this , 'czr_fn_comment_list' ), 20 );
+        add_action ( '__comment'              , array( $this , 'czr_fn_comment_navigation' ), 30 );
+        add_action ( '__comment'              , array( $this , 'czr_fn_comment_close' ), 40 );
+        add_filter ( 'comment_form_defaults'  , array( $this , 'czr_fn_set_comment_title') );
 
         //Add comment bubble
-        add_filter( 'tc_the_title'            , array( $this , 'czr_display_comment_bubble' ), 1 );
+        add_filter( 'tc_the_title'            , array( $this , 'czr_fn_display_comment_bubble' ), 1 );
         //Custom Bubble comment since 3.2.6
-        add_filter( 'tc_bubble_comment'       , array( $this , 'czr_custom_bubble_comment'), 10, 2 );
+        add_filter( 'tc_bubble_comment'       , array( $this , 'czr_fn_custom_bubble_comment'), 10, 2 );
       }
 
 
@@ -70,8 +70,8 @@ if ( ! class_exists( 'CZR_comments' ) ) :
       * @package Customizr
       * @since Customizr 3.0.10
      */
-      function czr_comments() {
-        if ( ! $this -> czr_are_comments_enabled() )
+      function czr_fn_comments() {
+        if ( ! $this -> czr_fn_are_comments_enabled() )
           return;
         do_action('tc_before_comments_template');
           comments_template( '' , true );
@@ -88,14 +88,14 @@ if ( ! class_exists( 'CZR_comments' ) ) :
         * @package Customizr
         * @since Customizr 3.0
        */
-        function czr_comment_title() {
+        function czr_fn_comment_title() {
           if ( 1 == get_comments_number() ) {
             $_title = __( 'One thought on', 'customizr' );
           } else {
             $_title = sprintf( '%1$s %2$s', number_format_i18n( get_comments_number(), 'customizr' ) , __( 'thoughts on', 'customizr' ) );
           }
 
-          echo apply_filters( 'czr_comment_title' ,
+          echo apply_filters( 'czr_fn_comment_title' ,
                 sprintf( '<h2 id="tc-comment-title" class="comments-title">%1$s &ldquo;%2$s&rdquo;</h2>' ,
                   $_title,
                   '<span>' . get_the_title() . '</span>'
@@ -111,8 +111,8 @@ if ( ! class_exists( 'CZR_comments' ) ) :
         * @package Customizr
         * @since Customizr 3.0
        */
-        function czr_comment_list() {
-          $_args = apply_filters( 'tc_list_comments_args' , array( 'callback' => array ( $this , 'czr_comment_callback' ) , 'style' => 'ul' ) );
+        function czr_fn_comment_list() {
+          $_args = apply_filters( 'tc_list_comments_args' , array( 'callback' => array ( $this , 'czr_fn_comment_callback' ) , 'style' => 'ul' ) );
           ob_start();
             ?>
               <ul class="commentlist">
@@ -121,7 +121,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
             <?php
           $html = ob_get_contents();
           if ($html) ob_end_clean();
-          echo apply_filters( 'czr_comment_list' , $html );
+          echo apply_filters( 'czr_fn_comment_list' , $html );
         }
 
 
@@ -136,7 +136,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
         * @package Customizr
         * @since Customizr 1.0
         */
-       function czr_comment_callback( $comment, $args, $depth ) {
+       function czr_fn_comment_callback( $comment, $args, $depth ) {
 
         $GLOBALS['comment'] = $comment;
         //get user defined max comment depth
@@ -153,7 +153,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
         <li <?php comment_class(); ?> id="comment-<?php comment_ID(); ?>">
           <article id="comment-<?php comment_ID(); ?>" class="comment">
             <p><?php _e( 'Pingback:' , 'customizr' ); ?> <?php comment_author_link(); ?>
-                <?php if ( ! CZR___::$instance -> czr_is_customizing() )  edit_comment_link( __( '(Edit)' , 'customizr' ), '<span class="edit-link btn btn-success btn-mini">' , '</span>' ); ?>
+                <?php if ( ! CZR___::$instance -> czr_fn_is_customizing() )  edit_comment_link( __( '(Edit)' , 'customizr' ), '<span class="edit-link btn btn-success btn-mini">' , '</span>' ); ?>
             </p>
           </article>
         <?php
@@ -195,7 +195,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
                             get_comment_author_link(),
                             // If current post author is also comment author, make it known visually.
                             ( $comment->user_id === $post->post_author ) ? '<span> ' . __( 'Post author' , 'customizr' ) . '</span>' : '' ,
-                            ! CZR___::$instance -> czr_is_customizing() && current_user_can( 'edit_comment', $comment->comment_ID ) ? '<p class="edit-link btn btn-success btn-mini"><a class="comment-edit-link" href="' . get_edit_comment_link( $comment->comment_ID ) . '">' . __( 'Edit' , 'customizr' ) . '</a></p>' : ''
+                            ! CZR___::$instance -> czr_fn_is_customizing() && current_user_can( 'edit_comment', $comment->comment_ID ) ? '<p class="edit-link btn btn-success btn-mini"><a class="comment-edit-link" href="' . get_edit_comment_link( $comment->comment_ID ) . '">' . __( 'Edit' , 'customizr' ) . '</a></p>' : ''
                         ),
                         sprintf( '<a class="comment-date" href="%1$s"><time datetime="%2$s">%3$s</time></a>' ,
                             esc_url( get_comment_link( $comment->comment_ID ) ),
@@ -222,7 +222,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
 
         $html = ob_get_contents();
         if ($html) ob_end_clean();
-        echo apply_filters( 'czr_comment_callback' , $html, $comment, $args, $depth, $max_comments_depth );
+        echo apply_filters( 'czr_fn_comment_callback' , $html, $comment, $args, $depth, $max_comments_depth );
       }
 
 
@@ -234,7 +234,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
     * @package Customizr
     * @since Customizr 3.0
    */
-    function czr_comment_navigation () {
+    function czr_fn_comment_navigation () {
       if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) : // are there comments to navigate through
 
         ob_start();
@@ -266,7 +266,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
 
         $html = ob_get_contents();
         ob_end_clean();
-        echo apply_filters( 'czr_comment_navigation' , $html );
+        echo apply_filters( 'czr_fn_comment_navigation' , $html );
 
       endif; // check for comment navigation
 
@@ -280,12 +280,12 @@ if ( ! class_exists( 'CZR_comments' ) ) :
     * @package Customizr
     * @since Customizr 3.0
     */
-    function czr_comment_close() {
+    function czr_fn_comment_close() {
       /* If there are no comments and comments are closed, let's leave a note.
        * But we only want the note on posts and pages that had comments in the first place.
        */
       if ( ! comments_open() && get_comments_number() ) :
-        echo apply_filters( 'czr_comment_close' ,
+        echo apply_filters( 'czr_fn_comment_close' ,
           sprintf('<p class="nocomments">%1$s</p>',
             __( 'Comments are closed.' , 'customizr' )
           )
@@ -309,8 +309,8 @@ if ( ! class_exists( 'CZR_comments' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    function czr_set_comment_list_display() {
-      return (bool) esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_comment_list' ) );
+    function czr_fn_set_comment_list_display() {
+      return (bool) esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_comment_list' ) );
     }
 
 
@@ -321,7 +321,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
     * @package Customizr
     * @since Customizr 3.2.0
     */
-    function czr_set_comment_title($_defaults) {
+    function czr_fn_set_comment_title($_defaults) {
       $_defaults['title_reply'] =  __( 'Leave a comment' , 'customizr' );
       return $_defaults;
     }
@@ -335,8 +335,8 @@ if ( ! class_exists( 'CZR_comments' ) ) :
     * @package Customizr
     * @since Customizr 3.2.6
     */
-    function czr_display_comment_bubble( $_title = null ) {
-      if ( ! $this -> czr_is_bubble_enabled() )
+    function czr_fn_display_comment_bubble( $_title = null ) {
+      if ( ! $this -> czr_fn_is_bubble_enabled() )
         return $_title;
 
       global $post;
@@ -347,7 +347,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
         apply_filters( 'tc_bubble_comment_anchor', '#tc-comment-title'),
         sprintf( '%1$s %2$s' , get_comments_number(), __( 'Comment(s) on' , 'customizr' ) ),
         is_null($_title) ? esc_attr( strip_tags( $post -> post_title ) ) : esc_attr( strip_tags( $_title ) ),
-        0 != get_comments_number() ? apply_filters( 'tc_bubble_comment' , '' , esc_attr( CZR_utils::$inst->czr_opt( 'tc_comment_bubble_shape' ) ) ) : ''
+        0 != get_comments_number() ? apply_filters( 'tc_bubble_comment' , '' , esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_comment_bubble_shape' ) ) ) : ''
       );
     }
 
@@ -360,7 +360,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
     * @package Customizr
     * @since Customizr 3.2.6
     */
-    function czr_custom_bubble_comment( $_html , $_opt ) {
+    function czr_fn_custom_bubble_comment( $_html , $_opt ) {
       return sprintf('%4$s<span class="tc-comment-bubble %1$s">%2$s %3$s</span>',
         'default' == $_opt ? "default-bubble" : $_opt,
         get_comments_number(),
@@ -379,14 +379,14 @@ if ( ! class_exists( 'CZR_comments' ) ) :
     * @package Customizr
     * @since Customizr 3.3.2
     */
-    function czr_comment_bubble_inline_css( $_css ) {
-      if ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_comment_show_bubble' ) ) )
+    function czr_fn_comment_bubble_inline_css( $_css ) {
+      if ( 0 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_comment_show_bubble' ) ) )
         return $_css;
 
       //apply custom color only if type custom
       //if color type is skin => bubble color is defined in the skin stylesheet
-      if ( 'skin' != esc_attr( CZR_utils::$inst->czr_opt( 'tc_comment_bubble_color_type' ) ) ) {
-        $_custom_bubble_color = esc_attr( CZR_utils::$inst->czr_opt( 'tc_comment_bubble_color' ) );
+      if ( 'skin' != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_comment_bubble_color_type' ) ) ) {
+        $_custom_bubble_color = esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_comment_bubble_color' ) );
         $_css .= "
           .comments-link .tc-comment-bubble {
             color: {$_custom_bubble_color};
@@ -398,7 +398,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
         ";
       }
 
-      if ( 'default' == esc_attr( CZR_utils::$inst->czr_opt( 'tc_comment_bubble_shape' ) ) )
+      if ( 'default' == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_comment_bubble_shape' ) ) )
         return $_css;
 
       $_css .= "
@@ -456,11 +456,11 @@ if ( ! class_exists( 'CZR_comments' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    private function czr_are_comments_enabled() {
+    private function czr_fn_are_comments_enabled() {
       global $post;
       // 1) By default not displayed on home, for protected posts, and if no comments for page option is checked
       if ( isset( $post ) ) {
-        $_bool = ( post_password_required() || czr__f( '__is_home' ) || ! is_singular() )  ? false : true;
+        $_bool = ( post_password_required() || czr_fn__f( '__is_home' ) || ! is_singular() )  ? false : true;
 
         //2) if user has enabled comment for this specific post / page => true
         //@todo contx : update default value user's value)
@@ -468,13 +468,13 @@ if ( ! class_exists( 'CZR_comments' ) ) :
 
         //3) check global user options for pages and posts
         if ( is_page() )
-          $_bool = 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_page_comments' )) && $_bool;
+          $_bool = 1 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_page_comments' )) && $_bool;
         else
-          $_bool = 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_comments' )) && $_bool;
+          $_bool = 1 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_post_comments' )) && $_bool;
       } else
         $_bool = false;
 
-      return apply_filters( 'czr_are_comments_enabled', $_bool );
+      return apply_filters( 'czr_fn_are_comments_enabled', $_bool );
     }
 
 
@@ -495,13 +495,13 @@ if ( ! class_exists( 'CZR_comments' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    private function czr_is_bubble_enabled() {
+    private function czr_fn_is_bubble_enabled() {
       $_bool_arr = array(
         in_the_loop(),
-        (bool) esc_attr( CZR_utils::$inst->czr_opt( 'tc_comment_show_bubble' ) ),
-        $this -> czr_are_comments_enabled(),
+        (bool) esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_comment_show_bubble' ) ),
+        $this -> czr_fn_are_comments_enabled(),
         get_comments_number() != 0,
-        (bool) esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_comment_list' ) ),
+        (bool) esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_comment_list' ) ),
         (bool) apply_filters( 'tc_comments_in_title', true ),
         in_array( get_post_type(), apply_filters('tc_show_comment_bubbles_for_post_types' , array( 'post' , 'page') ) )
       );

--- a/inc/parts/class-content-comments.php
+++ b/inc/parts/class-content-comments.php
@@ -17,13 +17,13 @@ if ( ! class_exists( 'CZR_comments' ) ) :
       function __construct () {
         self::$instance =& $this;
         //wp hook => wp_query is built
-        add_action ( 'wp'                     , array( $this , 'tc_comments_set_hooks' ) );
+        add_action ( 'wp'                     , array( $this , 'czr_comments_set_hooks' ) );
 
         //! tc_user_options_style filter is shared by several classes => must always check the local context inside the callback before appending new css
         //fired on hook : wp_enqueue_scripts
         //Set thumbnail specific design based on user options
         //Set user defined various inline stylings
-        add_filter( 'tc_user_options_style'   , array( $this , 'tc_comment_bubble_inline_css' ) );
+        add_filter( 'tc_user_options_style'   , array( $this , 'czr_comment_bubble_inline_css' ) );
       }
 
 
@@ -39,23 +39,23 @@ if ( ! class_exists( 'CZR_comments' ) ) :
       */
       function czr_comments_set_hooks() {
         //Maybe fires the comment's template
-        add_action ( '__after_loop'           , array( $this , 'tc_comments' ), 10 );
+        add_action ( '__after_loop'           , array( $this , 'czr_comments' ), 10 );
 
         //Apply a filter on the comment list ( comment list user defined option )
         //the filter tc_display_comment_list is fired in the comments.php template
-        add_filter( 'tc_display_comment_list' , array( $this , 'tc_set_comment_list_display' ) );
+        add_filter( 'tc_display_comment_list' , array( $this , 'czr_set_comment_list_display' ) );
 
         //Add actions in the comment's template
-        add_action ( '__comment'              , array( $this , 'tc_comment_title' ), 10 );
-        add_action ( '__comment'              , array( $this , 'tc_comment_list' ), 20 );
-        add_action ( '__comment'              , array( $this , 'tc_comment_navigation' ), 30 );
-        add_action ( '__comment'              , array( $this , 'tc_comment_close' ), 40 );
-        add_filter ( 'comment_form_defaults'  , array( $this , 'tc_set_comment_title') );
+        add_action ( '__comment'              , array( $this , 'czr_comment_title' ), 10 );
+        add_action ( '__comment'              , array( $this , 'czr_comment_list' ), 20 );
+        add_action ( '__comment'              , array( $this , 'czr_comment_navigation' ), 30 );
+        add_action ( '__comment'              , array( $this , 'czr_comment_close' ), 40 );
+        add_filter ( 'comment_form_defaults'  , array( $this , 'czr_set_comment_title') );
 
         //Add comment bubble
-        add_filter( 'tc_the_title'            , array( $this , 'tc_display_comment_bubble' ), 1 );
+        add_filter( 'tc_the_title'            , array( $this , 'czr_display_comment_bubble' ), 1 );
         //Custom Bubble comment since 3.2.6
-        add_filter( 'tc_bubble_comment'       , array( $this , 'tc_custom_bubble_comment'), 10, 2 );
+        add_filter( 'tc_bubble_comment'       , array( $this , 'czr_custom_bubble_comment'), 10, 2 );
       }
 
 
@@ -95,7 +95,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
             $_title = sprintf( '%1$s %2$s', number_format_i18n( get_comments_number(), 'customizr' ) , __( 'thoughts on', 'customizr' ) );
           }
 
-          echo apply_filters( 'tc_comment_title' ,
+          echo apply_filters( 'czr_comment_title' ,
                 sprintf( '<h2 id="tc-comment-title" class="comments-title">%1$s &ldquo;%2$s&rdquo;</h2>' ,
                   $_title,
                   '<span>' . get_the_title() . '</span>'
@@ -112,7 +112,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
         * @since Customizr 3.0
        */
         function czr_comment_list() {
-          $_args = apply_filters( 'tc_list_comments_args' , array( 'callback' => array ( $this , 'tc_comment_callback' ) , 'style' => 'ul' ) );
+          $_args = apply_filters( 'tc_list_comments_args' , array( 'callback' => array ( $this , 'czr_comment_callback' ) , 'style' => 'ul' ) );
           ob_start();
             ?>
               <ul class="commentlist">
@@ -121,7 +121,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
             <?php
           $html = ob_get_contents();
           if ($html) ob_end_clean();
-          echo apply_filters( 'tc_comment_list' , $html );
+          echo apply_filters( 'czr_comment_list' , $html );
         }
 
 
@@ -222,7 +222,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
 
         $html = ob_get_contents();
         if ($html) ob_end_clean();
-        echo apply_filters( 'tc_comment_callback' , $html, $comment, $args, $depth, $max_comments_depth );
+        echo apply_filters( 'czr_comment_callback' , $html, $comment, $args, $depth, $max_comments_depth );
       }
 
 
@@ -266,7 +266,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
 
         $html = ob_get_contents();
         ob_end_clean();
-        echo apply_filters( 'tc_comment_navigation' , $html );
+        echo apply_filters( 'czr_comment_navigation' , $html );
 
       endif; // check for comment navigation
 
@@ -285,7 +285,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
        * But we only want the note on posts and pages that had comments in the first place.
        */
       if ( ! comments_open() && get_comments_number() ) :
-        echo apply_filters( 'tc_comment_close' ,
+        echo apply_filters( 'czr_comment_close' ,
           sprintf('<p class="nocomments">%1$s</p>',
             __( 'Comments are closed.' , 'customizr' )
           )
@@ -474,7 +474,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
       } else
         $_bool = false;
 
-      return apply_filters( 'tc_are_comments_enabled', $_bool );
+      return apply_filters( 'czr_are_comments_enabled', $_bool );
     }
 
 

--- a/inc/parts/class-content-comments.php
+++ b/inc/parts/class-content-comments.php
@@ -11,8 +11,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_comments' ) ) :
-  class TC_comments {
+if ( ! class_exists( 'CZR_comments' ) ) :
+  class CZR_comments {
       static $instance;
       function __construct () {
         self::$instance =& $this;
@@ -153,7 +153,7 @@ if ( ! class_exists( 'TC_comments' ) ) :
         <li <?php comment_class(); ?> id="comment-<?php comment_ID(); ?>">
           <article id="comment-<?php comment_ID(); ?>" class="comment">
             <p><?php _e( 'Pingback:' , 'customizr' ); ?> <?php comment_author_link(); ?>
-                <?php if ( ! TC___::$instance -> tc_is_customizing() )  edit_comment_link( __( '(Edit)' , 'customizr' ), '<span class="edit-link btn btn-success btn-mini">' , '</span>' ); ?>
+                <?php if ( ! CZR___::$instance -> tc_is_customizing() )  edit_comment_link( __( '(Edit)' , 'customizr' ), '<span class="edit-link btn btn-success btn-mini">' , '</span>' ); ?>
             </p>
           </article>
         <?php
@@ -195,7 +195,7 @@ if ( ! class_exists( 'TC_comments' ) ) :
                             get_comment_author_link(),
                             // If current post author is also comment author, make it known visually.
                             ( $comment->user_id === $post->post_author ) ? '<span> ' . __( 'Post author' , 'customizr' ) . '</span>' : '' ,
-                            ! TC___::$instance -> tc_is_customizing() && current_user_can( 'edit_comment', $comment->comment_ID ) ? '<p class="edit-link btn btn-success btn-mini"><a class="comment-edit-link" href="' . get_edit_comment_link( $comment->comment_ID ) . '">' . __( 'Edit' , 'customizr' ) . '</a></p>' : ''
+                            ! CZR___::$instance -> tc_is_customizing() && current_user_can( 'edit_comment', $comment->comment_ID ) ? '<p class="edit-link btn btn-success btn-mini"><a class="comment-edit-link" href="' . get_edit_comment_link( $comment->comment_ID ) . '">' . __( 'Edit' , 'customizr' ) . '</a></p>' : ''
                         ),
                         sprintf( '<a class="comment-date" href="%1$s"><time datetime="%2$s">%3$s</time></a>' ,
                             esc_url( get_comment_link( $comment->comment_ID ) ),
@@ -310,7 +310,7 @@ if ( ! class_exists( 'TC_comments' ) ) :
     * @since Customizr 3.3+
     */
     function tc_set_comment_list_display() {
-      return (bool) esc_attr( TC_utils::$inst->tc_opt( 'tc_show_comment_list' ) );
+      return (bool) esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_comment_list' ) );
     }
 
 
@@ -347,7 +347,7 @@ if ( ! class_exists( 'TC_comments' ) ) :
         apply_filters( 'tc_bubble_comment_anchor', '#tc-comment-title'),
         sprintf( '%1$s %2$s' , get_comments_number(), __( 'Comment(s) on' , 'customizr' ) ),
         is_null($_title) ? esc_attr( strip_tags( $post -> post_title ) ) : esc_attr( strip_tags( $_title ) ),
-        0 != get_comments_number() ? apply_filters( 'tc_bubble_comment' , '' , esc_attr( TC_utils::$inst->tc_opt( 'tc_comment_bubble_shape' ) ) ) : ''
+        0 != get_comments_number() ? apply_filters( 'tc_bubble_comment' , '' , esc_attr( CZR_utils::$inst->tc_opt( 'tc_comment_bubble_shape' ) ) ) : ''
       );
     }
 
@@ -380,13 +380,13 @@ if ( ! class_exists( 'TC_comments' ) ) :
     * @since Customizr 3.3.2
     */
     function tc_comment_bubble_inline_css( $_css ) {
-      if ( 0 == esc_attr( TC_utils::$inst->tc_opt( 'tc_comment_show_bubble' ) ) )
+      if ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_comment_show_bubble' ) ) )
         return $_css;
 
       //apply custom color only if type custom
       //if color type is skin => bubble color is defined in the skin stylesheet
-      if ( 'skin' != esc_attr( TC_utils::$inst->tc_opt( 'tc_comment_bubble_color_type' ) ) ) {
-        $_custom_bubble_color = esc_attr( TC_utils::$inst->tc_opt( 'tc_comment_bubble_color' ) );
+      if ( 'skin' != esc_attr( CZR_utils::$inst->tc_opt( 'tc_comment_bubble_color_type' ) ) ) {
+        $_custom_bubble_color = esc_attr( CZR_utils::$inst->tc_opt( 'tc_comment_bubble_color' ) );
         $_css .= "
           .comments-link .tc-comment-bubble {
             color: {$_custom_bubble_color};
@@ -398,7 +398,7 @@ if ( ! class_exists( 'TC_comments' ) ) :
         ";
       }
 
-      if ( 'default' == esc_attr( TC_utils::$inst->tc_opt( 'tc_comment_bubble_shape' ) ) )
+      if ( 'default' == esc_attr( CZR_utils::$inst->tc_opt( 'tc_comment_bubble_shape' ) ) )
         return $_css;
 
       $_css .= "
@@ -468,9 +468,9 @@ if ( ! class_exists( 'TC_comments' ) ) :
 
         //3) check global user options for pages and posts
         if ( is_page() )
-          $_bool = 1 == esc_attr( TC_utils::$inst->tc_opt( 'tc_page_comments' )) && $_bool;
+          $_bool = 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_page_comments' )) && $_bool;
         else
-          $_bool = 1 == esc_attr( TC_utils::$inst->tc_opt( 'tc_post_comments' )) && $_bool;
+          $_bool = 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_comments' )) && $_bool;
       } else
         $_bool = false;
 
@@ -498,10 +498,10 @@ if ( ! class_exists( 'TC_comments' ) ) :
     private function tc_is_bubble_enabled() {
       $_bool_arr = array(
         in_the_loop(),
-        (bool) esc_attr( TC_utils::$inst->tc_opt( 'tc_comment_show_bubble' ) ),
+        (bool) esc_attr( CZR_utils::$inst->tc_opt( 'tc_comment_show_bubble' ) ),
         $this -> tc_are_comments_enabled(),
         get_comments_number() != 0,
-        (bool) esc_attr( TC_utils::$inst->tc_opt( 'tc_show_comment_list' ) ),
+        (bool) esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_comment_list' ) ),
         (bool) apply_filters( 'tc_comments_in_title', true ),
         in_array( get_post_type(), apply_filters('tc_show_comment_bubbles_for_post_types' , array( 'post' , 'page') ) )
       );

--- a/inc/parts/class-content-comments.php
+++ b/inc/parts/class-content-comments.php
@@ -95,7 +95,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
             $_title = sprintf( '%1$s %2$s', number_format_i18n( get_comments_number(), 'customizr' ) , __( 'thoughts on', 'customizr' ) );
           }
 
-          echo apply_filters( 'czr_fn_comment_title' ,
+          echo apply_filters( 'tc_comment_title' ,
                 sprintf( '<h2 id="tc-comment-title" class="comments-title">%1$s &ldquo;%2$s&rdquo;</h2>' ,
                   $_title,
                   '<span>' . get_the_title() . '</span>'
@@ -121,7 +121,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
             <?php
           $html = ob_get_contents();
           if ($html) ob_end_clean();
-          echo apply_filters( 'czr_fn_comment_list' , $html );
+          echo apply_filters( 'tc_comment_list' , $html );
         }
 
 
@@ -222,7 +222,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
 
         $html = ob_get_contents();
         if ($html) ob_end_clean();
-        echo apply_filters( 'czr_fn_comment_callback' , $html, $comment, $args, $depth, $max_comments_depth );
+        echo apply_filters( 'tc_comment_callback' , $html, $comment, $args, $depth, $max_comments_depth );
       }
 
 
@@ -266,7 +266,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
 
         $html = ob_get_contents();
         ob_end_clean();
-        echo apply_filters( 'czr_fn_comment_navigation' , $html );
+        echo apply_filters( 'tc_comment_navigation' , $html );
 
       endif; // check for comment navigation
 
@@ -285,7 +285,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
        * But we only want the note on posts and pages that had comments in the first place.
        */
       if ( ! comments_open() && get_comments_number() ) :
-        echo apply_filters( 'czr_fn_comment_close' ,
+        echo apply_filters( 'tc_comment_close' ,
           sprintf('<p class="nocomments">%1$s</p>',
             __( 'Comments are closed.' , 'customizr' )
           )
@@ -474,7 +474,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
       } else
         $_bool = false;
 
-      return apply_filters( 'czr_fn_are_comments_enabled', $_bool );
+      return apply_filters( 'tc_are_comments_enabled', $_bool );
     }
 
 

--- a/inc/parts/class-content-comments.php
+++ b/inc/parts/class-content-comments.php
@@ -71,7 +71,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
       * @since Customizr 3.0.10
      */
       function czr_comments() {
-        if ( ! $this -> tc_are_comments_enabled() )
+        if ( ! $this -> czr_are_comments_enabled() )
           return;
         do_action('tc_before_comments_template');
           comments_template( '' , true );
@@ -153,7 +153,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
         <li <?php comment_class(); ?> id="comment-<?php comment_ID(); ?>">
           <article id="comment-<?php comment_ID(); ?>" class="comment">
             <p><?php _e( 'Pingback:' , 'customizr' ); ?> <?php comment_author_link(); ?>
-                <?php if ( ! CZR___::$instance -> tc_is_customizing() )  edit_comment_link( __( '(Edit)' , 'customizr' ), '<span class="edit-link btn btn-success btn-mini">' , '</span>' ); ?>
+                <?php if ( ! CZR___::$instance -> czr_is_customizing() )  edit_comment_link( __( '(Edit)' , 'customizr' ), '<span class="edit-link btn btn-success btn-mini">' , '</span>' ); ?>
             </p>
           </article>
         <?php
@@ -195,7 +195,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
                             get_comment_author_link(),
                             // If current post author is also comment author, make it known visually.
                             ( $comment->user_id === $post->post_author ) ? '<span> ' . __( 'Post author' , 'customizr' ) . '</span>' : '' ,
-                            ! CZR___::$instance -> tc_is_customizing() && current_user_can( 'edit_comment', $comment->comment_ID ) ? '<p class="edit-link btn btn-success btn-mini"><a class="comment-edit-link" href="' . get_edit_comment_link( $comment->comment_ID ) . '">' . __( 'Edit' , 'customizr' ) . '</a></p>' : ''
+                            ! CZR___::$instance -> czr_is_customizing() && current_user_can( 'edit_comment', $comment->comment_ID ) ? '<p class="edit-link btn btn-success btn-mini"><a class="comment-edit-link" href="' . get_edit_comment_link( $comment->comment_ID ) . '">' . __( 'Edit' , 'customizr' ) . '</a></p>' : ''
                         ),
                         sprintf( '<a class="comment-date" href="%1$s"><time datetime="%2$s">%3$s</time></a>' ,
                             esc_url( get_comment_link( $comment->comment_ID ) ),
@@ -310,7 +310,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
     * @since Customizr 3.3+
     */
     function czr_set_comment_list_display() {
-      return (bool) esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_comment_list' ) );
+      return (bool) esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_comment_list' ) );
     }
 
 
@@ -336,7 +336,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
     * @since Customizr 3.2.6
     */
     function czr_display_comment_bubble( $_title = null ) {
-      if ( ! $this -> tc_is_bubble_enabled() )
+      if ( ! $this -> czr_is_bubble_enabled() )
         return $_title;
 
       global $post;
@@ -347,7 +347,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
         apply_filters( 'tc_bubble_comment_anchor', '#tc-comment-title'),
         sprintf( '%1$s %2$s' , get_comments_number(), __( 'Comment(s) on' , 'customizr' ) ),
         is_null($_title) ? esc_attr( strip_tags( $post -> post_title ) ) : esc_attr( strip_tags( $_title ) ),
-        0 != get_comments_number() ? apply_filters( 'tc_bubble_comment' , '' , esc_attr( CZR_utils::$inst->tc_opt( 'tc_comment_bubble_shape' ) ) ) : ''
+        0 != get_comments_number() ? apply_filters( 'tc_bubble_comment' , '' , esc_attr( CZR_utils::$inst->czr_opt( 'tc_comment_bubble_shape' ) ) ) : ''
       );
     }
 
@@ -380,13 +380,13 @@ if ( ! class_exists( 'CZR_comments' ) ) :
     * @since Customizr 3.3.2
     */
     function czr_comment_bubble_inline_css( $_css ) {
-      if ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_comment_show_bubble' ) ) )
+      if ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_comment_show_bubble' ) ) )
         return $_css;
 
       //apply custom color only if type custom
       //if color type is skin => bubble color is defined in the skin stylesheet
-      if ( 'skin' != esc_attr( CZR_utils::$inst->tc_opt( 'tc_comment_bubble_color_type' ) ) ) {
-        $_custom_bubble_color = esc_attr( CZR_utils::$inst->tc_opt( 'tc_comment_bubble_color' ) );
+      if ( 'skin' != esc_attr( CZR_utils::$inst->czr_opt( 'tc_comment_bubble_color_type' ) ) ) {
+        $_custom_bubble_color = esc_attr( CZR_utils::$inst->czr_opt( 'tc_comment_bubble_color' ) );
         $_css .= "
           .comments-link .tc-comment-bubble {
             color: {$_custom_bubble_color};
@@ -398,7 +398,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
         ";
       }
 
-      if ( 'default' == esc_attr( CZR_utils::$inst->tc_opt( 'tc_comment_bubble_shape' ) ) )
+      if ( 'default' == esc_attr( CZR_utils::$inst->czr_opt( 'tc_comment_bubble_shape' ) ) )
         return $_css;
 
       $_css .= "
@@ -460,7 +460,7 @@ if ( ! class_exists( 'CZR_comments' ) ) :
       global $post;
       // 1) By default not displayed on home, for protected posts, and if no comments for page option is checked
       if ( isset( $post ) ) {
-        $_bool = ( post_password_required() || tc__f( '__is_home' ) || ! is_singular() )  ? false : true;
+        $_bool = ( post_password_required() || czr__f( '__is_home' ) || ! is_singular() )  ? false : true;
 
         //2) if user has enabled comment for this specific post / page => true
         //@todo contx : update default value user's value)
@@ -468,9 +468,9 @@ if ( ! class_exists( 'CZR_comments' ) ) :
 
         //3) check global user options for pages and posts
         if ( is_page() )
-          $_bool = 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_page_comments' )) && $_bool;
+          $_bool = 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_page_comments' )) && $_bool;
         else
-          $_bool = 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_comments' )) && $_bool;
+          $_bool = 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_comments' )) && $_bool;
       } else
         $_bool = false;
 
@@ -498,10 +498,10 @@ if ( ! class_exists( 'CZR_comments' ) ) :
     private function czr_is_bubble_enabled() {
       $_bool_arr = array(
         in_the_loop(),
-        (bool) esc_attr( CZR_utils::$inst->tc_opt( 'tc_comment_show_bubble' ) ),
-        $this -> tc_are_comments_enabled(),
+        (bool) esc_attr( CZR_utils::$inst->czr_opt( 'tc_comment_show_bubble' ) ),
+        $this -> czr_are_comments_enabled(),
         get_comments_number() != 0,
-        (bool) esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_comment_list' ) ),
+        (bool) esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_comment_list' ) ),
         (bool) apply_filters( 'tc_comments_in_title', true ),
         in_array( get_post_type(), apply_filters('tc_show_comment_bubbles_for_post_types' , array( 'post' , 'page') ) )
       );

--- a/inc/parts/class-content-featured_pages.php
+++ b/inc/parts/class-content-featured_pages.php
@@ -30,10 +30,10 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
     * @since v3.4+
     */
     function czr_maybe_display_dismiss_notice() {
-      if ( ! CZR_placeholders::tc_is_fp_notice_on() )
+      if ( ! CZR_placeholders::czr_is_fp_notice_on() )
         return;
 
-      $_customizer_lnk = apply_filters( 'tc_fp_notice_customizer_url', CZR_utils::tc_get_customizer_url( array( 'control' => 'tc_show_featured_pages', 'section' => 'frontpage_sec') ) );
+      $_customizer_lnk = apply_filters( 'tc_fp_notice_customizer_url', CZR_utils::czr_get_customizer_url( array( 'control' => 'tc_show_featured_pages', 'section' => 'frontpage_sec') ) );
 
       ?>
       <div class="tc-placeholder-wrap tc-fp-notice">
@@ -65,10 +65,10 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
   	* @since Customizr 3.0
   	*/
     function czr_fp_block_display() {
-      if ( ! $this -> tc_show_featured_pages()  )
+      if ( ! $this -> czr_show_featured_pages()  )
         return;
 
-      $tc_show_featured_pages_img     = $this -> tc_show_featured_pages_img();
+      $tc_show_featured_pages_img     = $this -> czr_show_featured_pages_img();
 
   		//gets the featured pages array and sets the fp layout
   		$fp_ids                         = apply_filters( 'tc_featured_pages_ids' , CZR_init::$instance -> fp_ids);
@@ -109,7 +109,7 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
                                   ) : '',
                     $span_value,
                     $fp_ids[$i - 1],
-                    $this -> tc_fp_single_display( $fp_ids[$i - 1] , $tc_show_featured_pages_img ),
+                    $this -> czr_fp_single_display( $fp_ids[$i - 1] , $tc_show_featured_pages_img ),
                     ( $j == $fp_per_row || $i == $fp_nb ) ? '</div>' : ''
                 );
           //set $j back to start value if reach $fp_per_row
@@ -122,7 +122,7 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
 
 			</div><!-- .container -->
 
-      <?php  echo ! tc__f( '__is_home_empty') ? apply_filters( 'tc_after_fp_separator', '<hr class="featurette-divider '.current_filter().'">' ) : ''; ?>
+      <?php  echo ! czr__f( '__is_home_empty') ? apply_filters( 'tc_after_fp_separator', '<hr class="featurette-divider '.current_filter().'">' ) : ''; ?>
 
       <?php
       $html = ob_get_contents();
@@ -138,7 +138,7 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
       *******************************/
 	   /**
       * The template displaying one single featured page
-      * fired in : tc_fp_block_display()
+      * fired in : czr_fp_block_display()
       *
       * @package Customizr
       * @since Customizr 3.0
@@ -146,7 +146,7 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
       * @todo better area definition : dynamic
       */
       function czr_fp_single_display( $fp_single_id,$show_img) {
-        $_skin_color                        = CZR_utils::$inst -> tc_get_skin_color();
+        $_skin_color                        = CZR_utils::$inst -> czr_get_skin_color();
         $fp_holder_img                      = apply_filters (
           'tc_fp_holder_img' ,
           sprintf('<img class="tc-holder-img" data-src="holder.js/270x250/%1$s:%2$s" data-no-retina alt="Holder Thumbnail" style="width:270px;height:250px;"/>',
@@ -157,17 +157,17 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
         $featured_page_id                   = 0;
 
         //if fps are not set
-        if ( null == CZR_utils::$inst->tc_opt( 'tc_featured_page_'.$fp_single_id ) || ! CZR_utils::$inst->tc_opt( 'tc_featured_page_'.$fp_single_id ) ) {
+        if ( null == CZR_utils::$inst->czr_opt( 'tc_featured_page_'.$fp_single_id ) || ! CZR_utils::$inst->czr_opt( 'tc_featured_page_'.$fp_single_id ) ) {
             //admin link if user logged in
             $featured_page_link             = '';
             $customizr_link                 = '';
-            if ( ! CZR___::$instance -> tc_is_customizing() && is_user_logged_in() && current_user_can('edit_theme_options') ) {
+            if ( ! CZR___::$instance -> czr_is_customizing() && is_user_logged_in() && current_user_can('edit_theme_options') ) {
               $customizr_link              = sprintf( '<a href="%1$s" title="%2$s">%3$s</a>',
-                CZR_utils::tc_get_customizer_url( array( 'control' => 'tc_featured_text_'.$fp_single_id, 'section' => 'frontpage_sec') ),
+                CZR_utils::czr_get_customizer_url( array( 'control' => 'tc_featured_text_'.$fp_single_id, 'section' => 'frontpage_sec') ),
                 __( 'Customizer screen' , 'customizr' ),
                 __( 'Edit now.' , 'customizr' )
               );
-              $featured_page_link          = apply_filters( 'tc_fp_link_url', CZR_utils::tc_get_customizer_url( array( 'control' => 'tc_featured_page_'.$fp_single_id, 'section' => 'frontpage_sec') ) );
+              $featured_page_link          = apply_filters( 'tc_fp_link_url', CZR_utils::czr_get_customizer_url( array( 'control' => 'tc_featured_page_'.$fp_single_id, 'section' => 'frontpage_sec') ) );
             }
 
             //rendering
@@ -187,7 +187,7 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
         }
 
         else {
-            $featured_page_id               = apply_filters( 'tc_fp_id', esc_attr( CZR_utils::$inst->tc_opt( 'tc_featured_page_'.$fp_single_id) ), $fp_single_id );
+            $featured_page_id               = apply_filters( 'tc_fp_id', esc_attr( CZR_utils::$inst->czr_opt( 'tc_featured_page_'.$fp_single_id) ), $fp_single_id );
 
             $featured_page_link             = apply_filters( 'tc_fp_link_url', get_permalink( $featured_page_id ), $fp_single_id );
 
@@ -196,14 +196,14 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
             $edit_enabled                   = false;
             //when are we displaying the edit link?
             //never display when customizing
-            if ( ! CZR___::$instance -> tc_is_customizing() ) {
+            if ( ! CZR___::$instance -> czr_is_customizing() ) {
               $edit_enabled                 = ( (is_user_logged_in()) && current_user_can('edit_pages') && is_page( $featured_page_id ) ) ? true : $edit_enabled;
               $edit_enabled                 = ( (is_user_logged_in()) && current_user_can('edit_post' , $featured_page_id ) && ! is_page( $featured_page_id ) ) ? true : $edit_enabled;
             }
 
             $edit_enabled                   = apply_filters( 'tc_edit_in_fp_title', $edit_enabled );
 
-            $featured_text                  = apply_filters( 'tc_fp_text', CZR_utils::$inst->tc_opt( 'tc_featured_text_'.$fp_single_id ), $fp_single_id, $featured_page_id );
+            $featured_text                  = apply_filters( 'tc_fp_text', CZR_utils::$inst->czr_opt( 'tc_featured_text_'.$fp_single_id ), $fp_single_id, $featured_page_id );
             $featured_text                  = apply_filters( 'tc_fp_text_sanitize', strip_tags( html_entity_decode( $featured_text ) ), $fp_single_id, $featured_page_id );
 
             //get the page/post object
@@ -222,7 +222,7 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
             //allow user to specify a custom image id
             $fp_custom_img_id               = apply_filters( 'fp_img_id', null , $fp_single_id , $featured_page_id );
 
-            $fp_img = $this -> tc_get_fp_img( $fp_img_size, $featured_page_id, $fp_custom_img_id);
+            $fp_img = $this -> czr_get_fp_img( $fp_img_size, $featured_page_id, $fp_custom_img_id);
             $fp_img = $fp_img ? $fp_img : $fp_holder_img;
 
             $fp_img                 = apply_filters ('fp_img_src' , $fp_img , $fp_single_id , $featured_page_id );
@@ -268,9 +268,9 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
               echo apply_filters( 'tc_fp_text_block' , $tc_fp_text_block , $fp_single_id , $text, $featured_page_id);
 
               //button block
-              $tc_fp_button_text = apply_filters( 'tc_fp_button_text' , esc_attr( CZR_utils::$inst->tc_opt( 'tc_featured_page_button_text') ) , $fp_single_id );
+              $tc_fp_button_text = apply_filters( 'tc_fp_button_text' , esc_attr( CZR_utils::$inst->czr_opt( 'tc_featured_page_button_text') ) , $fp_single_id );
 
-              if ( $tc_fp_button_text || CZR___::$instance -> tc_is_customizing() ){
+              if ( $tc_fp_button_text || CZR___::$instance -> czr_is_customizing() ){
                 $tc_fp_button_class = apply_filters( 'tc_fp_button_class' , 'btn btn-primary fp-button', $fp_single_id );
                 $tc_fp_button_class = $tc_fp_button_text ? $tc_fp_button_class : $tc_fp_button_class . ' hidden';
                 $tc_fp_button_block = sprintf('<a class="%1$s" href="%2$s" title="%3$s">%4$s</a>',
@@ -299,8 +299,8 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
     *******************************/
     function czr_get_fp_img( $fp_img_size, $featured_page_id, $fp_custom_img_id ){
       //try to get "tc_thumb" , "tc_thumb_height" , "tc_thumb_width"
-      //tc_get_thumbnail_model( $requested_size = null, $_post_id = null , $_thumb_id = null )
-      $_fp_img_model = CZR_post_thumbnails::$instance -> tc_get_thumbnail_model( $fp_img_size, $featured_page_id, $fp_custom_img_id );
+      //czr_get_thumbnail_model( $requested_size = null, $_post_id = null , $_thumb_id = null )
+      $_fp_img_model = CZR_post_thumbnails::$instance -> czr_get_thumbnail_model( $fp_img_size, $featured_page_id, $fp_custom_img_id );
 
       //finally we define a default holder if no thumbnail found or page is protected
       if ( isset( $_fp_img_model["tc_thumb"]) && ! empty( $_fp_img_model["tc_thumb"] ) && ! post_password_required( $featured_page_id ) )
@@ -314,15 +314,15 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
 
     function czr_show_featured_pages() {
       //gets display fp option
-      $tc_show_featured_pages 	      = esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_featured_pages' ) );
+      $tc_show_featured_pages 	      = esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_featured_pages' ) );
 
-      return apply_filters( 'tc_show_fp', 0 != $tc_show_featured_pages && tc__f('__is_home') );
+      return apply_filters( 'tc_show_fp', 0 != $tc_show_featured_pages && czr__f('__is_home') );
     }
 
 
     function czr_show_featured_pages_img() {
       //gets  display img option
-      return apply_filters( 'tc_show_featured_pages_img', esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_featured_pages_img' ) ) );
+      return apply_filters( 'tc_show_featured_pages_img', esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_featured_pages_img' ) ) );
     }
 
   }//end of class

--- a/inc/parts/class-content-featured_pages.php
+++ b/inc/parts/class-content-featured_pages.php
@@ -33,7 +33,7 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
       if ( ! CZR_placeholders::czr_fn_is_fp_notice_on() )
         return;
 
-      $_customizer_lnk = apply_filters( 'tc_fp_notice_customizer_url', CZR_utils::czr_fn_get_customizer_url( array( 'control' => 'czr_fn_show_featured_pages', 'section' => 'frontpage_sec') ) );
+      $_customizer_lnk = apply_filters( 'tc_fp_notice_customizer_url', CZR_utils::czr_fn_get_customizer_url( array( 'control' => 'tc_show_featured_pages', 'section' => 'frontpage_sec') ) );
 
       ?>
       <div class="tc-placeholder-wrap tc-fp-notice">

--- a/inc/parts/class-content-featured_pages.php
+++ b/inc/parts/class-content-featured_pages.php
@@ -11,8 +11,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_featured_pages' ) ) :
-  class TC_featured_pages {
+if ( ! class_exists( 'CZR_featured_pages' ) ) :
+  class CZR_featured_pages {
     static $instance;
     function __construct () {
         self::$instance =& $this;
@@ -30,10 +30,10 @@ if ( ! class_exists( 'TC_featured_pages' ) ) :
     * @since v3.4+
     */
     function tc_maybe_display_dismiss_notice() {
-      if ( ! TC_placeholders::tc_is_fp_notice_on() )
+      if ( ! CZR_placeholders::tc_is_fp_notice_on() )
         return;
 
-      $_customizer_lnk = apply_filters( 'tc_fp_notice_customizer_url', TC_utils::tc_get_customizer_url( array( 'control' => 'tc_show_featured_pages', 'section' => 'frontpage_sec') ) );
+      $_customizer_lnk = apply_filters( 'tc_fp_notice_customizer_url', CZR_utils::tc_get_customizer_url( array( 'control' => 'tc_show_featured_pages', 'section' => 'frontpage_sec') ) );
 
       ?>
       <div class="tc-placeholder-wrap tc-fp-notice">
@@ -71,7 +71,7 @@ if ( ! class_exists( 'TC_featured_pages' ) ) :
       $tc_show_featured_pages_img     = $this -> tc_show_featured_pages_img();
 
   		//gets the featured pages array and sets the fp layout
-  		$fp_ids                         = apply_filters( 'tc_featured_pages_ids' , TC_init::$instance -> fp_ids);
+  		$fp_ids                         = apply_filters( 'tc_featured_pages_ids' , CZR_init::$instance -> fp_ids);
       $fp_nb                          = count($fp_ids);
       $fp_per_row                     = apply_filters( 'tc_fp_per_line', 3 );
 
@@ -146,7 +146,7 @@ if ( ! class_exists( 'TC_featured_pages' ) ) :
       * @todo better area definition : dynamic
       */
       function tc_fp_single_display( $fp_single_id,$show_img) {
-        $_skin_color                        = TC_utils::$inst -> tc_get_skin_color();
+        $_skin_color                        = CZR_utils::$inst -> tc_get_skin_color();
         $fp_holder_img                      = apply_filters (
           'tc_fp_holder_img' ,
           sprintf('<img class="tc-holder-img" data-src="holder.js/270x250/%1$s:%2$s" data-no-retina alt="Holder Thumbnail" style="width:270px;height:250px;"/>',
@@ -157,17 +157,17 @@ if ( ! class_exists( 'TC_featured_pages' ) ) :
         $featured_page_id                   = 0;
 
         //if fps are not set
-        if ( null == TC_utils::$inst->tc_opt( 'tc_featured_page_'.$fp_single_id ) || ! TC_utils::$inst->tc_opt( 'tc_featured_page_'.$fp_single_id ) ) {
+        if ( null == CZR_utils::$inst->tc_opt( 'tc_featured_page_'.$fp_single_id ) || ! CZR_utils::$inst->tc_opt( 'tc_featured_page_'.$fp_single_id ) ) {
             //admin link if user logged in
             $featured_page_link             = '';
             $customizr_link                 = '';
-            if ( ! TC___::$instance -> tc_is_customizing() && is_user_logged_in() && current_user_can('edit_theme_options') ) {
+            if ( ! CZR___::$instance -> tc_is_customizing() && is_user_logged_in() && current_user_can('edit_theme_options') ) {
               $customizr_link              = sprintf( '<a href="%1$s" title="%2$s">%3$s</a>',
-                TC_utils::tc_get_customizer_url( array( 'control' => 'tc_featured_text_'.$fp_single_id, 'section' => 'frontpage_sec') ),
+                CZR_utils::tc_get_customizer_url( array( 'control' => 'tc_featured_text_'.$fp_single_id, 'section' => 'frontpage_sec') ),
                 __( 'Customizer screen' , 'customizr' ),
                 __( 'Edit now.' , 'customizr' )
               );
-              $featured_page_link          = apply_filters( 'tc_fp_link_url', TC_utils::tc_get_customizer_url( array( 'control' => 'tc_featured_page_'.$fp_single_id, 'section' => 'frontpage_sec') ) );
+              $featured_page_link          = apply_filters( 'tc_fp_link_url', CZR_utils::tc_get_customizer_url( array( 'control' => 'tc_featured_page_'.$fp_single_id, 'section' => 'frontpage_sec') ) );
             }
 
             //rendering
@@ -187,7 +187,7 @@ if ( ! class_exists( 'TC_featured_pages' ) ) :
         }
 
         else {
-            $featured_page_id               = apply_filters( 'tc_fp_id', esc_attr( TC_utils::$inst->tc_opt( 'tc_featured_page_'.$fp_single_id) ), $fp_single_id );
+            $featured_page_id               = apply_filters( 'tc_fp_id', esc_attr( CZR_utils::$inst->tc_opt( 'tc_featured_page_'.$fp_single_id) ), $fp_single_id );
 
             $featured_page_link             = apply_filters( 'tc_fp_link_url', get_permalink( $featured_page_id ), $fp_single_id );
 
@@ -196,14 +196,14 @@ if ( ! class_exists( 'TC_featured_pages' ) ) :
             $edit_enabled                   = false;
             //when are we displaying the edit link?
             //never display when customizing
-            if ( ! TC___::$instance -> tc_is_customizing() ) {
+            if ( ! CZR___::$instance -> tc_is_customizing() ) {
               $edit_enabled                 = ( (is_user_logged_in()) && current_user_can('edit_pages') && is_page( $featured_page_id ) ) ? true : $edit_enabled;
               $edit_enabled                 = ( (is_user_logged_in()) && current_user_can('edit_post' , $featured_page_id ) && ! is_page( $featured_page_id ) ) ? true : $edit_enabled;
             }
-            
+
             $edit_enabled                   = apply_filters( 'tc_edit_in_fp_title', $edit_enabled );
 
-            $featured_text                  = apply_filters( 'tc_fp_text', TC_utils::$inst->tc_opt( 'tc_featured_text_'.$fp_single_id ), $fp_single_id, $featured_page_id );
+            $featured_text                  = apply_filters( 'tc_fp_text', CZR_utils::$inst->tc_opt( 'tc_featured_text_'.$fp_single_id ), $fp_single_id, $featured_page_id );
             $featured_text                  = apply_filters( 'tc_fp_text_sanitize', strip_tags( html_entity_decode( $featured_text ) ), $fp_single_id, $featured_page_id );
 
             //get the page/post object
@@ -268,9 +268,9 @@ if ( ! class_exists( 'TC_featured_pages' ) ) :
               echo apply_filters( 'tc_fp_text_block' , $tc_fp_text_block , $fp_single_id , $text, $featured_page_id);
 
               //button block
-              $tc_fp_button_text = apply_filters( 'tc_fp_button_text' , esc_attr( TC_utils::$inst->tc_opt( 'tc_featured_page_button_text') ) , $fp_single_id );
+              $tc_fp_button_text = apply_filters( 'tc_fp_button_text' , esc_attr( CZR_utils::$inst->tc_opt( 'tc_featured_page_button_text') ) , $fp_single_id );
 
-              if ( $tc_fp_button_text || TC___::$instance -> tc_is_customizing() ){
+              if ( $tc_fp_button_text || CZR___::$instance -> tc_is_customizing() ){
                 $tc_fp_button_class = apply_filters( 'tc_fp_button_class' , 'btn btn-primary fp-button', $fp_single_id );
                 $tc_fp_button_class = $tc_fp_button_text ? $tc_fp_button_class : $tc_fp_button_class . ' hidden';
                 $tc_fp_button_block = sprintf('<a class="%1$s" href="%2$s" title="%3$s">%4$s</a>',
@@ -300,7 +300,7 @@ if ( ! class_exists( 'TC_featured_pages' ) ) :
     function tc_get_fp_img( $fp_img_size, $featured_page_id, $fp_custom_img_id ){
       //try to get "tc_thumb" , "tc_thumb_height" , "tc_thumb_width"
       //tc_get_thumbnail_model( $requested_size = null, $_post_id = null , $_thumb_id = null )
-      $_fp_img_model = TC_post_thumbnails::$instance -> tc_get_thumbnail_model( $fp_img_size, $featured_page_id, $fp_custom_img_id );
+      $_fp_img_model = CZR_post_thumbnails::$instance -> tc_get_thumbnail_model( $fp_img_size, $featured_page_id, $fp_custom_img_id );
 
       //finally we define a default holder if no thumbnail found or page is protected
       if ( isset( $_fp_img_model["tc_thumb"]) && ! empty( $_fp_img_model["tc_thumb"] ) && ! post_password_required( $featured_page_id ) )
@@ -314,7 +314,7 @@ if ( ! class_exists( 'TC_featured_pages' ) ) :
 
     function tc_show_featured_pages() {
       //gets display fp option
-      $tc_show_featured_pages 	      = esc_attr( TC_utils::$inst->tc_opt( 'tc_show_featured_pages' ) );
+      $tc_show_featured_pages 	      = esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_featured_pages' ) );
 
       return apply_filters( 'tc_show_fp', 0 != $tc_show_featured_pages && tc__f('__is_home') );
     }
@@ -322,7 +322,7 @@ if ( ! class_exists( 'TC_featured_pages' ) ) :
 
     function tc_show_featured_pages_img() {
       //gets  display img option
-      return apply_filters( 'tc_show_featured_pages_img', esc_attr( TC_utils::$inst->tc_opt( 'tc_show_featured_pages_img' ) ) );
+      return apply_filters( 'tc_show_featured_pages_img', esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_featured_pages_img' ) ) );
     }
 
   }//end of class

--- a/inc/parts/class-content-featured_pages.php
+++ b/inc/parts/class-content-featured_pages.php
@@ -128,7 +128,7 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
       <?php
       $html = ob_get_contents();
       if ($html) ob_end_clean();
-      echo apply_filters( 'czr_fn_fp_block_display' , $html, $args );
+      echo apply_filters( 'tc_fp_block_display' , $html, $args );
 	   }
 
 
@@ -290,7 +290,7 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
           <?php
           $html = ob_get_contents();
           if ($html) ob_end_clean();
-          return apply_filters( 'czr_fn_fp_single_display' , $html, $fp_single_id, $show_img, $fp_img, $featured_page_link, $featured_page_title, $text, $featured_page_id );
+          return apply_filters( 'tc_fp_single_display' , $html, $fp_single_id, $show_img, $fp_img, $featured_page_link, $featured_page_title, $text, $featured_page_id );
       }//end of function
 
 

--- a/inc/parts/class-content-featured_pages.php
+++ b/inc/parts/class-content-featured_pages.php
@@ -16,8 +16,8 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
     static $instance;
     function __construct () {
         self::$instance =& $this;
-        add_action( '__before_main_container'     , array( $this , 'czr_fp_block_display'), 10 );
-        add_action( '__after_fp'                  , array( $this , 'czr_maybe_display_dismiss_notice'));
+        add_action( '__before_main_container'     , array( $this , 'czr_fn_fp_block_display'), 10 );
+        add_action( '__after_fp'                  , array( $this , 'czr_fn_maybe_display_dismiss_notice'));
     }
 
 
@@ -29,11 +29,11 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
     * hook : __after_fp
     * @since v3.4+
     */
-    function czr_maybe_display_dismiss_notice() {
-      if ( ! CZR_placeholders::czr_is_fp_notice_on() )
+    function czr_fn_maybe_display_dismiss_notice() {
+      if ( ! CZR_placeholders::czr_fn_is_fp_notice_on() )
         return;
 
-      $_customizer_lnk = apply_filters( 'tc_fp_notice_customizer_url', CZR_utils::czr_get_customizer_url( array( 'control' => 'czr_show_featured_pages', 'section' => 'frontpage_sec') ) );
+      $_customizer_lnk = apply_filters( 'tc_fp_notice_customizer_url', CZR_utils::czr_fn_get_customizer_url( array( 'control' => 'czr_fn_show_featured_pages', 'section' => 'frontpage_sec') ) );
 
       ?>
       <div class="tc-placeholder-wrap tc-fp-notice">
@@ -64,12 +64,12 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
   	* @package Customizr
   	* @since Customizr 3.0
   	*/
-    function czr_fp_block_display() {
+    function czr_fn_fp_block_display() {
 
-      if ( ! $this -> czr_show_featured_pages()  )
+      if ( ! $this -> czr_fn_show_featured_pages()  )
         return;
 
-      $tc_show_featured_pages_img     = $this -> czr_show_featured_pages_img();
+      $tc_show_featured_pages_img     = $this -> czr_fn_show_featured_pages_img();
 
   		//gets the featured pages array and sets the fp layout
   		$fp_ids                         = apply_filters( 'tc_featured_pages_ids' , CZR_init::$instance -> fp_ids);
@@ -110,7 +110,7 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
                                   ) : '',
                     $span_value,
                     $fp_ids[$i - 1],
-                    $this -> czr_fp_single_display( $fp_ids[$i - 1] , $tc_show_featured_pages_img ),
+                    $this -> czr_fn_fp_single_display( $fp_ids[$i - 1] , $tc_show_featured_pages_img ),
                     ( $j == $fp_per_row || $i == $fp_nb ) ? '</div>' : ''
                 );
           //set $j back to start value if reach $fp_per_row
@@ -123,12 +123,12 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
 
 			</div><!-- .container -->
 
-      <?php  echo ! czr__f( '__is_home_empty') ? apply_filters( 'tc_after_fp_separator', '<hr class="featurette-divider '.current_filter().'">' ) : ''; ?>
+      <?php  echo ! czr_fn__f( '__is_home_empty') ? apply_filters( 'tc_after_fp_separator', '<hr class="featurette-divider '.current_filter().'">' ) : ''; ?>
 
       <?php
       $html = ob_get_contents();
       if ($html) ob_end_clean();
-      echo apply_filters( 'czr_fp_block_display' , $html, $args );
+      echo apply_filters( 'czr_fn_fp_block_display' , $html, $args );
 	   }
 
 
@@ -139,15 +139,15 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
       *******************************/
 	   /**
       * The template displaying one single featured page
-      * fired in : czr_fp_block_display()
+      * fired in : czr_fn_fp_block_display()
       *
       * @package Customizr
       * @since Customizr 3.0
       * @param area are defined in featured-pages templates,show_img is a customizer option
       * @todo better area definition : dynamic
       */
-      function czr_fp_single_display( $fp_single_id,$show_img) {
-        $_skin_color                        = CZR_utils::$inst -> czr_get_skin_color();
+      function czr_fn_fp_single_display( $fp_single_id,$show_img) {
+        $_skin_color                        = CZR_utils::$inst -> czr_fn_get_skin_color();
         $fp_holder_img                      = apply_filters (
           'tc_fp_holder_img' ,
           sprintf('<img class="tc-holder-img" data-src="holder.js/270x250/%1$s:%2$s" data-no-retina alt="Holder Thumbnail" style="width:270px;height:250px;"/>',
@@ -158,17 +158,17 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
         $featured_page_id                   = 0;
 
         //if fps are not set
-        if ( null == CZR_utils::$inst->czr_opt( 'tc_featured_page_'.$fp_single_id ) || ! CZR_utils::$inst->czr_opt( 'tc_featured_page_'.$fp_single_id ) ) {
+        if ( null == CZR_utils::$inst->czr_fn_opt( 'tc_featured_page_'.$fp_single_id ) || ! CZR_utils::$inst->czr_fn_opt( 'tc_featured_page_'.$fp_single_id ) ) {
             //admin link if user logged in
             $featured_page_link             = '';
             $customizr_link                 = '';
-            if ( ! CZR___::$instance -> czr_is_customizing() && is_user_logged_in() && current_user_can('edit_theme_options') ) {
+            if ( ! CZR___::$instance -> czr_fn_is_customizing() && is_user_logged_in() && current_user_can('edit_theme_options') ) {
               $customizr_link              = sprintf( '<a href="%1$s" title="%2$s">%3$s</a>',
-                CZR_utils::czr_get_customizer_url( array( 'control' => 'tc_featured_text_'.$fp_single_id, 'section' => 'frontpage_sec') ),
+                CZR_utils::czr_fn_get_customizer_url( array( 'control' => 'tc_featured_text_'.$fp_single_id, 'section' => 'frontpage_sec') ),
                 __( 'Customizer screen' , 'customizr' ),
                 __( 'Edit now.' , 'customizr' )
               );
-              $featured_page_link          = apply_filters( 'tc_fp_link_url', CZR_utils::czr_get_customizer_url( array( 'control' => 'tc_featured_page_'.$fp_single_id, 'section' => 'frontpage_sec') ) );
+              $featured_page_link          = apply_filters( 'tc_fp_link_url', CZR_utils::czr_fn_get_customizer_url( array( 'control' => 'tc_featured_page_'.$fp_single_id, 'section' => 'frontpage_sec') ) );
             }
 
             //rendering
@@ -188,7 +188,7 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
         }
 
         else {
-            $featured_page_id               = apply_filters( 'tc_fp_id', esc_attr( CZR_utils::$inst->czr_opt( 'tc_featured_page_'.$fp_single_id) ), $fp_single_id );
+            $featured_page_id               = apply_filters( 'tc_fp_id', esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_featured_page_'.$fp_single_id) ), $fp_single_id );
 
             $featured_page_link             = apply_filters( 'tc_fp_link_url', get_permalink( $featured_page_id ), $fp_single_id );
 
@@ -197,14 +197,14 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
             $edit_enabled                   = false;
             //when are we displaying the edit link?
             //never display when customizing
-            if ( ! CZR___::$instance -> czr_is_customizing() ) {
+            if ( ! CZR___::$instance -> czr_fn_is_customizing() ) {
               $edit_enabled                 = ( (is_user_logged_in()) && current_user_can('edit_pages') && is_page( $featured_page_id ) ) ? true : $edit_enabled;
               $edit_enabled                 = ( (is_user_logged_in()) && current_user_can('edit_post' , $featured_page_id ) && ! is_page( $featured_page_id ) ) ? true : $edit_enabled;
             }
 
             $edit_enabled                   = apply_filters( 'tc_edit_in_fp_title', $edit_enabled );
 
-            $featured_text                  = apply_filters( 'tc_fp_text', CZR_utils::$inst->czr_opt( 'tc_featured_text_'.$fp_single_id ), $fp_single_id, $featured_page_id );
+            $featured_text                  = apply_filters( 'tc_fp_text', CZR_utils::$inst->czr_fn_opt( 'tc_featured_text_'.$fp_single_id ), $fp_single_id, $featured_page_id );
             $featured_text                  = apply_filters( 'tc_fp_text_sanitize', strip_tags( html_entity_decode( $featured_text ) ), $fp_single_id, $featured_page_id );
 
             //get the page/post object
@@ -223,7 +223,7 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
             //allow user to specify a custom image id
             $fp_custom_img_id               = apply_filters( 'fp_img_id', null , $fp_single_id , $featured_page_id );
 
-            $fp_img = $this -> czr_get_fp_img( $fp_img_size, $featured_page_id, $fp_custom_img_id);
+            $fp_img = $this -> czr_fn_get_fp_img( $fp_img_size, $featured_page_id, $fp_custom_img_id);
             $fp_img = $fp_img ? $fp_img : $fp_holder_img;
 
             $fp_img                 = apply_filters ('fp_img_src' , $fp_img , $fp_single_id , $featured_page_id );
@@ -269,9 +269,9 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
               echo apply_filters( 'tc_fp_text_block' , $tc_fp_text_block , $fp_single_id , $text, $featured_page_id);
 
               //button block
-              $tc_fp_button_text = apply_filters( 'tc_fp_button_text' , esc_attr( CZR_utils::$inst->czr_opt( 'tc_featured_page_button_text') ) , $fp_single_id );
+              $tc_fp_button_text = apply_filters( 'tc_fp_button_text' , esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_featured_page_button_text') ) , $fp_single_id );
 
-              if ( $tc_fp_button_text || CZR___::$instance -> czr_is_customizing() ){
+              if ( $tc_fp_button_text || CZR___::$instance -> czr_fn_is_customizing() ){
                 $tc_fp_button_class = apply_filters( 'tc_fp_button_class' , 'btn btn-primary fp-button', $fp_single_id );
                 $tc_fp_button_class = $tc_fp_button_text ? $tc_fp_button_class : $tc_fp_button_class . ' hidden';
                 $tc_fp_button_block = sprintf('<a class="%1$s" href="%2$s" title="%3$s">%4$s</a>',
@@ -290,7 +290,7 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
           <?php
           $html = ob_get_contents();
           if ($html) ob_end_clean();
-          return apply_filters( 'czr_fp_single_display' , $html, $fp_single_id, $show_img, $fp_img, $featured_page_link, $featured_page_title, $text, $featured_page_id );
+          return apply_filters( 'czr_fn_fp_single_display' , $html, $fp_single_id, $show_img, $fp_img, $featured_page_link, $featured_page_title, $text, $featured_page_id );
       }//end of function
 
 
@@ -298,10 +298,10 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
     /******************************
     * HELPERS
     *******************************/
-    function czr_get_fp_img( $fp_img_size, $featured_page_id, $fp_custom_img_id ){
+    function czr_fn_get_fp_img( $fp_img_size, $featured_page_id, $fp_custom_img_id ){
       //try to get "tc_thumb" , "tc_thumb_height" , "tc_thumb_width"
-      //czr_get_thumbnail_model( $requested_size = null, $_post_id = null , $_thumb_id = null )
-      $_fp_img_model = CZR_post_thumbnails::$instance -> czr_get_thumbnail_model( $fp_img_size, $featured_page_id, $fp_custom_img_id );
+      //czr_fn_get_thumbnail_model( $requested_size = null, $_post_id = null , $_thumb_id = null )
+      $_fp_img_model = CZR_post_thumbnails::$instance -> czr_fn_get_thumbnail_model( $fp_img_size, $featured_page_id, $fp_custom_img_id );
 
       //finally we define a default holder if no thumbnail found or page is protected
       if ( isset( $_fp_img_model["tc_thumb"]) && ! empty( $_fp_img_model["tc_thumb"] ) && ! post_password_required( $featured_page_id ) )
@@ -313,17 +313,17 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
     }
 
 
-    function czr_show_featured_pages() {
+    function czr_fn_show_featured_pages() {
       //gets display fp option
-      $tc_show_featured_pages 	      = esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_featured_pages' ) );
+      $tc_show_featured_pages 	      = esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_featured_pages' ) );
 
-      return apply_filters( 'tc_show_fp', 0 != $tc_show_featured_pages && czr__f('__is_home') );
+      return apply_filters( 'tc_show_fp', 0 != $tc_show_featured_pages && czr_fn__f('__is_home') );
     }
 
 
-    function czr_show_featured_pages_img() {
+    function czr_fn_show_featured_pages_img() {
       //gets  display img option
-      return apply_filters( 'tc_show_featured_pages_img', esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_featured_pages_img' ) ) );
+      return apply_filters( 'tc_show_featured_pages_img', esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_featured_pages_img' ) ) );
     }
 
   }//end of class

--- a/inc/parts/class-content-featured_pages.php
+++ b/inc/parts/class-content-featured_pages.php
@@ -16,8 +16,8 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
     static $instance;
     function __construct () {
         self::$instance =& $this;
-        add_action( '__before_main_container'     , array( $this , 'tc_fp_block_display'), 10 );
-        add_action( '__after_fp'                  , array( $this , 'tc_maybe_display_dismiss_notice'));
+        add_action( '__before_main_container'     , array( $this , 'czr_fp_block_display'), 10 );
+        add_action( '__after_fp'                  , array( $this , 'czr_maybe_display_dismiss_notice'));
     }
 
 
@@ -33,7 +33,7 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
       if ( ! CZR_placeholders::czr_is_fp_notice_on() )
         return;
 
-      $_customizer_lnk = apply_filters( 'tc_fp_notice_customizer_url', CZR_utils::czr_get_customizer_url( array( 'control' => 'tc_show_featured_pages', 'section' => 'frontpage_sec') ) );
+      $_customizer_lnk = apply_filters( 'tc_fp_notice_customizer_url', CZR_utils::czr_get_customizer_url( array( 'control' => 'czr_show_featured_pages', 'section' => 'frontpage_sec') ) );
 
       ?>
       <div class="tc-placeholder-wrap tc-fp-notice">
@@ -65,6 +65,7 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
   	* @since Customizr 3.0
   	*/
     function czr_fp_block_display() {
+
       if ( ! $this -> czr_show_featured_pages()  )
         return;
 
@@ -127,7 +128,7 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
       <?php
       $html = ob_get_contents();
       if ($html) ob_end_clean();
-      echo apply_filters( 'tc_fp_block_display' , $html, $args );
+      echo apply_filters( 'czr_fp_block_display' , $html, $args );
 	   }
 
 
@@ -289,7 +290,7 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
           <?php
           $html = ob_get_contents();
           if ($html) ob_end_clean();
-          return apply_filters( 'tc_fp_single_display' , $html, $fp_single_id, $show_img, $fp_img, $featured_page_link, $featured_page_title, $text, $featured_page_id );
+          return apply_filters( 'czr_fp_single_display' , $html, $fp_single_id, $show_img, $fp_img, $featured_page_link, $featured_page_title, $text, $featured_page_id );
       }//end of function
 
 

--- a/inc/parts/class-content-featured_pages.php
+++ b/inc/parts/class-content-featured_pages.php
@@ -29,7 +29,7 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
     * hook : __after_fp
     * @since v3.4+
     */
-    function tc_maybe_display_dismiss_notice() {
+    function czr_maybe_display_dismiss_notice() {
       if ( ! CZR_placeholders::tc_is_fp_notice_on() )
         return;
 
@@ -64,7 +64,7 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
   	* @package Customizr
   	* @since Customizr 3.0
   	*/
-    function tc_fp_block_display() {
+    function czr_fp_block_display() {
       if ( ! $this -> tc_show_featured_pages()  )
         return;
 
@@ -145,7 +145,7 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
       * @param area are defined in featured-pages templates,show_img is a customizer option
       * @todo better area definition : dynamic
       */
-      function tc_fp_single_display( $fp_single_id,$show_img) {
+      function czr_fp_single_display( $fp_single_id,$show_img) {
         $_skin_color                        = CZR_utils::$inst -> tc_get_skin_color();
         $fp_holder_img                      = apply_filters (
           'tc_fp_holder_img' ,
@@ -297,7 +297,7 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
     /******************************
     * HELPERS
     *******************************/
-    function tc_get_fp_img( $fp_img_size, $featured_page_id, $fp_custom_img_id ){
+    function czr_get_fp_img( $fp_img_size, $featured_page_id, $fp_custom_img_id ){
       //try to get "tc_thumb" , "tc_thumb_height" , "tc_thumb_width"
       //tc_get_thumbnail_model( $requested_size = null, $_post_id = null , $_thumb_id = null )
       $_fp_img_model = CZR_post_thumbnails::$instance -> tc_get_thumbnail_model( $fp_img_size, $featured_page_id, $fp_custom_img_id );
@@ -312,7 +312,7 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
     }
 
 
-    function tc_show_featured_pages() {
+    function czr_show_featured_pages() {
       //gets display fp option
       $tc_show_featured_pages 	      = esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_featured_pages' ) );
 
@@ -320,7 +320,7 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
     }
 
 
-    function tc_show_featured_pages_img() {
+    function czr_show_featured_pages_img() {
       //gets  display img option
       return apply_filters( 'tc_show_featured_pages_img', esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_featured_pages_img' ) ) );
     }

--- a/inc/parts/class-content-gallery.php
+++ b/inc/parts/class-content-gallery.php
@@ -17,9 +17,9 @@ if ( ! class_exists( 'CZR_gallery' ) ) :
       function __construct () {
         self::$instance =& $this;
 
-        add_filter ( 'tc_article_container_class' , array( $this, 'tc_add_gallery_class' ), 20 );
+        add_filter ( 'tc_article_container_class' , array( $this, 'czr_add_gallery_class' ), 20 );
         //adds a filter for link markup (allow lightbox)
-        add_filter ( 'wp_get_attachment_link'     , array( $this, 'tc_modify_attachment_link') , 20, 6 );
+        add_filter ( 'wp_get_attachment_link'     , array( $this, 'czr_modify_attachment_link') , 20, 6 );
       }
 
       /**

--- a/inc/parts/class-content-gallery.php
+++ b/inc/parts/class-content-gallery.php
@@ -31,7 +31,7 @@ if ( ! class_exists( 'CZR_gallery' ) ) :
        *
        */
       function czr_add_gallery_class( $_classes ){
-        if (  $this -> tc_is_gallery_enabled() && apply_filters( 'tc_gallery_style', esc_attr( CZR_utils::$inst -> tc_opt( 'tc_gallery_style' ) ) ) )
+        if (  $this -> czr_is_gallery_enabled() && apply_filters( 'tc_gallery_style', esc_attr( CZR_utils::$inst -> czr_opt( 'tc_gallery_style' ) ) ) )
           array_push($_classes, 'tc-gallery-style');
         return $_classes;
       }
@@ -47,10 +47,10 @@ if ( ! class_exists( 'CZR_gallery' ) ) :
        */
       function czr_modify_attachment_link( $markup, $id, $size, $permalink, $icon, $text ) {
 
-        if ( ! $this -> tc_is_gallery_enabled() )
+        if ( ! $this -> czr_is_gallery_enabled() )
           return $markup;
 
-        $tc_gallery_fancybox = apply_filters( 'tc_gallery_fancybox', esc_attr( CZR_utils::$inst -> tc_opt( 'tc_gallery_fancybox' ) ) , $id );
+        $tc_gallery_fancybox = apply_filters( 'tc_gallery_fancybox', esc_attr( CZR_utils::$inst -> czr_opt( 'tc_gallery_fancybox' ) ) , $id );
 
         if ( $tc_gallery_fancybox == 1 && $permalink == false ) //add the filter only if link to the attachment file/image
           {
@@ -85,7 +85,7 @@ if ( ! class_exists( 'CZR_gallery' ) ) :
        * HELPERS
        */
       function czr_is_gallery_enabled(){
-        return apply_filters('tc_enable_gallery', esc_attr( CZR_utils::$inst -> tc_opt('tc_enable_gallery') ) );
+        return apply_filters('tc_enable_gallery', esc_attr( CZR_utils::$inst -> czr_opt('tc_enable_gallery') ) );
       }
   }//end of class
 endif;

--- a/inc/parts/class-content-gallery.php
+++ b/inc/parts/class-content-gallery.php
@@ -30,7 +30,7 @@ if ( ! class_exists( 'CZR_gallery' ) ) :
        * @since Customizr 3.3.21
        *
        */
-      function tc_add_gallery_class( $_classes ){
+      function czr_add_gallery_class( $_classes ){
         if (  $this -> tc_is_gallery_enabled() && apply_filters( 'tc_gallery_style', esc_attr( CZR_utils::$inst -> tc_opt( 'tc_gallery_style' ) ) ) )
           array_push($_classes, 'tc-gallery-style');
         return $_classes;
@@ -45,7 +45,7 @@ if ( ! class_exists( 'CZR_gallery' ) ) :
        * @since Customizr 3.0.5
        *
        */
-      function tc_modify_attachment_link( $markup, $id, $size, $permalink, $icon, $text ) {
+      function czr_modify_attachment_link( $markup, $id, $size, $permalink, $icon, $text ) {
 
         if ( ! $this -> tc_is_gallery_enabled() )
           return $markup;
@@ -84,7 +84,7 @@ if ( ! class_exists( 'CZR_gallery' ) ) :
       /*
        * HELPERS
        */
-      function tc_is_gallery_enabled(){
+      function czr_is_gallery_enabled(){
         return apply_filters('tc_enable_gallery', esc_attr( CZR_utils::$inst -> tc_opt('tc_enable_gallery') ) );
       }
   }//end of class

--- a/inc/parts/class-content-gallery.php
+++ b/inc/parts/class-content-gallery.php
@@ -11,8 +11,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_gallery' ) ) :
-  class TC_gallery {
+if ( ! class_exists( 'CZR_gallery' ) ) :
+  class CZR_gallery {
       static $instance;
       function __construct () {
         self::$instance =& $this;
@@ -31,7 +31,7 @@ if ( ! class_exists( 'TC_gallery' ) ) :
        *
        */
       function tc_add_gallery_class( $_classes ){
-        if (  $this -> tc_is_gallery_enabled() && apply_filters( 'tc_gallery_style', esc_attr( TC_utils::$inst -> tc_opt( 'tc_gallery_style' ) ) ) )
+        if (  $this -> tc_is_gallery_enabled() && apply_filters( 'tc_gallery_style', esc_attr( CZR_utils::$inst -> tc_opt( 'tc_gallery_style' ) ) ) )
           array_push($_classes, 'tc-gallery-style');
         return $_classes;
       }
@@ -50,7 +50,7 @@ if ( ! class_exists( 'TC_gallery' ) ) :
         if ( ! $this -> tc_is_gallery_enabled() )
           return $markup;
 
-        $tc_gallery_fancybox = apply_filters( 'tc_gallery_fancybox', esc_attr( TC_utils::$inst -> tc_opt( 'tc_gallery_fancybox' ) ) , $id );
+        $tc_gallery_fancybox = apply_filters( 'tc_gallery_fancybox', esc_attr( CZR_utils::$inst -> tc_opt( 'tc_gallery_fancybox' ) ) , $id );
 
         if ( $tc_gallery_fancybox == 1 && $permalink == false ) //add the filter only if link to the attachment file/image
           {
@@ -85,7 +85,7 @@ if ( ! class_exists( 'TC_gallery' ) ) :
        * HELPERS
        */
       function tc_is_gallery_enabled(){
-        return apply_filters('tc_enable_gallery', esc_attr( TC_utils::$inst -> tc_opt('tc_enable_gallery') ) );
+        return apply_filters('tc_enable_gallery', esc_attr( CZR_utils::$inst -> tc_opt('tc_enable_gallery') ) );
       }
   }//end of class
 endif;

--- a/inc/parts/class-content-gallery.php
+++ b/inc/parts/class-content-gallery.php
@@ -17,9 +17,9 @@ if ( ! class_exists( 'CZR_gallery' ) ) :
       function __construct () {
         self::$instance =& $this;
 
-        add_filter ( 'tc_article_container_class' , array( $this, 'czr_add_gallery_class' ), 20 );
+        add_filter ( 'tc_article_container_class' , array( $this, 'czr_fn_add_gallery_class' ), 20 );
         //adds a filter for link markup (allow lightbox)
-        add_filter ( 'wp_get_attachment_link'     , array( $this, 'czr_modify_attachment_link') , 20, 6 );
+        add_filter ( 'wp_get_attachment_link'     , array( $this, 'czr_fn_modify_attachment_link') , 20, 6 );
       }
 
       /**
@@ -30,8 +30,8 @@ if ( ! class_exists( 'CZR_gallery' ) ) :
        * @since Customizr 3.3.21
        *
        */
-      function czr_add_gallery_class( $_classes ){
-        if (  $this -> czr_is_gallery_enabled() && apply_filters( 'tc_gallery_style', esc_attr( CZR_utils::$inst -> czr_opt( 'tc_gallery_style' ) ) ) )
+      function czr_fn_add_gallery_class( $_classes ){
+        if (  $this -> czr_fn_is_gallery_enabled() && apply_filters( 'tc_gallery_style', esc_attr( CZR_utils::$inst -> czr_fn_opt( 'tc_gallery_style' ) ) ) )
           array_push($_classes, 'tc-gallery-style');
         return $_classes;
       }
@@ -45,12 +45,12 @@ if ( ! class_exists( 'CZR_gallery' ) ) :
        * @since Customizr 3.0.5
        *
        */
-      function czr_modify_attachment_link( $markup, $id, $size, $permalink, $icon, $text ) {
+      function czr_fn_modify_attachment_link( $markup, $id, $size, $permalink, $icon, $text ) {
 
-        if ( ! $this -> czr_is_gallery_enabled() )
+        if ( ! $this -> czr_fn_is_gallery_enabled() )
           return $markup;
 
-        $tc_gallery_fancybox = apply_filters( 'tc_gallery_fancybox', esc_attr( CZR_utils::$inst -> czr_opt( 'tc_gallery_fancybox' ) ) , $id );
+        $tc_gallery_fancybox = apply_filters( 'tc_gallery_fancybox', esc_attr( CZR_utils::$inst -> czr_fn_opt( 'tc_gallery_fancybox' ) ) , $id );
 
         if ( $tc_gallery_fancybox == 1 && $permalink == false ) //add the filter only if link to the attachment file/image
           {
@@ -84,8 +84,8 @@ if ( ! class_exists( 'CZR_gallery' ) ) :
       /*
        * HELPERS
        */
-      function czr_is_gallery_enabled(){
-        return apply_filters('tc_enable_gallery', esc_attr( CZR_utils::$inst -> czr_opt('tc_enable_gallery') ) );
+      function czr_fn_is_gallery_enabled(){
+        return apply_filters('tc_enable_gallery', esc_attr( CZR_utils::$inst -> czr_fn_opt('tc_enable_gallery') ) );
       }
   }//end of class
 endif;

--- a/inc/parts/class-content-headings.php
+++ b/inc/parts/class-content-headings.php
@@ -17,11 +17,11 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       function __construct () {
         self::$instance =& $this;
         //set actions and filters for posts and page headings
-        add_action( 'template_redirect'                            , array( $this , 'tc_set_post_page_heading_hooks') );
+        add_action( 'template_redirect'                            , array( $this , 'czr_set_post_page_heading_hooks') );
         //set actions and filters for archives headings
-        add_action( 'template_redirect'                            , array( $this , 'tc_set_archives_heading_hooks') );
+        add_action( 'template_redirect'                            , array( $this , 'czr_set_archives_heading_hooks') );
         //Set headings user options
-        add_action( 'template_redirect'                            , array( $this , 'tc_set_headings_options') );
+        add_action( 'template_redirect'                            , array( $this , 'czr_set_headings_options') );
       }
 
 
@@ -43,12 +43,12 @@ if ( ! class_exists( 'CZR_headings' ) ) :
           return;
 
         //Headings for archives, authors, search, 404
-        add_action ( '__before_loop'                  , array( $this , 'tc_render_headings_view' ) );
+        add_action ( '__before_loop'                  , array( $this , 'czr_render_headings_view' ) );
         //Set archive icon with customizer options (since 3.2.0)
-        add_filter ( 'tc_archive_icon'                , array( $this , 'tc_set_archive_icon' ) );
+        add_filter ( 'tc_archive_icon'                , array( $this , 'czr_set_archive_icon' ) );
 
-        add_filter( 'tc_archive_header_class'         , array( $this , 'tc_archive_title_and_class_callback'), 10, 2 );
-        add_filter( 'tc_headings_archive_html'        , array( $this , 'tc_archive_title_and_class_callback'), 10, 1 );
+        add_filter( 'tc_archive_header_class'         , array( $this , 'czr_archive_title_and_class_callback'), 10, 2 );
+        add_filter( 'tc_headings_archive_html'        , array( $this , 'czr_archive_title_and_class_callback'), 10, 1 );
         global $wp_query;
         if ( czr__f('__is_home') )
           add_filter( 'tc_archive_headings_separator' , '__return_false' );
@@ -70,20 +70,20 @@ if ( ! class_exists( 'CZR_headings' ) ) :
           return;
 
         //Set single post/page icon with customizer options (since 3.2.0)
-        add_filter ( 'tc_content_title_icon'    , array( $this , 'tc_set_post_page_icon' ) );
+        add_filter ( 'tc_content_title_icon'    , array( $this , 'czr_set_post_page_icon' ) );
         //Prepare the headings for post, page, attachment
-        add_action ( '__before_content'         , array( $this , 'tc_render_headings_view' ) );
+        add_action ( '__before_content'         , array( $this , 'czr_render_headings_view' ) );
         //Populate heading with default content
-        add_filter ( 'tc_headings_content_html' , array( $this , 'tc_post_page_title_callback'), 10, 2 );
+        add_filter ( 'tc_headings_content_html' , array( $this , 'czr_post_page_title_callback'), 10, 2 );
         //Create the Customizr title
-        add_filter( 'tc_the_title'              , array( $this , 'tc_content_heading_title' ) , 0 );
+        add_filter( 'tc_the_title'              , array( $this , 'czr_content_heading_title' ) , 0 );
         //Add edit link
-        add_filter( 'tc_the_title'              , array( $this , 'tc_add_edit_link_after_title' ), 2 );
+        add_filter( 'tc_the_title'              , array( $this , 'czr_add_edit_link_after_title' ), 2 );
         //Set user defined archive titles
-        add_filter( 'tc_category_archive_title' , array( $this , 'tc_set_archive_custom_title' ) );
-        add_filter( 'tc_tag_archive_title'      , array( $this , 'tc_set_archive_custom_title' ) );
-        add_filter( 'tc_search_results_title'   , array( $this , 'tc_set_archive_custom_title' ) );
-        add_filter( 'tc_author_archive_title'   , array( $this , 'tc_set_archive_custom_title' ) );
+        add_filter( 'tc_category_archive_title' , array( $this , 'czr_set_archive_custom_title' ) );
+        add_filter( 'tc_tag_archive_title'      , array( $this , 'czr_set_archive_custom_title' ) );
+        add_filter( 'tc_search_results_title'   , array( $this , 'czr_set_archive_custom_title' ) );
+        add_filter( 'tc_author_archive_title'   , array( $this , 'czr_set_archive_custom_title' ) );
 
 
         //SOME DEFAULT OPTIONS
@@ -92,7 +92,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
           add_filter( 'tc_content_headings_separator' , '__return_false' );
 
         //No headings for some post formats
-        add_filter( 'tc_headings_content_html'  , array( $this, 'tc_post_formats_heading') , 100 );
+        add_filter( 'tc_headings_content_html'  , array( $this, 'czr_post_formats_heading') , 100 );
 
       }
 
@@ -124,7 +124,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
         <?php
         $html = ob_get_contents();
         if ($html) ob_end_clean();
-        echo apply_filters( 'tc_render_headings_view', $html );
+        echo apply_filters( 'czr_render_headings_view', $html );
       }//end of function
 
 
@@ -452,7 +452,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
           return;
 
         //Add update status next to the title (@since 3.2.6)
-        add_filter( 'tc_the_title'                  , array( $this , 'tc_add_update_notice_in_title'), 20);
+        add_filter( 'tc_the_title'                  , array( $this , 'czr_add_update_notice_in_title'), 20);
       }
 
 

--- a/inc/parts/class-content-headings.php
+++ b/inc/parts/class-content-headings.php
@@ -39,7 +39,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       function czr_set_archives_heading_hooks() {
         //is there anything to render in the current context
         //by default don't display the Customizr title in feeds
-        if ( apply_filters('tc_display_customizr_headings',  ! $this -> tc_archive_title_and_class_callback() || is_feed() ) )
+        if ( apply_filters('tc_display_customizr_headings',  ! $this -> czr_archive_title_and_class_callback() || is_feed() ) )
           return;
 
         //Headings for archives, authors, search, 404
@@ -50,7 +50,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
         add_filter( 'tc_archive_header_class'         , array( $this , 'tc_archive_title_and_class_callback'), 10, 2 );
         add_filter( 'tc_headings_archive_html'        , array( $this , 'tc_archive_title_and_class_callback'), 10, 1 );
         global $wp_query;
-        if ( tc__f('__is_home') )
+        if ( czr__f('__is_home') )
           add_filter( 'tc_archive_headings_separator' , '__return_false' );
       }
 
@@ -201,12 +201,12 @@ if ( ! class_exists( 'CZR_headings' ) ) :
         if ( ! in_the_loop() )
           return $_title;
 
-        if ( ! apply_filters( 'tc_edit_in_title', $this -> tc_is_edit_enabled() ) )
+        if ( ! apply_filters( 'tc_edit_in_title', $this -> czr_is_edit_enabled() ) )
           return $_title;
 
         return sprintf('%1$s %2$s',
           $_title,
-          $this -> tc_render_edit_link_view( $_echo = false )
+          $this -> czr_render_edit_link_view( $_echo = false )
         );
 
       }
@@ -220,7 +220,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       */
       public function czr_is_edit_enabled() {
         //never display when customizing
-        if ( CZR___::$instance -> tc_is_customizing() )
+        if ( CZR___::$instance -> czr_is_customizing() )
           return false;
         //when are we displaying the edit link?
         $edit_enabled = ( (is_user_logged_in()) && is_page() && current_user_can('edit_pages') ) ? true : false;
@@ -255,13 +255,13 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       */
       function czr_set_post_page_icon( $_bool ) {
           if ( is_page() )
-            $_bool = ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_page_title_icon' ) ) ) ? false : $_bool;
+            $_bool = ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_page_title_icon' ) ) ) ? false : $_bool;
           if ( is_single() && ! is_page() )
-            $_bool = ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_post_title_icon' ) ) ) ? false : $_bool;
+            $_bool = ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_post_title_icon' ) ) ) ? false : $_bool;
           if ( ! is_single() )
-            $_bool = ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_post_list_title_icon' ) ) ) ? false : $_bool;
+            $_bool = ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_post_list_title_icon' ) ) ) ? false : $_bool;
           //last condition
-          return ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_title_icon' ) ) ) ? false : $_bool;
+          return ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_title_icon' ) ) ) ? false : $_bool;
       }
 
 
@@ -274,9 +274,9 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @since Customizr 3.2.0
       */
       function czr_set_archive_icon( $_class ) {
-          $_class = ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_archive_title_icon' ) ) ) ? '' : $_class;
+          $_class = ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_archive_title_icon' ) ) ) ? '' : $_class;
           //last condition
-          return 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_title_icon' ) ) ? '' : $_class;
+          return 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_title_icon' ) ) ? '' : $_class;
       }
 
 
@@ -471,7 +471,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
               return $html;
 
           //Is the notice option enabled AND this post type eligible for updated notice ? (default is post)
-          if ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_metas_update_notice_in_title' ) ) || ! in_array( get_post_type(), apply_filters('tc_show_update_notice_for_post_types' , array( 'post') ) ) )
+          if ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_metas_update_notice_in_title' ) ) || ! in_array( get_post_type(), apply_filters('tc_show_update_notice_for_post_types' , array( 'post') ) ) )
               return $html;
 
           //php version check for DateTime
@@ -480,11 +480,11 @@ if ( ! class_exists( 'CZR_headings' ) ) :
             return $html;
 
           //get the user defined interval in days
-          $_interval = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_metas_update_notice_interval' ) );
+          $_interval = esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_metas_update_notice_interval' ) );
           $_interval = ( 0 != $_interval ) ? $_interval : 30;
 
           //Check if the last update is less than n days old. (replace n by your own value)
-          $has_recent_update = ( CZR_utils::$inst -> tc_post_has_update( true ) && CZR_utils::$inst -> tc_post_has_update( 'in_days') < $_interval ) ? true : false;
+          $has_recent_update = ( CZR_utils::$inst -> czr_post_has_update( true ) && CZR_utils::$inst -> czr_post_has_update( 'in_days') < $_interval ) ? true : false;
 
           if ( ! $has_recent_update )
               return $html;
@@ -494,8 +494,8 @@ if ( ! class_exists( 'CZR_headings' ) ) :
               'tc_update_notice_in_title',
               sprintf('%1$s &nbsp; <span class="tc-update-notice label %3$s">%2$s</span>',
                   $html,
-                  esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_metas_update_notice_text' ) ),
-                  esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_metas_update_notice_format' ) )
+                  esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_metas_update_notice_text' ) ),
+                  esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_metas_update_notice_format' ) )
               )
           );
       }
@@ -510,19 +510,19 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       function czr_set_archive_custom_title( $_title ) {
         switch ( current_filter() ) {
           case 'tc_category_archive_title' :
-            return esc_attr( CZR_utils::$inst->tc_opt( 'tc_cat_title' ) );
+            return esc_attr( CZR_utils::$inst->czr_opt( 'tc_cat_title' ) );
           break;
 
           case 'tc_tag_archive_title' :
-            return esc_attr( CZR_utils::$inst->tc_opt( 'tc_tag_title' ) );
+            return esc_attr( CZR_utils::$inst->czr_opt( 'tc_tag_title' ) );
           break;
 
           case 'tc_search_results_title' :
-            return esc_attr( CZR_utils::$inst->tc_opt( 'tc_search_title' ) );
+            return esc_attr( CZR_utils::$inst->czr_opt( 'tc_search_title' ) );
           break;
 
           case 'tc_author_archive_title' :
-            return esc_attr( CZR_utils::$inst->tc_opt( 'tc_author_title' ) );
+            return esc_attr( CZR_utils::$inst->czr_opt( 'tc_author_title' ) );
           break;
         }
         return $_title;

--- a/inc/parts/class-content-headings.php
+++ b/inc/parts/class-content-headings.php
@@ -36,7 +36,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.2.6
       */
-      function tc_set_archives_heading_hooks() {
+      function czr_set_archives_heading_hooks() {
         //is there anything to render in the current context
         //by default don't display the Customizr title in feeds
         if ( apply_filters('tc_display_customizr_headings',  ! $this -> tc_archive_title_and_class_callback() || is_feed() ) )
@@ -63,7 +63,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.2.6
       */
-      function tc_set_post_page_heading_hooks() {
+      function czr_set_post_page_heading_hooks() {
 
         //by default don't display the Customizr title of the front page and in feeds
         if ( apply_filters('tc_display_customizr_headings', ( is_front_page() && 'page' == get_option( 'show_on_front' ) ) ) || is_feed() )
@@ -108,7 +108,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.1.0
       */
-      function tc_render_headings_view() {
+      function czr_render_headings_view() {
         $_heading_type = in_the_loop() ? 'content' : 'archive';
         ob_start();
         ?>
@@ -142,7 +142,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.2.9
       */
-      function tc_post_formats_heading( $_html ) {
+      function czr_post_formats_heading( $_html ) {
         if( in_array( get_post_format(), apply_filters( 'tc_post_formats_with_no_heading', CZR_init::$instance -> post_formats_with_no_heading ) ) )
           return;
         return $_html;
@@ -156,7 +156,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.2.6
       */
-      function tc_post_page_title_callback( $_content = null , $_heading_type = null ) {
+      function czr_post_page_title_callback( $_content = null , $_heading_type = null ) {
         $_title = apply_filters( 'tc_title_text', get_the_title() );
         return sprintf('<%1$s class="entry-title %2$s">%3$s</%1$s>',
               apply_filters( 'tc_content_title_tag' , is_singular() ? 'h1' : 'h2' ),
@@ -172,7 +172,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.2.6
       */
-      function tc_content_heading_title( $_title ) {
+      function czr_content_heading_title( $_title ) {
         //Must be in the loop
         if ( ! in_the_loop() )
           return $_title;
@@ -196,7 +196,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.2.6
       */
-      function tc_add_edit_link_after_title( $_title ) {
+      function czr_add_edit_link_after_title( $_title ) {
         //Must be in the loop
         if ( ! in_the_loop() )
           return $_title;
@@ -218,7 +218,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.3+
       */
-      public function tc_is_edit_enabled() {
+      public function czr_is_edit_enabled() {
         //never display when customizing
         if ( CZR___::$instance -> tc_is_customizing() )
           return false;
@@ -235,7 +235,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.3+
       */
-      function tc_render_edit_link_view( $_echo = true ) {
+      function czr_render_edit_link_view( $_echo = true ) {
         $_view = sprintf('<span class="edit-link btn btn-inverse btn-mini"><a class="post-edit-link" href="%1$s" title="%2$s">%2$s</a></span>',
           get_edit_post_link(),
           __( 'Edit' , 'customizr' )
@@ -253,7 +253,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.2.0
       */
-      function tc_set_post_page_icon( $_bool ) {
+      function czr_set_post_page_icon( $_bool ) {
           if ( is_page() )
             $_bool = ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_page_title_icon' ) ) ) ? false : $_bool;
           if ( is_single() && ! is_page() )
@@ -273,7 +273,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.2.0
       */
-      function tc_set_archive_icon( $_class ) {
+      function czr_set_archive_icon( $_class ) {
           $_class = ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_archive_title_icon' ) ) ) ? '' : $_class;
           //last condition
           return 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_title_icon' ) ) ? '' : $_class;
@@ -290,7 +290,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.2.0
       */
-      function tc_archive_title_and_class_callback( $_title = null, $_return_class = false ) {
+      function czr_archive_title_and_class_callback( $_title = null, $_return_class = false ) {
         //declares variables to return
         $content          = false;
         $_header_class    = false;
@@ -446,7 +446,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.2.6
       */
-      function tc_set_headings_options() {
+      function czr_set_headings_options() {
         //by default don't display the Customizr title in feeds
         if ( apply_filters('tc_display_customizr_headings',  is_feed() ) )
           return;
@@ -465,7 +465,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.2.0
       */
-      function tc_add_update_notice_in_title($html) {
+      function czr_add_update_notice_in_title($html) {
           //First checks if we are in the loop and we are not displaying a page
           if ( ! in_the_loop() || is_page() )
               return $html;
@@ -507,7 +507,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @return string of user defined title
       * @since Customizr 3.3+
       */
-      function tc_set_archive_custom_title( $_title ) {
+      function czr_set_archive_custom_title( $_title ) {
         switch ( current_filter() ) {
           case 'tc_category_archive_title' :
             return esc_attr( CZR_utils::$inst->tc_opt( 'tc_cat_title' ) );

--- a/inc/parts/class-content-headings.php
+++ b/inc/parts/class-content-headings.php
@@ -124,7 +124,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
         <?php
         $html = ob_get_contents();
         if ($html) ob_end_clean();
-        echo apply_filters( 'czr_fn_render_headings_view', $html );
+        echo apply_filters( 'tc_render_headings_view', $html );
       }//end of function
 
 

--- a/inc/parts/class-content-headings.php
+++ b/inc/parts/class-content-headings.php
@@ -17,11 +17,11 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       function __construct () {
         self::$instance =& $this;
         //set actions and filters for posts and page headings
-        add_action( 'template_redirect'                            , array( $this , 'czr_set_post_page_heading_hooks') );
+        add_action( 'template_redirect'                            , array( $this , 'czr_fn_set_post_page_heading_hooks') );
         //set actions and filters for archives headings
-        add_action( 'template_redirect'                            , array( $this , 'czr_set_archives_heading_hooks') );
+        add_action( 'template_redirect'                            , array( $this , 'czr_fn_set_archives_heading_hooks') );
         //Set headings user options
-        add_action( 'template_redirect'                            , array( $this , 'czr_set_headings_options') );
+        add_action( 'template_redirect'                            , array( $this , 'czr_fn_set_headings_options') );
       }
 
 
@@ -36,21 +36,21 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.2.6
       */
-      function czr_set_archives_heading_hooks() {
+      function czr_fn_set_archives_heading_hooks() {
         //is there anything to render in the current context
         //by default don't display the Customizr title in feeds
-        if ( apply_filters('tc_display_customizr_headings',  ! $this -> czr_archive_title_and_class_callback() || is_feed() ) )
+        if ( apply_filters('tc_display_customizr_headings',  ! $this -> czr_fn_archive_title_and_class_callback() || is_feed() ) )
           return;
 
         //Headings for archives, authors, search, 404
-        add_action ( '__before_loop'                  , array( $this , 'czr_render_headings_view' ) );
+        add_action ( '__before_loop'                  , array( $this , 'czr_fn_render_headings_view' ) );
         //Set archive icon with customizer options (since 3.2.0)
-        add_filter ( 'tc_archive_icon'                , array( $this , 'czr_set_archive_icon' ) );
+        add_filter ( 'tc_archive_icon'                , array( $this , 'czr_fn_set_archive_icon' ) );
 
-        add_filter( 'tc_archive_header_class'         , array( $this , 'czr_archive_title_and_class_callback'), 10, 2 );
-        add_filter( 'tc_headings_archive_html'        , array( $this , 'czr_archive_title_and_class_callback'), 10, 1 );
+        add_filter( 'tc_archive_header_class'         , array( $this , 'czr_fn_archive_title_and_class_callback'), 10, 2 );
+        add_filter( 'tc_headings_archive_html'        , array( $this , 'czr_fn_archive_title_and_class_callback'), 10, 1 );
         global $wp_query;
-        if ( czr__f('__is_home') )
+        if ( czr_fn__f('__is_home') )
           add_filter( 'tc_archive_headings_separator' , '__return_false' );
       }
 
@@ -63,27 +63,27 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.2.6
       */
-      function czr_set_post_page_heading_hooks() {
+      function czr_fn_set_post_page_heading_hooks() {
 
         //by default don't display the Customizr title of the front page and in feeds
         if ( apply_filters('tc_display_customizr_headings', ( is_front_page() && 'page' == get_option( 'show_on_front' ) ) ) || is_feed() )
           return;
 
         //Set single post/page icon with customizer options (since 3.2.0)
-        add_filter ( 'tc_content_title_icon'    , array( $this , 'czr_set_post_page_icon' ) );
+        add_filter ( 'tc_content_title_icon'    , array( $this , 'czr_fn_set_post_page_icon' ) );
         //Prepare the headings for post, page, attachment
-        add_action ( '__before_content'         , array( $this , 'czr_render_headings_view' ) );
+        add_action ( '__before_content'         , array( $this , 'czr_fn_render_headings_view' ) );
         //Populate heading with default content
-        add_filter ( 'tc_headings_content_html' , array( $this , 'czr_post_page_title_callback'), 10, 2 );
+        add_filter ( 'tc_headings_content_html' , array( $this , 'czr_fn_post_page_title_callback'), 10, 2 );
         //Create the Customizr title
-        add_filter( 'tc_the_title'              , array( $this , 'czr_content_heading_title' ) , 0 );
+        add_filter( 'tc_the_title'              , array( $this , 'czr_fn_content_heading_title' ) , 0 );
         //Add edit link
-        add_filter( 'tc_the_title'              , array( $this , 'czr_add_edit_link_after_title' ), 2 );
+        add_filter( 'tc_the_title'              , array( $this , 'czr_fn_add_edit_link_after_title' ), 2 );
         //Set user defined archive titles
-        add_filter( 'tc_category_archive_title' , array( $this , 'czr_set_archive_custom_title' ) );
-        add_filter( 'tc_tag_archive_title'      , array( $this , 'czr_set_archive_custom_title' ) );
-        add_filter( 'tc_search_results_title'   , array( $this , 'czr_set_archive_custom_title' ) );
-        add_filter( 'tc_author_archive_title'   , array( $this , 'czr_set_archive_custom_title' ) );
+        add_filter( 'tc_category_archive_title' , array( $this , 'czr_fn_set_archive_custom_title' ) );
+        add_filter( 'tc_tag_archive_title'      , array( $this , 'czr_fn_set_archive_custom_title' ) );
+        add_filter( 'tc_search_results_title'   , array( $this , 'czr_fn_set_archive_custom_title' ) );
+        add_filter( 'tc_author_archive_title'   , array( $this , 'czr_fn_set_archive_custom_title' ) );
 
 
         //SOME DEFAULT OPTIONS
@@ -92,7 +92,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
           add_filter( 'tc_content_headings_separator' , '__return_false' );
 
         //No headings for some post formats
-        add_filter( 'tc_headings_content_html'  , array( $this, 'czr_post_formats_heading') , 100 );
+        add_filter( 'tc_headings_content_html'  , array( $this, 'czr_fn_post_formats_heading') , 100 );
 
       }
 
@@ -108,7 +108,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.1.0
       */
-      function czr_render_headings_view() {
+      function czr_fn_render_headings_view() {
         $_heading_type = in_the_loop() ? 'content' : 'archive';
         ob_start();
         ?>
@@ -124,7 +124,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
         <?php
         $html = ob_get_contents();
         if ($html) ob_end_clean();
-        echo apply_filters( 'czr_render_headings_view', $html );
+        echo apply_filters( 'czr_fn_render_headings_view', $html );
       }//end of function
 
 
@@ -142,7 +142,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.2.9
       */
-      function czr_post_formats_heading( $_html ) {
+      function czr_fn_post_formats_heading( $_html ) {
         if( in_array( get_post_format(), apply_filters( 'tc_post_formats_with_no_heading', CZR_init::$instance -> post_formats_with_no_heading ) ) )
           return;
         return $_html;
@@ -156,7 +156,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.2.6
       */
-      function czr_post_page_title_callback( $_content = null , $_heading_type = null ) {
+      function czr_fn_post_page_title_callback( $_content = null , $_heading_type = null ) {
         $_title = apply_filters( 'tc_title_text', get_the_title() );
         return sprintf('<%1$s class="entry-title %2$s">%3$s</%1$s>',
               apply_filters( 'tc_content_title_tag' , is_singular() ? 'h1' : 'h2' ),
@@ -172,7 +172,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.2.6
       */
-      function czr_content_heading_title( $_title ) {
+      function czr_fn_content_heading_title( $_title ) {
         //Must be in the loop
         if ( ! in_the_loop() )
           return $_title;
@@ -196,17 +196,17 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.2.6
       */
-      function czr_add_edit_link_after_title( $_title ) {
+      function czr_fn_add_edit_link_after_title( $_title ) {
         //Must be in the loop
         if ( ! in_the_loop() )
           return $_title;
 
-        if ( ! apply_filters( 'tc_edit_in_title', $this -> czr_is_edit_enabled() ) )
+        if ( ! apply_filters( 'tc_edit_in_title', $this -> czr_fn_is_edit_enabled() ) )
           return $_title;
 
         return sprintf('%1$s %2$s',
           $_title,
-          $this -> czr_render_edit_link_view( $_echo = false )
+          $this -> czr_fn_render_edit_link_view( $_echo = false )
         );
 
       }
@@ -218,9 +218,9 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.3+
       */
-      public function czr_is_edit_enabled() {
+      public function czr_fn_is_edit_enabled() {
         //never display when customizing
-        if ( CZR___::$instance -> czr_is_customizing() )
+        if ( CZR___::$instance -> czr_fn_is_customizing() )
           return false;
         //when are we displaying the edit link?
         $edit_enabled = ( (is_user_logged_in()) && is_page() && current_user_can('edit_pages') ) ? true : false;
@@ -235,7 +235,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.3+
       */
-      function czr_render_edit_link_view( $_echo = true ) {
+      function czr_fn_render_edit_link_view( $_echo = true ) {
         $_view = sprintf('<span class="edit-link btn btn-inverse btn-mini"><a class="post-edit-link" href="%1$s" title="%2$s">%2$s</a></span>',
           get_edit_post_link(),
           __( 'Edit' , 'customizr' )
@@ -253,15 +253,15 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.2.0
       */
-      function czr_set_post_page_icon( $_bool ) {
+      function czr_fn_set_post_page_icon( $_bool ) {
           if ( is_page() )
-            $_bool = ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_page_title_icon' ) ) ) ? false : $_bool;
+            $_bool = ( 0 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_page_title_icon' ) ) ) ? false : $_bool;
           if ( is_single() && ! is_page() )
-            $_bool = ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_post_title_icon' ) ) ) ? false : $_bool;
+            $_bool = ( 0 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_post_title_icon' ) ) ) ? false : $_bool;
           if ( ! is_single() )
-            $_bool = ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_post_list_title_icon' ) ) ) ? false : $_bool;
+            $_bool = ( 0 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_post_list_title_icon' ) ) ) ? false : $_bool;
           //last condition
-          return ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_title_icon' ) ) ) ? false : $_bool;
+          return ( 0 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_title_icon' ) ) ) ? false : $_bool;
       }
 
 
@@ -273,10 +273,10 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.2.0
       */
-      function czr_set_archive_icon( $_class ) {
-          $_class = ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_archive_title_icon' ) ) ) ? '' : $_class;
+      function czr_fn_set_archive_icon( $_class ) {
+          $_class = ( 0 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_archive_title_icon' ) ) ) ? '' : $_class;
           //last condition
-          return 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_title_icon' ) ) ? '' : $_class;
+          return 0 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_title_icon' ) ) ? '' : $_class;
       }
 
 
@@ -290,7 +290,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.2.0
       */
-      function czr_archive_title_and_class_callback( $_title = null, $_return_class = false ) {
+      function czr_fn_archive_title_and_class_callback( $_title = null, $_return_class = false ) {
         //declares variables to return
         $content          = false;
         $_header_class    = false;
@@ -446,13 +446,13 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.2.6
       */
-      function czr_set_headings_options() {
+      function czr_fn_set_headings_options() {
         //by default don't display the Customizr title in feeds
         if ( apply_filters('tc_display_customizr_headings',  is_feed() ) )
           return;
 
         //Add update status next to the title (@since 3.2.6)
-        add_filter( 'tc_the_title'                  , array( $this , 'czr_add_update_notice_in_title'), 20);
+        add_filter( 'tc_the_title'                  , array( $this , 'czr_fn_add_update_notice_in_title'), 20);
       }
 
 
@@ -465,13 +465,13 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @package Customizr
       * @since Customizr 3.2.0
       */
-      function czr_add_update_notice_in_title($html) {
+      function czr_fn_add_update_notice_in_title($html) {
           //First checks if we are in the loop and we are not displaying a page
           if ( ! in_the_loop() || is_page() )
               return $html;
 
           //Is the notice option enabled AND this post type eligible for updated notice ? (default is post)
-          if ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_metas_update_notice_in_title' ) ) || ! in_array( get_post_type(), apply_filters('tc_show_update_notice_for_post_types' , array( 'post') ) ) )
+          if ( 0 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_post_metas_update_notice_in_title' ) ) || ! in_array( get_post_type(), apply_filters('tc_show_update_notice_for_post_types' , array( 'post') ) ) )
               return $html;
 
           //php version check for DateTime
@@ -480,11 +480,11 @@ if ( ! class_exists( 'CZR_headings' ) ) :
             return $html;
 
           //get the user defined interval in days
-          $_interval = esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_metas_update_notice_interval' ) );
+          $_interval = esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_post_metas_update_notice_interval' ) );
           $_interval = ( 0 != $_interval ) ? $_interval : 30;
 
           //Check if the last update is less than n days old. (replace n by your own value)
-          $has_recent_update = ( CZR_utils::$inst -> czr_post_has_update( true ) && CZR_utils::$inst -> czr_post_has_update( 'in_days') < $_interval ) ? true : false;
+          $has_recent_update = ( CZR_utils::$inst -> czr_fn_post_has_update( true ) && CZR_utils::$inst -> czr_fn_post_has_update( 'in_days') < $_interval ) ? true : false;
 
           if ( ! $has_recent_update )
               return $html;
@@ -494,8 +494,8 @@ if ( ! class_exists( 'CZR_headings' ) ) :
               'tc_update_notice_in_title',
               sprintf('%1$s &nbsp; <span class="tc-update-notice label %3$s">%2$s</span>',
                   $html,
-                  esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_metas_update_notice_text' ) ),
-                  esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_metas_update_notice_format' ) )
+                  esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_post_metas_update_notice_text' ) ),
+                  esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_post_metas_update_notice_format' ) )
               )
           );
       }
@@ -507,22 +507,22 @@ if ( ! class_exists( 'CZR_headings' ) ) :
       * @return string of user defined title
       * @since Customizr 3.3+
       */
-      function czr_set_archive_custom_title( $_title ) {
+      function czr_fn_set_archive_custom_title( $_title ) {
         switch ( current_filter() ) {
           case 'tc_category_archive_title' :
-            return esc_attr( CZR_utils::$inst->czr_opt( 'tc_cat_title' ) );
+            return esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_cat_title' ) );
           break;
 
           case 'tc_tag_archive_title' :
-            return esc_attr( CZR_utils::$inst->czr_opt( 'tc_tag_title' ) );
+            return esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_tag_title' ) );
           break;
 
           case 'tc_search_results_title' :
-            return esc_attr( CZR_utils::$inst->czr_opt( 'tc_search_title' ) );
+            return esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_search_title' ) );
           break;
 
           case 'tc_author_archive_title' :
-            return esc_attr( CZR_utils::$inst->czr_opt( 'tc_author_title' ) );
+            return esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_author_title' ) );
           break;
         }
         return $_title;

--- a/inc/parts/class-content-headings.php
+++ b/inc/parts/class-content-headings.php
@@ -11,8 +11,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_headings' ) ) :
-  class TC_headings {
+if ( ! class_exists( 'CZR_headings' ) ) :
+  class CZR_headings {
       static $instance;
       function __construct () {
         self::$instance =& $this;
@@ -143,7 +143,7 @@ if ( ! class_exists( 'TC_headings' ) ) :
       * @since Customizr 3.2.9
       */
       function tc_post_formats_heading( $_html ) {
-        if( in_array( get_post_format(), apply_filters( 'tc_post_formats_with_no_heading', TC_init::$instance -> post_formats_with_no_heading ) ) )
+        if( in_array( get_post_format(), apply_filters( 'tc_post_formats_with_no_heading', CZR_init::$instance -> post_formats_with_no_heading ) ) )
           return;
         return $_html;
       }
@@ -220,8 +220,8 @@ if ( ! class_exists( 'TC_headings' ) ) :
       */
       public function tc_is_edit_enabled() {
         //never display when customizing
-        if ( TC___::$instance -> tc_is_customizing() )
-          return false; 
+        if ( CZR___::$instance -> tc_is_customizing() )
+          return false;
         //when are we displaying the edit link?
         $edit_enabled = ( (is_user_logged_in()) && is_page() && current_user_can('edit_pages') ) ? true : false;
         return ( (is_user_logged_in()) && 0 !== get_the_ID() && current_user_can('edit_post' , get_the_ID() ) && ! is_page() ) ? true : $edit_enabled;
@@ -255,13 +255,13 @@ if ( ! class_exists( 'TC_headings' ) ) :
       */
       function tc_set_post_page_icon( $_bool ) {
           if ( is_page() )
-            $_bool = ( 0 == esc_attr( TC_utils::$inst->tc_opt( 'tc_show_page_title_icon' ) ) ) ? false : $_bool;
+            $_bool = ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_page_title_icon' ) ) ) ? false : $_bool;
           if ( is_single() && ! is_page() )
-            $_bool = ( 0 == esc_attr( TC_utils::$inst->tc_opt( 'tc_show_post_title_icon' ) ) ) ? false : $_bool;
+            $_bool = ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_post_title_icon' ) ) ) ? false : $_bool;
           if ( ! is_single() )
-            $_bool = ( 0 == esc_attr( TC_utils::$inst->tc_opt( 'tc_show_post_list_title_icon' ) ) ) ? false : $_bool;
+            $_bool = ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_post_list_title_icon' ) ) ) ? false : $_bool;
           //last condition
-          return ( 0 == esc_attr( TC_utils::$inst->tc_opt( 'tc_show_title_icon' ) ) ) ? false : $_bool;
+          return ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_title_icon' ) ) ) ? false : $_bool;
       }
 
 
@@ -274,9 +274,9 @@ if ( ! class_exists( 'TC_headings' ) ) :
       * @since Customizr 3.2.0
       */
       function tc_set_archive_icon( $_class ) {
-          $_class = ( 0 == esc_attr( TC_utils::$inst->tc_opt( 'tc_show_archive_title_icon' ) ) ) ? '' : $_class;
+          $_class = ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_archive_title_icon' ) ) ) ? '' : $_class;
           //last condition
-          return 0 == esc_attr( TC_utils::$inst->tc_opt( 'tc_show_title_icon' ) ) ? '' : $_class;
+          return 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_title_icon' ) ) ? '' : $_class;
       }
 
 
@@ -471,7 +471,7 @@ if ( ! class_exists( 'TC_headings' ) ) :
               return $html;
 
           //Is the notice option enabled AND this post type eligible for updated notice ? (default is post)
-          if ( 0 == esc_attr( TC_utils::$inst->tc_opt( 'tc_post_metas_update_notice_in_title' ) ) || ! in_array( get_post_type(), apply_filters('tc_show_update_notice_for_post_types' , array( 'post') ) ) )
+          if ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_metas_update_notice_in_title' ) ) || ! in_array( get_post_type(), apply_filters('tc_show_update_notice_for_post_types' , array( 'post') ) ) )
               return $html;
 
           //php version check for DateTime
@@ -480,11 +480,11 @@ if ( ! class_exists( 'TC_headings' ) ) :
             return $html;
 
           //get the user defined interval in days
-          $_interval = esc_attr( TC_utils::$inst->tc_opt( 'tc_post_metas_update_notice_interval' ) );
+          $_interval = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_metas_update_notice_interval' ) );
           $_interval = ( 0 != $_interval ) ? $_interval : 30;
 
           //Check if the last update is less than n days old. (replace n by your own value)
-          $has_recent_update = ( TC_utils::$inst -> tc_post_has_update( true ) && TC_utils::$inst -> tc_post_has_update( 'in_days') < $_interval ) ? true : false;
+          $has_recent_update = ( CZR_utils::$inst -> tc_post_has_update( true ) && CZR_utils::$inst -> tc_post_has_update( 'in_days') < $_interval ) ? true : false;
 
           if ( ! $has_recent_update )
               return $html;
@@ -494,8 +494,8 @@ if ( ! class_exists( 'TC_headings' ) ) :
               'tc_update_notice_in_title',
               sprintf('%1$s &nbsp; <span class="tc-update-notice label %3$s">%2$s</span>',
                   $html,
-                  esc_attr( TC_utils::$inst->tc_opt( 'tc_post_metas_update_notice_text' ) ),
-                  esc_attr( TC_utils::$inst->tc_opt( 'tc_post_metas_update_notice_format' ) )
+                  esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_metas_update_notice_text' ) ),
+                  esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_metas_update_notice_format' ) )
               )
           );
       }
@@ -510,19 +510,19 @@ if ( ! class_exists( 'TC_headings' ) ) :
       function tc_set_archive_custom_title( $_title ) {
         switch ( current_filter() ) {
           case 'tc_category_archive_title' :
-            return esc_attr( TC_utils::$inst->tc_opt( 'tc_cat_title' ) );
+            return esc_attr( CZR_utils::$inst->tc_opt( 'tc_cat_title' ) );
           break;
 
           case 'tc_tag_archive_title' :
-            return esc_attr( TC_utils::$inst->tc_opt( 'tc_tag_title' ) );
+            return esc_attr( CZR_utils::$inst->tc_opt( 'tc_tag_title' ) );
           break;
 
           case 'tc_search_results_title' :
-            return esc_attr( TC_utils::$inst->tc_opt( 'tc_search_title' ) );
+            return esc_attr( CZR_utils::$inst->tc_opt( 'tc_search_title' ) );
           break;
 
           case 'tc_author_archive_title' :
-            return esc_attr( TC_utils::$inst->tc_opt( 'tc_author_title' ) );
+            return esc_attr( CZR_utils::$inst->tc_opt( 'tc_author_title' ) );
           break;
         }
         return $_title;

--- a/inc/parts/class-content-no_results.php
+++ b/inc/parts/class-content-no_results.php
@@ -25,7 +25,7 @@ if ( ! class_exists( 'CZR_no_results' ) ) :
        * @package Customizr
        * @since Customizr 3.0
        */
-      function tc_no_result_content() {
+      function czr_no_result_content() {
           global $wp_query;
           if ( !is_search() || (is_search() && 0 != $wp_query -> post_count) )
               return;

--- a/inc/parts/class-content-no_results.php
+++ b/inc/parts/class-content-no_results.php
@@ -32,7 +32,7 @@ if ( ! class_exists( 'CZR_no_results' ) ) :
 
           $content_no_results    = apply_filters( 'tc_no_results', CZR_init::$instance -> content_no_results );
 
-          echo apply_filters( 'czr_fn_no_result_content',
+          echo apply_filters( 'tc_no_result_content',
               sprintf('<div class="%1$s"><div class="entry-content %2$s">%3$s</div>%4$s</div>',
                   apply_filters( 'tc_no_results_wrapper_class', 'tc-content span12 format-quote' ),
                   apply_filters( 'tc_no_results_content_icon', 'format-icon' ),

--- a/inc/parts/class-content-no_results.php
+++ b/inc/parts/class-content-no_results.php
@@ -16,7 +16,7 @@ if ( ! class_exists( 'CZR_no_results' ) ) :
       static $instance;
       function __construct () {
           self::$instance =& $this;
-          add_action  ( '__loop'                        , array( $this , 'tc_no_result_content' ));
+          add_action  ( '__loop'                        , array( $this , 'czr_no_result_content' ));
       }
 
       /**
@@ -32,7 +32,7 @@ if ( ! class_exists( 'CZR_no_results' ) ) :
 
           $content_no_results    = apply_filters( 'tc_no_results', CZR_init::$instance -> content_no_results );
 
-          echo apply_filters( 'tc_no_result_content',
+          echo apply_filters( 'czr_no_result_content',
               sprintf('<div class="%1$s"><div class="entry-content %2$s">%3$s</div>%4$s</div>',
                   apply_filters( 'tc_no_results_wrapper_class', 'tc-content span12 format-quote' ),
                   apply_filters( 'tc_no_results_content_icon', 'format-icon' ),

--- a/inc/parts/class-content-no_results.php
+++ b/inc/parts/class-content-no_results.php
@@ -16,7 +16,7 @@ if ( ! class_exists( 'CZR_no_results' ) ) :
       static $instance;
       function __construct () {
           self::$instance =& $this;
-          add_action  ( '__loop'                        , array( $this , 'czr_no_result_content' ));
+          add_action  ( '__loop'                        , array( $this , 'czr_fn_no_result_content' ));
       }
 
       /**
@@ -25,14 +25,14 @@ if ( ! class_exists( 'CZR_no_results' ) ) :
        * @package Customizr
        * @since Customizr 3.0
        */
-      function czr_no_result_content() {
+      function czr_fn_no_result_content() {
           global $wp_query;
           if ( !is_search() || (is_search() && 0 != $wp_query -> post_count) )
               return;
 
           $content_no_results    = apply_filters( 'tc_no_results', CZR_init::$instance -> content_no_results );
 
-          echo apply_filters( 'czr_no_result_content',
+          echo apply_filters( 'czr_fn_no_result_content',
               sprintf('<div class="%1$s"><div class="entry-content %2$s">%3$s</div>%4$s</div>',
                   apply_filters( 'tc_no_results_wrapper_class', 'tc-content span12 format-quote' ),
                   apply_filters( 'tc_no_results_content_icon', 'format-icon' ),

--- a/inc/parts/class-content-no_results.php
+++ b/inc/parts/class-content-no_results.php
@@ -11,8 +11,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_no_results' ) ) :
-  class TC_no_results {
+if ( ! class_exists( 'CZR_no_results' ) ) :
+  class CZR_no_results {
       static $instance;
       function __construct () {
           self::$instance =& $this;
@@ -30,7 +30,7 @@ if ( ! class_exists( 'TC_no_results' ) ) :
           if ( !is_search() || (is_search() && 0 != $wp_query -> post_count) )
               return;
 
-          $content_no_results    = apply_filters( 'tc_no_results', TC_init::$instance -> content_no_results );
+          $content_no_results    = apply_filters( 'tc_no_results', CZR_init::$instance -> content_no_results );
 
           echo apply_filters( 'tc_no_result_content',
               sprintf('<div class="%1$s"><div class="entry-content %2$s">%3$s</div>%4$s</div>',

--- a/inc/parts/class-content-page.php
+++ b/inc/parts/class-content-page.php
@@ -73,7 +73,7 @@ if ( ! class_exists( 'CZR_page' ) ) :
 
       $html = ob_get_contents();
       if ($html) ob_end_clean();
-      echo apply_filters( 'czr_fn_page_content', $html );
+      echo apply_filters( 'tc_page_content', $html );
     }
 
 

--- a/inc/parts/class-content-page.php
+++ b/inc/parts/class-content-page.php
@@ -16,7 +16,7 @@ if ( ! class_exists( 'CZR_page' ) ) :
     static $instance;
     function __construct () {
       self::$instance =& $this;
-      add_action( 'wp'                , array( $this , 'tc_set_page_hooks' ) );
+      add_action( 'wp'                , array( $this , 'czr_set_page_hooks' ) );
     }
 
 
@@ -32,9 +32,9 @@ if ( ! class_exists( 'CZR_page' ) ) :
     */
     function czr_set_page_hooks() {
       //add page content and footer to the __loop
-      add_action( '__loop'           , array( $this , 'tc_page_content' ) );
+      add_action( '__loop'           , array( $this , 'czr_page_content' ) );
       //page help blocks
-      add_filter( 'the_content'       , array( $this, 'tc_maybe_display_img_smartload_help') , PHP_INT_MAX );
+      add_filter( 'the_content'       , array( $this, 'czr_maybe_display_img_smartload_help') , PHP_INT_MAX );
     }
 
 
@@ -73,7 +73,7 @@ if ( ! class_exists( 'CZR_page' ) ) :
 
       $html = ob_get_contents();
       if ($html) ob_end_clean();
-      echo apply_filters( 'tc_page_content', $html );
+      echo apply_filters( 'czr_page_content', $html );
     }
 
 

--- a/inc/parts/class-content-page.php
+++ b/inc/parts/class-content-page.php
@@ -46,7 +46,7 @@ if ( ! class_exists( 'CZR_page' ) ) :
      * @since Customizr 3.0
      */
     function czr_page_content() {
-      if ( ! $this -> tc_page_display_controller() )
+      if ( ! $this -> czr_page_display_controller() )
         return;
 
       ob_start();
@@ -87,10 +87,10 @@ if ( ! class_exists( 'CZR_page' ) ) :
     * @since Customizr 3.4+
     */
     function czr_maybe_display_img_smartload_help( $the_content ) {
-      if ( ! ( $this -> tc_page_display_controller()  &&  in_the_loop() && CZR_placeholders::tc_is_img_smartload_help_on( $the_content ) ) )
+      if ( ! ( $this -> czr_page_display_controller()  &&  in_the_loop() && CZR_placeholders::czr_is_img_smartload_help_on( $the_content ) ) )
         return $the_content;
 
-      return CZR_placeholders::tc_get_smartload_help_block() . $the_content;
+      return CZR_placeholders::czr_get_smartload_help_block() . $the_content;
     }
 
 
@@ -105,9 +105,9 @@ if ( ! class_exists( 'CZR_page' ) ) :
     * @since Customizr 3.4+
     */
     function czr_page_display_controller() {
-      $tc_show_page_content = 'page' == tc__f('__post_type')
+      $tc_show_page_content = 'page' == czr__f('__post_type')
           && is_singular()
-          && ! tc__f( '__is_home_empty');
+          && ! czr__f( '__is_home_empty');
 
       return apply_filters( 'tc_show_page_content', $tc_show_page_content );
     }

--- a/inc/parts/class-content-page.php
+++ b/inc/parts/class-content-page.php
@@ -16,7 +16,7 @@ if ( ! class_exists( 'CZR_page' ) ) :
     static $instance;
     function __construct () {
       self::$instance =& $this;
-      add_action( 'wp'                , array( $this , 'czr_set_page_hooks' ) );
+      add_action( 'wp'                , array( $this , 'czr_fn_set_page_hooks' ) );
     }
 
 
@@ -30,11 +30,11 @@ if ( ! class_exists( 'CZR_page' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function czr_set_page_hooks() {
+    function czr_fn_set_page_hooks() {
       //add page content and footer to the __loop
-      add_action( '__loop'           , array( $this , 'czr_page_content' ) );
+      add_action( '__loop'           , array( $this , 'czr_fn_page_content' ) );
       //page help blocks
-      add_filter( 'the_content'       , array( $this, 'czr_maybe_display_img_smartload_help') , PHP_INT_MAX );
+      add_filter( 'the_content'       , array( $this, 'czr_fn_maybe_display_img_smartload_help') , PHP_INT_MAX );
     }
 
 
@@ -45,8 +45,8 @@ if ( ! class_exists( 'CZR_page' ) ) :
      * @package Customizr
      * @since Customizr 3.0
      */
-    function czr_page_content() {
-      if ( ! $this -> czr_page_display_controller() )
+    function czr_fn_page_content() {
+      if ( ! $this -> czr_fn_page_display_controller() )
         return;
 
       ob_start();
@@ -73,7 +73,7 @@ if ( ! class_exists( 'CZR_page' ) ) :
 
       $html = ob_get_contents();
       if ($html) ob_end_clean();
-      echo apply_filters( 'czr_page_content', $html );
+      echo apply_filters( 'czr_fn_page_content', $html );
     }
 
 
@@ -86,11 +86,11 @@ if ( ! class_exists( 'CZR_page' ) ) :
     * hook : the_content
     * @since Customizr 3.4+
     */
-    function czr_maybe_display_img_smartload_help( $the_content ) {
-      if ( ! ( $this -> czr_page_display_controller()  &&  in_the_loop() && CZR_placeholders::czr_is_img_smartload_help_on( $the_content ) ) )
+    function czr_fn_maybe_display_img_smartload_help( $the_content ) {
+      if ( ! ( $this -> czr_fn_page_display_controller()  &&  in_the_loop() && CZR_placeholders::czr_fn_is_img_smartload_help_on( $the_content ) ) )
         return $the_content;
 
-      return CZR_placeholders::czr_get_smartload_help_block() . $the_content;
+      return CZR_placeholders::czr_fn_get_smartload_help_block() . $the_content;
     }
 
 
@@ -104,10 +104,10 @@ if ( ! class_exists( 'CZR_page' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function czr_page_display_controller() {
-      $tc_show_page_content = 'page' == czr__f('__post_type')
+    function czr_fn_page_display_controller() {
+      $tc_show_page_content = 'page' == czr_fn__f('__post_type')
           && is_singular()
-          && ! czr__f( '__is_home_empty');
+          && ! czr_fn__f( '__is_home_empty');
 
       return apply_filters( 'tc_show_page_content', $tc_show_page_content );
     }

--- a/inc/parts/class-content-page.php
+++ b/inc/parts/class-content-page.php
@@ -30,7 +30,7 @@ if ( ! class_exists( 'CZR_page' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function tc_set_page_hooks() {
+    function czr_set_page_hooks() {
       //add page content and footer to the __loop
       add_action( '__loop'           , array( $this , 'tc_page_content' ) );
       //page help blocks
@@ -45,7 +45,7 @@ if ( ! class_exists( 'CZR_page' ) ) :
      * @package Customizr
      * @since Customizr 3.0
      */
-    function tc_page_content() {
+    function czr_page_content() {
       if ( ! $this -> tc_page_display_controller() )
         return;
 
@@ -86,7 +86,7 @@ if ( ! class_exists( 'CZR_page' ) ) :
     * hook : the_content
     * @since Customizr 3.4+
     */
-    function tc_maybe_display_img_smartload_help( $the_content ) {
+    function czr_maybe_display_img_smartload_help( $the_content ) {
       if ( ! ( $this -> tc_page_display_controller()  &&  in_the_loop() && CZR_placeholders::tc_is_img_smartload_help_on( $the_content ) ) )
         return $the_content;
 
@@ -104,7 +104,7 @@ if ( ! class_exists( 'CZR_page' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function tc_page_display_controller() {
+    function czr_page_display_controller() {
       $tc_show_page_content = 'page' == tc__f('__post_type')
           && is_singular()
           && ! tc__f( '__is_home_empty');

--- a/inc/parts/class-content-page.php
+++ b/inc/parts/class-content-page.php
@@ -11,8 +11,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_page' ) ) :
-  class TC_page {
+if ( ! class_exists( 'CZR_page' ) ) :
+  class CZR_page {
     static $instance;
     function __construct () {
       self::$instance =& $this;
@@ -20,7 +20,7 @@ if ( ! class_exists( 'TC_page' ) ) :
     }
 
 
-        
+
     /***************************
     * PAGE HOOKS SETUP
     ****************************/
@@ -87,10 +87,10 @@ if ( ! class_exists( 'TC_page' ) ) :
     * @since Customizr 3.4+
     */
     function tc_maybe_display_img_smartload_help( $the_content ) {
-      if ( ! ( $this -> tc_page_display_controller()  &&  in_the_loop() && TC_placeholders::tc_is_img_smartload_help_on( $the_content ) ) )
+      if ( ! ( $this -> tc_page_display_controller()  &&  in_the_loop() && CZR_placeholders::tc_is_img_smartload_help_on( $the_content ) ) )
         return $the_content;
 
-      return TC_placeholders::tc_get_smartload_help_block() . $the_content;
+      return CZR_placeholders::tc_get_smartload_help_block() . $the_content;
     }
 
 
@@ -105,8 +105,8 @@ if ( ! class_exists( 'TC_page' ) ) :
     * @since Customizr 3.4+
     */
     function tc_page_display_controller() {
-      $tc_show_page_content = 'page' == tc__f('__post_type') 
-          && is_singular() 
+      $tc_show_page_content = 'page' == tc__f('__post_type')
+          && is_singular()
           && ! tc__f( '__is_home_empty');
 
       return apply_filters( 'tc_show_page_content', $tc_show_page_content );

--- a/inc/parts/class-content-post.php
+++ b/inc/parts/class-content-post.php
@@ -16,15 +16,15 @@ if ( ! class_exists( 'CZR_post' ) ) :
     static $instance;
     function __construct () {
       self::$instance =& $this;
-      add_action( 'wp'                , array( $this , 'czr_set_single_post_hooks' ));
+      add_action( 'wp'                , array( $this , 'czr_fn_set_single_post_hooks' ));
       //Set single post thumbnail with customizer options (since 3.2.0)
-      add_action( 'wp'                , array( $this , 'czr_set_single_post_thumbnail_hooks' ));
+      add_action( 'wp'                , array( $this , 'czr_fn_set_single_post_thumbnail_hooks' ));
 
       //append inline style to the custom stylesheet
       //! tc_user_options_style filter is shared by several classes => must always check the local context inside the callback before appending new css
       //fired on hook : wp_enqueue_scripts
       //Set thumbnail specific design based on user options
-      add_filter( 'tc_user_options_style'    , array( $this , 'czr_write_thumbnail_inline_css') );
+      add_filter( 'tc_user_options_style'    , array( $this , 'czr_fn_write_thumbnail_inline_css') );
     }
 
 
@@ -37,13 +37,13 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * @package Customizr
     * @since Customizr 3.2.0
     */
-    function czr_set_single_post_hooks() {
+    function czr_fn_set_single_post_hooks() {
       //add post header, content and footer to the __loop
-      add_action( '__loop'              , array( $this , 'czr_post_content' ));
+      add_action( '__loop'              , array( $this , 'czr_fn_post_content' ));
       //posts parts actions
-      add_action( '__after_content'     , array( $this , 'czr_post_footer' ));
+      add_action( '__after_content'     , array( $this , 'czr_fn_post_footer' ));
       //smartload help block
-      add_filter( 'the_content'         , array( $this, 'czr_maybe_display_img_smartload_help') , PHP_INT_MAX );
+      add_filter( 'the_content'         , array( $this, 'czr_fn_maybe_display_img_smartload_help') , PHP_INT_MAX );
 
     }
 
@@ -55,24 +55,24 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * @package Customizr
     * @since Customizr 3.2.0
     */
-    function czr_set_single_post_thumbnail_hooks() {
-      if ( $this -> czr_single_post_display_controller() )
-        add_action( '__before_content'        , array( $this, 'czr_maybe_display_featured_image_help') );
+    function czr_fn_set_single_post_thumbnail_hooks() {
+      if ( $this -> czr_fn_single_post_display_controller() )
+        add_action( '__before_content'        , array( $this, 'czr_fn_maybe_display_featured_image_help') );
 
       //__before_main_wrapper, 200
       //__before_content 0
       //__before_content 20
-      if ( ! $this -> czr_show_single_post_thumbnail() )
+      if ( ! $this -> czr_fn_show_single_post_thumbnail() )
         return;
 
-      $_exploded_location   = explode('|', esc_attr( CZR_utils::$inst->czr_opt( 'tc_single_post_thumb_location' )) );
+      $_exploded_location   = explode('|', esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_single_post_thumb_location' )) );
       $_hook                = isset($_exploded_location[0]) ? $_exploded_location[0] : '__before_content';
       $_priority            = ( isset($_exploded_location[1]) && is_numeric($_exploded_location[1]) ) ? $_exploded_location[1] : 20;
 
       //Hook post view
-      add_action( $_hook, array($this , 'czr_single_post_prepare_thumb') , $_priority );
+      add_action( $_hook, array($this , 'czr_fn_single_post_prepare_thumb') , $_priority );
       //Set thumb shape with customizer options (since 3.2.0)
-      add_filter( 'tc_post_thumb_wrapper'      , array( $this , 'czr_set_thumb_shape'), 10 , 2 );
+      add_filter( 'tc_post_thumb_wrapper'      , array( $this , 'czr_fn_set_thumb_shape'), 10 , 2 );
     }
 
 
@@ -86,9 +86,9 @@ if ( ! class_exists( 'CZR_post' ) ) :
      * @package Customizr
      * @since Customizr 3.0
      */
-    function czr_post_content() {
+    function czr_fn_post_content() {
       //check conditional tags : we want to show single post or single custom post types
-      if ( ! $this -> czr_single_post_display_controller() )
+      if ( ! $this -> czr_fn_single_post_display_controller() )
           return;
       //display an icon for div if there is no title
       $icon_class = in_array( get_post_format(), array(  'quote' , 'aside' , 'status' , 'link' ) ) ? apply_filters( 'tc_post_format_icon', 'format-icon' ) :'' ;
@@ -105,7 +105,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
       do_action( '__after_content' );
       $html = ob_get_contents();
       if ($html) ob_end_clean();
-      echo apply_filters( 'czr_post_content', $html );
+      echo apply_filters( 'czr_fn_post_content', $html );
     }
 
 
@@ -116,12 +116,12 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * @package Customizr
     * @since Customizr 3.0
     */
-    function czr_post_footer() {
+    function czr_fn_post_footer() {
       //check conditional tags : we want to show single post or single custom post types
-      if ( ! $this -> czr_single_post_display_controller() || ! apply_filters( 'tc_show_single_post_footer', true ) )
+      if ( ! $this -> czr_fn_single_post_display_controller() || ! apply_filters( 'tc_show_single_post_footer', true ) )
           return;
       //@todo check if some conditions below not redundant?
-      if ( ! is_singular() || ! get_the_author_meta( 'description' ) || ! apply_filters( 'tc_show_author_metas_in_post', true ) || ! esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_author_info' ) ) )
+      if ( ! is_singular() || ! get_the_author_meta( 'description' ) || ! apply_filters( 'tc_show_author_metas_in_post', true ) || ! esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_author_info' ) ) )
         return;
 
       $html = sprintf('<footer class="entry-meta">%1$s<div class="author-info"><div class="%2$s">%3$s %4$s</div></div></footer>',
@@ -144,7 +144,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
                           )
                     )
       );//end sprintf
-      echo apply_filters( 'czr_post_footer', $html );
+      echo apply_filters( 'czr_fn_post_footer', $html );
     }
 
 
@@ -154,20 +154,20 @@ if ( ! class_exists( 'CZR_post' ) ) :
     /**
     * Get Single post thumb model + view
     * Inject it in the view
-    * hook : esc_attr( CZR_utils::$inst->czr_opt( 'tc_single_post_thumb_location' ) || '__before_content'
+    * hook : esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_single_post_thumb_location' ) || '__before_content'
     * @return  void
     * @package Customizr
     * @since Customizr 3.2.3
     */
-    function czr_single_post_prepare_thumb() {
-      $_size_to_request = apply_filters( 'tc_single_post_thumb_size' , $this -> czr_get_current_thumb_size() );
+    function czr_fn_single_post_prepare_thumb() {
+      $_size_to_request = apply_filters( 'tc_single_post_thumb_size' , $this -> czr_fn_get_current_thumb_size() );
       //get the thumbnail data (src, width, height) if any
       //array( "tc_thumb" , "tc_thumb_height" , "tc_thumb_width" )
-      $_thumb_model   = CZR_post_thumbnails::$instance -> czr_get_thumbnail_model( $_size_to_request ) ;
+      $_thumb_model   = CZR_post_thumbnails::$instance -> czr_fn_get_thumbnail_model( $_size_to_request ) ;
       //may be render
-      if ( CZR_post_thumbnails::$instance -> czr_has_thumb() ) {
+      if ( CZR_post_thumbnails::$instance -> czr_fn_has_thumb() ) {
         $_thumb_class   = implode( " " , apply_filters( 'tc_single_post_thumb_class' , array( 'row-fluid', 'tc-single-post-thumbnail-wrapper', current_filter() ) ) );
-        $this -> czr_render_single_post_view( $_thumb_model , $_thumb_class );
+        $this -> czr_fn_render_single_post_view( $_thumb_model , $_thumb_class );
       }
     }
 
@@ -177,11 +177,11 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * @package Customizr
     * @since Customizr 3.2.3
     */
-    private function czr_render_single_post_view( $_thumb_model , $_thumb_class ) {
-      echo apply_filters( 'czr_render_single_post_view',
+    private function czr_fn_render_single_post_view( $_thumb_model , $_thumb_class ) {
+      echo apply_filters( 'czr_fn_render_single_post_view',
         sprintf( '<div class="%1$s">%2$s</div>' ,
           $_thumb_class,
-          CZR_post_thumbnails::$instance -> czr_render_thumb_view( $_thumb_model, 'span12', false )
+          CZR_post_thumbnails::$instance -> czr_fn_render_thumb_view( $_thumb_model, 'span12', false )
         )
       );
     }
@@ -195,8 +195,8 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * hook : __before_content
     * @since Customizr 3.4
     */
-    function czr_maybe_display_featured_image_help() {
-      if ( ! CZR_placeholders::czr_is_thumbnail_help_on() )
+    function czr_fn_maybe_display_featured_image_help() {
+      if ( ! CZR_placeholders::czr_fn_is_thumbnail_help_on() )
         return;
       ?>
       <div class="tc-placeholder-wrap tc-thumbnail-help">
@@ -204,7 +204,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
           printf('<p><strong>%1$s</strong></p><p>%2$s</p><p>%3$s</p>',
               __( "You can display your post's featured image here if you have set one.", "customizr" ),
               sprintf( __("%s to display a featured image here.", "customizr"),
-                sprintf( '<strong><a href="%1$s" title="%2$s">%2$s</a></strong>', CZR_utils::czr_get_customizer_url( array( "section" => "single_posts_sec") ), __( "Jump to the customizer now", "customizr") )
+                sprintf( '<strong><a href="%1$s" title="%2$s">%2$s</a></strong>', CZR_utils::czr_fn_get_customizer_url( array( "section" => "single_posts_sec") ), __( "Jump to the customizer now", "customizr") )
               ),
               sprintf( __( "Don't know how to set a featured image to a post? Learn how in the %s.", "customizr" ),
                 sprintf('<a href="%1$s" title="%2$s" target="_blank">%2$s</a><span class="tc-external"></span>' , esc_url('codex.wordpress.org/Post_Thumbnails#Setting_a_Post_Thumbnail'), __("WordPress documentation" , "customizr" ) )
@@ -226,11 +226,11 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * hook : the_content
     * @since Customizr 3.4+
     */
-    function czr_maybe_display_img_smartload_help( $the_content ) {
-      if ( ! ( $this -> czr_single_post_display_controller()  &&  in_the_loop() && CZR_placeholders::czr_is_img_smartload_help_on( $the_content ) ) )
+    function czr_fn_maybe_display_img_smartload_help( $the_content ) {
+      if ( ! ( $this -> czr_fn_single_post_display_controller()  &&  in_the_loop() && CZR_placeholders::czr_fn_is_img_smartload_help_on( $the_content ) ) )
         return $the_content;
 
-      return CZR_placeholders::czr_get_smartload_help_block() . $the_content;
+      return CZR_placeholders::czr_fn_get_smartload_help_block() . $the_content;
     }
 
 
@@ -245,14 +245,14 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * @package Customizr
     * @since Customizr 3.2.0
     */
-    function czr_single_post_display_controller() {
+    function czr_fn_single_post_display_controller() {
       //check conditional tags : we want to show single post or single custom post types
       global $post;
       $tc_show_single_post_content = isset($post)
         && 'page' != $post -> post_type
         && 'attachment' != $post -> post_type
         && is_singular()
-        && ! czr__f( '__is_home_empty');
+        && ! czr_fn__f( '__is_home_empty');
       return apply_filters( 'tc_show_single_post_content', $tc_show_single_post_content );
     }
 
@@ -263,10 +263,10 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * @package Customizr
     * @since Customizr 3.2.11
     */
-    function czr_show_single_post_thumbnail() {
-      return $this -> czr_single_post_display_controller()
-        && 'hide' != esc_attr( CZR_utils::$inst->czr_opt( 'tc_single_post_thumb_location' ) )
-        && apply_filters( 'czr_show_single_post_thumbnail' , true );
+    function czr_fn_show_single_post_thumbnail() {
+      return $this -> czr_fn_single_post_display_controller()
+        && 'hide' != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_single_post_thumb_location' ) )
+        && apply_filters( 'czr_fn_show_single_post_thumbnail' , true );
     }
 
 
@@ -276,8 +276,8 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * @package Customizr
     * @since Customizr 3.2.3
     */
-    private function czr_get_current_thumb_size() {
-      $_exploded_location   = explode( '|', esc_attr( CZR_utils::$inst->czr_opt( 'tc_single_post_thumb_location' ) ) );
+    private function czr_fn_get_current_thumb_size() {
+      $_exploded_location   = explode( '|', esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_single_post_thumb_location' ) ) );
       $_hook                = isset( $_exploded_location[0] ) ? $_exploded_location[0] : '__before_content';
       return '__before_main_wrapper' == $_hook ? 'slider-full' : 'slider';
     }
@@ -289,7 +289,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * @package Customizr
     * @since Customizr 3.2.0
     */
-    function czr_set_thumb_shape( $thumb_wrapper, $thumb_img ) {
+    function czr_fn_set_thumb_shape( $thumb_wrapper, $thumb_img ) {
       return sprintf('<div class="%4$s"><a class="tc-rectangular-thumb" href="%1$s" title="%2$s">%3$s</a></div>',
             get_permalink( get_the_ID() ),
             esc_attr( strip_tags( get_the_title( get_the_ID() ) ) ),
@@ -306,10 +306,10 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * @package Customizr
     * @since Customizr 3.2.6
     */
-    function czr_write_thumbnail_inline_css( $_css ) {
-      if ( ! $this -> czr_show_single_post_thumbnail() )
+    function czr_fn_write_thumbnail_inline_css( $_css ) {
+      if ( ! $this -> czr_fn_show_single_post_thumbnail() )
         return $_css;
-      $_single_thumb_height   = esc_attr( CZR_utils::$inst->czr_opt( 'tc_single_post_thumb_height' ) );
+      $_single_thumb_height   = esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_single_post_thumb_height' ) );
       $_single_thumb_height   = (! $_single_thumb_height || ! is_numeric($_single_thumb_height) ) ? 250 : $_single_thumb_height;
       return sprintf("%s\n%s",
         $_css,

--- a/inc/parts/class-content-post.php
+++ b/inc/parts/class-content-post.php
@@ -16,15 +16,15 @@ if ( ! class_exists( 'CZR_post' ) ) :
     static $instance;
     function __construct () {
       self::$instance =& $this;
-      add_action( 'wp'                , array( $this , 'tc_set_single_post_hooks' ));
+      add_action( 'wp'                , array( $this , 'czr_set_single_post_hooks' ));
       //Set single post thumbnail with customizer options (since 3.2.0)
-      add_action( 'wp'                , array( $this , 'tc_set_single_post_thumbnail_hooks' ));
+      add_action( 'wp'                , array( $this , 'czr_set_single_post_thumbnail_hooks' ));
 
       //append inline style to the custom stylesheet
       //! tc_user_options_style filter is shared by several classes => must always check the local context inside the callback before appending new css
       //fired on hook : wp_enqueue_scripts
       //Set thumbnail specific design based on user options
-      add_filter( 'tc_user_options_style'    , array( $this , 'tc_write_thumbnail_inline_css') );
+      add_filter( 'tc_user_options_style'    , array( $this , 'czr_write_thumbnail_inline_css') );
     }
 
 
@@ -39,11 +39,11 @@ if ( ! class_exists( 'CZR_post' ) ) :
     */
     function czr_set_single_post_hooks() {
       //add post header, content and footer to the __loop
-      add_action( '__loop'              , array( $this , 'tc_post_content' ));
+      add_action( '__loop'              , array( $this , 'czr_post_content' ));
       //posts parts actions
-      add_action( '__after_content'     , array( $this , 'tc_post_footer' ));
+      add_action( '__after_content'     , array( $this , 'czr_post_footer' ));
       //smartload help block
-      add_filter( 'the_content'         , array( $this, 'tc_maybe_display_img_smartload_help') , PHP_INT_MAX );
+      add_filter( 'the_content'         , array( $this, 'czr_maybe_display_img_smartload_help') , PHP_INT_MAX );
 
     }
 
@@ -57,7 +57,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
     */
     function czr_set_single_post_thumbnail_hooks() {
       if ( $this -> czr_single_post_display_controller() )
-        add_action( '__before_content'        , array( $this, 'tc_maybe_display_featured_image_help') );
+        add_action( '__before_content'        , array( $this, 'czr_maybe_display_featured_image_help') );
 
       //__before_main_wrapper, 200
       //__before_content 0
@@ -70,9 +70,9 @@ if ( ! class_exists( 'CZR_post' ) ) :
       $_priority            = ( isset($_exploded_location[1]) && is_numeric($_exploded_location[1]) ) ? $_exploded_location[1] : 20;
 
       //Hook post view
-      add_action( $_hook, array($this , 'tc_single_post_prepare_thumb') , $_priority );
+      add_action( $_hook, array($this , 'czr_single_post_prepare_thumb') , $_priority );
       //Set thumb shape with customizer options (since 3.2.0)
-      add_filter( 'tc_post_thumb_wrapper'      , array( $this , 'tc_set_thumb_shape'), 10 , 2 );
+      add_filter( 'tc_post_thumb_wrapper'      , array( $this , 'czr_set_thumb_shape'), 10 , 2 );
     }
 
 
@@ -105,7 +105,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
       do_action( '__after_content' );
       $html = ob_get_contents();
       if ($html) ob_end_clean();
-      echo apply_filters( 'tc_post_content', $html );
+      echo apply_filters( 'czr_post_content', $html );
     }
 
 
@@ -144,7 +144,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
                           )
                     )
       );//end sprintf
-      echo apply_filters( 'tc_post_footer', $html );
+      echo apply_filters( 'czr_post_footer', $html );
     }
 
 
@@ -178,7 +178,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * @since Customizr 3.2.3
     */
     private function czr_render_single_post_view( $_thumb_model , $_thumb_class ) {
-      echo apply_filters( 'tc_render_single_post_view',
+      echo apply_filters( 'czr_render_single_post_view',
         sprintf( '<div class="%1$s">%2$s</div>' ,
           $_thumb_class,
           CZR_post_thumbnails::$instance -> czr_render_thumb_view( $_thumb_model, 'span12', false )
@@ -266,7 +266,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
     function czr_show_single_post_thumbnail() {
       return $this -> czr_single_post_display_controller()
         && 'hide' != esc_attr( CZR_utils::$inst->czr_opt( 'tc_single_post_thumb_location' ) )
-        && apply_filters( 'tc_show_single_post_thumbnail' , true );
+        && apply_filters( 'czr_show_single_post_thumbnail' , true );
     }
 
 

--- a/inc/parts/class-content-post.php
+++ b/inc/parts/class-content-post.php
@@ -11,8 +11,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_post' ) ) :
-  class TC_post {
+if ( ! class_exists( 'CZR_post' ) ) :
+  class CZR_post {
     static $instance;
     function __construct () {
       self::$instance =& $this;
@@ -65,7 +65,7 @@ if ( ! class_exists( 'TC_post' ) ) :
       if ( ! $this -> tc_show_single_post_thumbnail() )
         return;
 
-      $_exploded_location   = explode('|', esc_attr( TC_utils::$inst->tc_opt( 'tc_single_post_thumb_location' )) );
+      $_exploded_location   = explode('|', esc_attr( CZR_utils::$inst->tc_opt( 'tc_single_post_thumb_location' )) );
       $_hook                = isset($_exploded_location[0]) ? $_exploded_location[0] : '__before_content';
       $_priority            = ( isset($_exploded_location[1]) && is_numeric($_exploded_location[1]) ) ? $_exploded_location[1] : 20;
 
@@ -121,7 +121,7 @@ if ( ! class_exists( 'TC_post' ) ) :
       if ( ! $this -> tc_single_post_display_controller() || ! apply_filters( 'tc_show_single_post_footer', true ) )
           return;
       //@todo check if some conditions below not redundant?
-      if ( ! is_singular() || ! get_the_author_meta( 'description' ) || ! apply_filters( 'tc_show_author_metas_in_post', true ) || ! esc_attr( TC_utils::$inst->tc_opt( 'tc_show_author_info' ) ) )
+      if ( ! is_singular() || ! get_the_author_meta( 'description' ) || ! apply_filters( 'tc_show_author_metas_in_post', true ) || ! esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_author_info' ) ) )
         return;
 
       $html = sprintf('<footer class="entry-meta">%1$s<div class="author-info"><div class="%2$s">%3$s %4$s</div></div></footer>',
@@ -154,7 +154,7 @@ if ( ! class_exists( 'TC_post' ) ) :
     /**
     * Get Single post thumb model + view
     * Inject it in the view
-    * hook : esc_attr( TC_utils::$inst->tc_opt( 'tc_single_post_thumb_location' ) || '__before_content'
+    * hook : esc_attr( CZR_utils::$inst->tc_opt( 'tc_single_post_thumb_location' ) || '__before_content'
     * @return  void
     * @package Customizr
     * @since Customizr 3.2.3
@@ -163,9 +163,9 @@ if ( ! class_exists( 'TC_post' ) ) :
       $_size_to_request = apply_filters( 'tc_single_post_thumb_size' , $this -> tc_get_current_thumb_size() );
       //get the thumbnail data (src, width, height) if any
       //array( "tc_thumb" , "tc_thumb_height" , "tc_thumb_width" )
-      $_thumb_model   = TC_post_thumbnails::$instance -> tc_get_thumbnail_model( $_size_to_request ) ;
+      $_thumb_model   = CZR_post_thumbnails::$instance -> tc_get_thumbnail_model( $_size_to_request ) ;
       //may be render
-      if ( TC_post_thumbnails::$instance -> tc_has_thumb() ) {
+      if ( CZR_post_thumbnails::$instance -> tc_has_thumb() ) {
         $_thumb_class   = implode( " " , apply_filters( 'tc_single_post_thumb_class' , array( 'row-fluid', 'tc-single-post-thumbnail-wrapper', current_filter() ) ) );
         $this -> tc_render_single_post_view( $_thumb_model , $_thumb_class );
       }
@@ -181,7 +181,7 @@ if ( ! class_exists( 'TC_post' ) ) :
       echo apply_filters( 'tc_render_single_post_view',
         sprintf( '<div class="%1$s">%2$s</div>' ,
           $_thumb_class,
-          TC_post_thumbnails::$instance -> tc_render_thumb_view( $_thumb_model, 'span12', false )
+          CZR_post_thumbnails::$instance -> tc_render_thumb_view( $_thumb_model, 'span12', false )
         )
       );
     }
@@ -196,7 +196,7 @@ if ( ! class_exists( 'TC_post' ) ) :
     * @since Customizr 3.4
     */
     function tc_maybe_display_featured_image_help() {
-      if ( ! TC_placeholders::tc_is_thumbnail_help_on() )
+      if ( ! CZR_placeholders::tc_is_thumbnail_help_on() )
         return;
       ?>
       <div class="tc-placeholder-wrap tc-thumbnail-help">
@@ -204,7 +204,7 @@ if ( ! class_exists( 'TC_post' ) ) :
           printf('<p><strong>%1$s</strong></p><p>%2$s</p><p>%3$s</p>',
               __( "You can display your post's featured image here if you have set one.", "customizr" ),
               sprintf( __("%s to display a featured image here.", "customizr"),
-                sprintf( '<strong><a href="%1$s" title="%2$s">%2$s</a></strong>', TC_utils::tc_get_customizer_url( array( "section" => "single_posts_sec") ), __( "Jump to the customizer now", "customizr") )
+                sprintf( '<strong><a href="%1$s" title="%2$s">%2$s</a></strong>', CZR_utils::tc_get_customizer_url( array( "section" => "single_posts_sec") ), __( "Jump to the customizer now", "customizr") )
               ),
               sprintf( __( "Don't know how to set a featured image to a post? Learn how in the %s.", "customizr" ),
                 sprintf('<a href="%1$s" title="%2$s" target="_blank">%2$s</a><span class="tc-external"></span>' , esc_url('codex.wordpress.org/Post_Thumbnails#Setting_a_Post_Thumbnail'), __("WordPress documentation" , "customizr" ) )
@@ -227,10 +227,10 @@ if ( ! class_exists( 'TC_post' ) ) :
     * @since Customizr 3.4+
     */
     function tc_maybe_display_img_smartload_help( $the_content ) {
-      if ( ! ( $this -> tc_single_post_display_controller()  &&  in_the_loop() && TC_placeholders::tc_is_img_smartload_help_on( $the_content ) ) )
+      if ( ! ( $this -> tc_single_post_display_controller()  &&  in_the_loop() && CZR_placeholders::tc_is_img_smartload_help_on( $the_content ) ) )
         return $the_content;
 
-      return TC_placeholders::tc_get_smartload_help_block() . $the_content;
+      return CZR_placeholders::tc_get_smartload_help_block() . $the_content;
     }
 
 
@@ -265,7 +265,7 @@ if ( ! class_exists( 'TC_post' ) ) :
     */
     function tc_show_single_post_thumbnail() {
       return $this -> tc_single_post_display_controller()
-        && 'hide' != esc_attr( TC_utils::$inst->tc_opt( 'tc_single_post_thumb_location' ) )
+        && 'hide' != esc_attr( CZR_utils::$inst->tc_opt( 'tc_single_post_thumb_location' ) )
         && apply_filters( 'tc_show_single_post_thumbnail' , true );
     }
 
@@ -277,7 +277,7 @@ if ( ! class_exists( 'TC_post' ) ) :
     * @since Customizr 3.2.3
     */
     private function tc_get_current_thumb_size() {
-      $_exploded_location   = explode( '|', esc_attr( TC_utils::$inst->tc_opt( 'tc_single_post_thumb_location' ) ) );
+      $_exploded_location   = explode( '|', esc_attr( CZR_utils::$inst->tc_opt( 'tc_single_post_thumb_location' ) ) );
       $_hook                = isset( $_exploded_location[0] ) ? $_exploded_location[0] : '__before_content';
       return '__before_main_wrapper' == $_hook ? 'slider-full' : 'slider';
     }
@@ -309,7 +309,7 @@ if ( ! class_exists( 'TC_post' ) ) :
     function tc_write_thumbnail_inline_css( $_css ) {
       if ( ! $this -> tc_show_single_post_thumbnail() )
         return $_css;
-      $_single_thumb_height   = esc_attr( TC_utils::$inst->tc_opt( 'tc_single_post_thumb_height' ) );
+      $_single_thumb_height   = esc_attr( CZR_utils::$inst->tc_opt( 'tc_single_post_thumb_height' ) );
       $_single_thumb_height   = (! $_single_thumb_height || ! is_numeric($_single_thumb_height) ) ? 250 : $_single_thumb_height;
       return sprintf("%s\n%s",
         $_css,

--- a/inc/parts/class-content-post.php
+++ b/inc/parts/class-content-post.php
@@ -37,7 +37,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * @package Customizr
     * @since Customizr 3.2.0
     */
-    function tc_set_single_post_hooks() {
+    function czr_set_single_post_hooks() {
       //add post header, content and footer to the __loop
       add_action( '__loop'              , array( $this , 'tc_post_content' ));
       //posts parts actions
@@ -55,7 +55,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * @package Customizr
     * @since Customizr 3.2.0
     */
-    function tc_set_single_post_thumbnail_hooks() {
+    function czr_set_single_post_thumbnail_hooks() {
       if ( $this -> tc_single_post_display_controller() )
         add_action( '__before_content'        , array( $this, 'tc_maybe_display_featured_image_help') );
 
@@ -86,7 +86,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
      * @package Customizr
      * @since Customizr 3.0
      */
-    function tc_post_content() {
+    function czr_post_content() {
       //check conditional tags : we want to show single post or single custom post types
       if ( ! $this -> tc_single_post_display_controller() )
           return;
@@ -116,7 +116,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * @package Customizr
     * @since Customizr 3.0
     */
-    function tc_post_footer() {
+    function czr_post_footer() {
       //check conditional tags : we want to show single post or single custom post types
       if ( ! $this -> tc_single_post_display_controller() || ! apply_filters( 'tc_show_single_post_footer', true ) )
           return;
@@ -159,7 +159,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * @package Customizr
     * @since Customizr 3.2.3
     */
-    function tc_single_post_prepare_thumb() {
+    function czr_single_post_prepare_thumb() {
       $_size_to_request = apply_filters( 'tc_single_post_thumb_size' , $this -> tc_get_current_thumb_size() );
       //get the thumbnail data (src, width, height) if any
       //array( "tc_thumb" , "tc_thumb_height" , "tc_thumb_width" )
@@ -177,7 +177,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * @package Customizr
     * @since Customizr 3.2.3
     */
-    private function tc_render_single_post_view( $_thumb_model , $_thumb_class ) {
+    private function czr_render_single_post_view( $_thumb_model , $_thumb_class ) {
       echo apply_filters( 'tc_render_single_post_view',
         sprintf( '<div class="%1$s">%2$s</div>' ,
           $_thumb_class,
@@ -195,7 +195,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * hook : __before_content
     * @since Customizr 3.4
     */
-    function tc_maybe_display_featured_image_help() {
+    function czr_maybe_display_featured_image_help() {
       if ( ! CZR_placeholders::tc_is_thumbnail_help_on() )
         return;
       ?>
@@ -226,7 +226,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * hook : the_content
     * @since Customizr 3.4+
     */
-    function tc_maybe_display_img_smartload_help( $the_content ) {
+    function czr_maybe_display_img_smartload_help( $the_content ) {
       if ( ! ( $this -> tc_single_post_display_controller()  &&  in_the_loop() && CZR_placeholders::tc_is_img_smartload_help_on( $the_content ) ) )
         return $the_content;
 
@@ -245,7 +245,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * @package Customizr
     * @since Customizr 3.2.0
     */
-    function tc_single_post_display_controller() {
+    function czr_single_post_display_controller() {
       //check conditional tags : we want to show single post or single custom post types
       global $post;
       $tc_show_single_post_content = isset($post)
@@ -263,7 +263,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * @package Customizr
     * @since Customizr 3.2.11
     */
-    function tc_show_single_post_thumbnail() {
+    function czr_show_single_post_thumbnail() {
       return $this -> tc_single_post_display_controller()
         && 'hide' != esc_attr( CZR_utils::$inst->tc_opt( 'tc_single_post_thumb_location' ) )
         && apply_filters( 'tc_show_single_post_thumbnail' , true );
@@ -276,7 +276,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * @package Customizr
     * @since Customizr 3.2.3
     */
-    private function tc_get_current_thumb_size() {
+    private function czr_get_current_thumb_size() {
       $_exploded_location   = explode( '|', esc_attr( CZR_utils::$inst->tc_opt( 'tc_single_post_thumb_location' ) ) );
       $_hook                = isset( $_exploded_location[0] ) ? $_exploded_location[0] : '__before_content';
       return '__before_main_wrapper' == $_hook ? 'slider-full' : 'slider';
@@ -289,7 +289,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * @package Customizr
     * @since Customizr 3.2.0
     */
-    function tc_set_thumb_shape( $thumb_wrapper, $thumb_img ) {
+    function czr_set_thumb_shape( $thumb_wrapper, $thumb_img ) {
       return sprintf('<div class="%4$s"><a class="tc-rectangular-thumb" href="%1$s" title="%2$s">%3$s</a></div>',
             get_permalink( get_the_ID() ),
             esc_attr( strip_tags( get_the_title( get_the_ID() ) ) ),
@@ -306,7 +306,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * @package Customizr
     * @since Customizr 3.2.6
     */
-    function tc_write_thumbnail_inline_css( $_css ) {
+    function czr_write_thumbnail_inline_css( $_css ) {
       if ( ! $this -> tc_show_single_post_thumbnail() )
         return $_css;
       $_single_thumb_height   = esc_attr( CZR_utils::$inst->tc_opt( 'tc_single_post_thumb_height' ) );

--- a/inc/parts/class-content-post.php
+++ b/inc/parts/class-content-post.php
@@ -56,16 +56,16 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * @since Customizr 3.2.0
     */
     function czr_set_single_post_thumbnail_hooks() {
-      if ( $this -> tc_single_post_display_controller() )
+      if ( $this -> czr_single_post_display_controller() )
         add_action( '__before_content'        , array( $this, 'tc_maybe_display_featured_image_help') );
 
       //__before_main_wrapper, 200
       //__before_content 0
       //__before_content 20
-      if ( ! $this -> tc_show_single_post_thumbnail() )
+      if ( ! $this -> czr_show_single_post_thumbnail() )
         return;
 
-      $_exploded_location   = explode('|', esc_attr( CZR_utils::$inst->tc_opt( 'tc_single_post_thumb_location' )) );
+      $_exploded_location   = explode('|', esc_attr( CZR_utils::$inst->czr_opt( 'tc_single_post_thumb_location' )) );
       $_hook                = isset($_exploded_location[0]) ? $_exploded_location[0] : '__before_content';
       $_priority            = ( isset($_exploded_location[1]) && is_numeric($_exploded_location[1]) ) ? $_exploded_location[1] : 20;
 
@@ -88,7 +88,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
      */
     function czr_post_content() {
       //check conditional tags : we want to show single post or single custom post types
-      if ( ! $this -> tc_single_post_display_controller() )
+      if ( ! $this -> czr_single_post_display_controller() )
           return;
       //display an icon for div if there is no title
       $icon_class = in_array( get_post_format(), array(  'quote' , 'aside' , 'status' , 'link' ) ) ? apply_filters( 'tc_post_format_icon', 'format-icon' ) :'' ;
@@ -118,10 +118,10 @@ if ( ! class_exists( 'CZR_post' ) ) :
     */
     function czr_post_footer() {
       //check conditional tags : we want to show single post or single custom post types
-      if ( ! $this -> tc_single_post_display_controller() || ! apply_filters( 'tc_show_single_post_footer', true ) )
+      if ( ! $this -> czr_single_post_display_controller() || ! apply_filters( 'tc_show_single_post_footer', true ) )
           return;
       //@todo check if some conditions below not redundant?
-      if ( ! is_singular() || ! get_the_author_meta( 'description' ) || ! apply_filters( 'tc_show_author_metas_in_post', true ) || ! esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_author_info' ) ) )
+      if ( ! is_singular() || ! get_the_author_meta( 'description' ) || ! apply_filters( 'tc_show_author_metas_in_post', true ) || ! esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_author_info' ) ) )
         return;
 
       $html = sprintf('<footer class="entry-meta">%1$s<div class="author-info"><div class="%2$s">%3$s %4$s</div></div></footer>',
@@ -154,20 +154,20 @@ if ( ! class_exists( 'CZR_post' ) ) :
     /**
     * Get Single post thumb model + view
     * Inject it in the view
-    * hook : esc_attr( CZR_utils::$inst->tc_opt( 'tc_single_post_thumb_location' ) || '__before_content'
+    * hook : esc_attr( CZR_utils::$inst->czr_opt( 'tc_single_post_thumb_location' ) || '__before_content'
     * @return  void
     * @package Customizr
     * @since Customizr 3.2.3
     */
     function czr_single_post_prepare_thumb() {
-      $_size_to_request = apply_filters( 'tc_single_post_thumb_size' , $this -> tc_get_current_thumb_size() );
+      $_size_to_request = apply_filters( 'tc_single_post_thumb_size' , $this -> czr_get_current_thumb_size() );
       //get the thumbnail data (src, width, height) if any
       //array( "tc_thumb" , "tc_thumb_height" , "tc_thumb_width" )
-      $_thumb_model   = CZR_post_thumbnails::$instance -> tc_get_thumbnail_model( $_size_to_request ) ;
+      $_thumb_model   = CZR_post_thumbnails::$instance -> czr_get_thumbnail_model( $_size_to_request ) ;
       //may be render
-      if ( CZR_post_thumbnails::$instance -> tc_has_thumb() ) {
+      if ( CZR_post_thumbnails::$instance -> czr_has_thumb() ) {
         $_thumb_class   = implode( " " , apply_filters( 'tc_single_post_thumb_class' , array( 'row-fluid', 'tc-single-post-thumbnail-wrapper', current_filter() ) ) );
-        $this -> tc_render_single_post_view( $_thumb_model , $_thumb_class );
+        $this -> czr_render_single_post_view( $_thumb_model , $_thumb_class );
       }
     }
 
@@ -181,7 +181,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
       echo apply_filters( 'tc_render_single_post_view',
         sprintf( '<div class="%1$s">%2$s</div>' ,
           $_thumb_class,
-          CZR_post_thumbnails::$instance -> tc_render_thumb_view( $_thumb_model, 'span12', false )
+          CZR_post_thumbnails::$instance -> czr_render_thumb_view( $_thumb_model, 'span12', false )
         )
       );
     }
@@ -196,7 +196,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * @since Customizr 3.4
     */
     function czr_maybe_display_featured_image_help() {
-      if ( ! CZR_placeholders::tc_is_thumbnail_help_on() )
+      if ( ! CZR_placeholders::czr_is_thumbnail_help_on() )
         return;
       ?>
       <div class="tc-placeholder-wrap tc-thumbnail-help">
@@ -204,7 +204,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
           printf('<p><strong>%1$s</strong></p><p>%2$s</p><p>%3$s</p>',
               __( "You can display your post's featured image here if you have set one.", "customizr" ),
               sprintf( __("%s to display a featured image here.", "customizr"),
-                sprintf( '<strong><a href="%1$s" title="%2$s">%2$s</a></strong>', CZR_utils::tc_get_customizer_url( array( "section" => "single_posts_sec") ), __( "Jump to the customizer now", "customizr") )
+                sprintf( '<strong><a href="%1$s" title="%2$s">%2$s</a></strong>', CZR_utils::czr_get_customizer_url( array( "section" => "single_posts_sec") ), __( "Jump to the customizer now", "customizr") )
               ),
               sprintf( __( "Don't know how to set a featured image to a post? Learn how in the %s.", "customizr" ),
                 sprintf('<a href="%1$s" title="%2$s" target="_blank">%2$s</a><span class="tc-external"></span>' , esc_url('codex.wordpress.org/Post_Thumbnails#Setting_a_Post_Thumbnail'), __("WordPress documentation" , "customizr" ) )
@@ -227,10 +227,10 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * @since Customizr 3.4+
     */
     function czr_maybe_display_img_smartload_help( $the_content ) {
-      if ( ! ( $this -> tc_single_post_display_controller()  &&  in_the_loop() && CZR_placeholders::tc_is_img_smartload_help_on( $the_content ) ) )
+      if ( ! ( $this -> czr_single_post_display_controller()  &&  in_the_loop() && CZR_placeholders::czr_is_img_smartload_help_on( $the_content ) ) )
         return $the_content;
 
-      return CZR_placeholders::tc_get_smartload_help_block() . $the_content;
+      return CZR_placeholders::czr_get_smartload_help_block() . $the_content;
     }
 
 
@@ -252,7 +252,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
         && 'page' != $post -> post_type
         && 'attachment' != $post -> post_type
         && is_singular()
-        && ! tc__f( '__is_home_empty');
+        && ! czr__f( '__is_home_empty');
       return apply_filters( 'tc_show_single_post_content', $tc_show_single_post_content );
     }
 
@@ -264,8 +264,8 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * @since Customizr 3.2.11
     */
     function czr_show_single_post_thumbnail() {
-      return $this -> tc_single_post_display_controller()
-        && 'hide' != esc_attr( CZR_utils::$inst->tc_opt( 'tc_single_post_thumb_location' ) )
+      return $this -> czr_single_post_display_controller()
+        && 'hide' != esc_attr( CZR_utils::$inst->czr_opt( 'tc_single_post_thumb_location' ) )
         && apply_filters( 'tc_show_single_post_thumbnail' , true );
     }
 
@@ -277,7 +277,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * @since Customizr 3.2.3
     */
     private function czr_get_current_thumb_size() {
-      $_exploded_location   = explode( '|', esc_attr( CZR_utils::$inst->tc_opt( 'tc_single_post_thumb_location' ) ) );
+      $_exploded_location   = explode( '|', esc_attr( CZR_utils::$inst->czr_opt( 'tc_single_post_thumb_location' ) ) );
       $_hook                = isset( $_exploded_location[0] ) ? $_exploded_location[0] : '__before_content';
       return '__before_main_wrapper' == $_hook ? 'slider-full' : 'slider';
     }
@@ -307,9 +307,9 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * @since Customizr 3.2.6
     */
     function czr_write_thumbnail_inline_css( $_css ) {
-      if ( ! $this -> tc_show_single_post_thumbnail() )
+      if ( ! $this -> czr_show_single_post_thumbnail() )
         return $_css;
-      $_single_thumb_height   = esc_attr( CZR_utils::$inst->tc_opt( 'tc_single_post_thumb_height' ) );
+      $_single_thumb_height   = esc_attr( CZR_utils::$inst->czr_opt( 'tc_single_post_thumb_height' ) );
       $_single_thumb_height   = (! $_single_thumb_height || ! is_numeric($_single_thumb_height) ) ? 250 : $_single_thumb_height;
       return sprintf("%s\n%s",
         $_css,

--- a/inc/parts/class-content-post.php
+++ b/inc/parts/class-content-post.php
@@ -105,7 +105,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
       do_action( '__after_content' );
       $html = ob_get_contents();
       if ($html) ob_end_clean();
-      echo apply_filters( 'czr_fn_post_content', $html );
+      echo apply_filters( 'tc_post_content', $html );
     }
 
 
@@ -144,7 +144,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
                           )
                     )
       );//end sprintf
-      echo apply_filters( 'czr_fn_post_footer', $html );
+      echo apply_filters( 'tc_post_footer', $html );
     }
 
 
@@ -178,7 +178,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
     * @since Customizr 3.2.3
     */
     private function czr_fn_render_single_post_view( $_thumb_model , $_thumb_class ) {
-      echo apply_filters( 'czr_fn_render_single_post_view',
+      echo apply_filters( 'tc_render_single_post_view',
         sprintf( '<div class="%1$s">%2$s</div>' ,
           $_thumb_class,
           CZR_post_thumbnails::$instance -> czr_fn_render_thumb_view( $_thumb_model, 'span12', false )
@@ -266,7 +266,7 @@ if ( ! class_exists( 'CZR_post' ) ) :
     function czr_fn_show_single_post_thumbnail() {
       return $this -> czr_fn_single_post_display_controller()
         && 'hide' != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_single_post_thumb_location' ) )
-        && apply_filters( 'czr_fn_show_single_post_thumbnail' , true );
+        && apply_filters( 'tc_show_single_post_thumbnail' , true );
     }
 
 

--- a/inc/parts/class-content-post_list.php
+++ b/inc/parts/class-content-post_list.php
@@ -42,7 +42,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.2.6
   */
-  function tc_set_thumb_early_options() {
+  function czr_set_thumb_early_options() {
     //Set thumb size depending on the customizer thumbnail position options (since 3.2.0)
     add_filter ( 'tc_thumb_size_name'     , array( $this , 'tc_set_thumb_size') );
   }
@@ -55,7 +55,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.2.0
   */
-  function tc_set_early_hooks() {
+  function czr_set_early_hooks() {
     //Filter home/blog postsa (priority 9 is to make it act before the grid hook for expanded post)
     add_action ( 'pre_get_posts'         , array( $this , 'tc_filter_home_blog_posts_by_tax' ), 9);
     //Include attachments in search results
@@ -72,7 +72,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.2.0
   */
-  function tc_set_post_list_hooks() {
+  function czr_set_post_list_hooks() {
     if ( ! $this -> tc_post_list_controller() )
       return;
     //displays the article with filtered layout : content + thumbnail
@@ -110,7 +110,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.0.10
   */
-  function tc_prepare_section_view() {
+  function czr_prepare_section_view() {
     global $post;
     if ( ! isset( $post ) || empty( $post ) || ! apply_filters( 'tc_show_post_in_post_list', $this -> tc_post_list_controller() , $post ) )
       return;
@@ -131,7 +131,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.3.2
   */
-  private function tc_get_content_model($_layout) {
+  private function czr_get_content_model($_layout) {
     $_content      = '';
     if ( $this -> tc_show_excerpt() )
       $_content = apply_filters( 'the_excerpt', get_the_excerpt() );
@@ -156,7 +156,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.3.2
   */
-  private function tc_show_excerpt() {
+  private function czr_show_excerpt() {
     //When do we show the post excerpt?
     //1) when set in options
     //2) + other filters conditions
@@ -169,7 +169,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.3.2
   */
-  private function tc_show_thumb() {
+  private function czr_show_thumb() {
     //when do we display the thumbnail ?
     //1) there must be a thumbnail
     //2) the excerpt option is not set to full
@@ -195,7 +195,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.0.10
   */
-  private function tc_render_section_view( $_layout, $_content_model, $_thumb_model ) {
+  private function czr_render_section_view( $_layout, $_content_model, $_thumb_model ) {
     global $wp_query;
     //Renders the filtered layout for content + thumbnail
     if ( isset($_layout['alternate']) && $_layout['alternate'] ) {
@@ -229,7 +229,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.0
   */
-  private function tc_render_content_view( $_content_model ) {
+  private function czr_render_content_view( $_content_model ) {
     //extract "_layout_class" , "_icon_class" , "_content"
     extract($_content_model);
     $_sub_class = 'entry-summary';
@@ -284,7 +284,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.2.0
   */
-  function tc_set_thumb_shape( $thumb_wrapper, $thumb_img ) {
+  function czr_set_thumb_shape( $thumb_wrapper, $thumb_img ) {
     $_shape = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_thumb_shape') );
 
     //1) check if shape is rounded, squared on rectangular
@@ -308,7 +308,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.3.2
   */
-  function tc_add_post_list_context( $_classes ) {
+  function czr_add_post_list_context( $_classes ) {
     return array_merge( $_classes , array( 'tc-post-list-context' ) );
   }
 
@@ -320,7 +320,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.2.0
   */
-  public function tc_post_list_controller() {
+  public function czr_post_list_controller() {
     global $wp_query;
     //must be archive or search result. Returns false if home is empty in options.
     return apply_filters( 'tc_post_list_controller',
@@ -340,7 +340,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.1.20
   */
-  function tc_include_cpt_in_lists( $query ) {
+  function czr_include_cpt_in_lists( $query ) {
     if (
       is_admin()
       || ! $query->is_main_query()
@@ -375,7 +375,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.0.10
   */
-  function tc_include_attachments_in_search( $query ) {
+  function czr_include_attachments_in_search( $query ) {
       if (! is_search() || ! apply_filters( 'tc_include_attachments_in_search_results' , false ) )
         return;
 
@@ -396,7 +396,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.4.10
   */
-  function tc_filter_home_blog_posts_by_tax( $query ) {
+  function czr_filter_home_blog_posts_by_tax( $query ) {
       // when we have to filter?
       // in home and blog page
       if (
@@ -423,7 +423,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.2.0
   */
-  function tc_add_thumb_shape_name( $_classes ) {
+  function czr_add_thumb_shape_name( $_classes ) {
     return array_merge( $_classes , array(esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_thumb_shape') ) ) );
   }
 
@@ -434,7 +434,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.2.0
   */
-  function tc_set_excerpt_length( $length ) {
+  function czr_set_excerpt_length( $length ) {
     $_custom = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_excerpt_length' ) );
     return ( false === $_custom || !is_numeric($_custom) ) ? $length : $_custom;
   }
@@ -446,7 +446,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.2.0
   */
-  function tc_set_post_list_layout( $_layout ) {
+  function czr_set_post_list_layout( $_layout ) {
     $_position                  = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_thumb_position' ) );
     //since 3.4.16 the alternate layout is not available when the position is top or bottom
     $_layout['alternate']        = ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_thumb_alternate' ) )
@@ -464,7 +464,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.2.0
   */
-  function tc_set_content_class( $_classes ) {
+  function czr_set_content_class( $_classes ) {
     $_position                  = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_thumb_position' ) );
     return array_merge( $_classes , array( "thumb-position-{$_position}") );
   }
@@ -479,7 +479,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.2.6
   */
-  function tc_change_thumbnail_inline_css_width( $_style,  $image, $_filtered_thumb_size) {
+  function czr_change_thumbnail_inline_css_width( $_style,  $image, $_filtered_thumb_size) {
     //conditions :
     //note : handled with javascript if tc_center_img option enabled
     $_bool = array_product(
@@ -512,7 +512,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.2.6
   */
-  function tc_write_thumbnail_inline_css( $_css ) {
+  function czr_write_thumbnail_inline_css( $_css ) {
     if ( ! $this -> tc_post_list_controller() )
       return $_css;
     $_list_thumb_height     = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_thumb_height' ) );
@@ -534,7 +534,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.2.0
   */
-  function tc_set_thumb_size( $_default_size ) {
+  function czr_set_thumb_size( $_default_size ) {
     $_shape = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_thumb_shape') );
     if ( ! $_shape || false !== strpos($_shape, 'rounded') || false !== strpos($_shape, 'squared') )
       return $_default_size;
@@ -554,7 +554,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.3+
   */
-  function tc_add_support_for_shortcode_special_chars( $_content ) {
+  function czr_add_support_for_shortcode_special_chars( $_content ) {
     return str_replace( ']]>', ']]&gt;', apply_filters( 'the_content', $_content ) );
   }
 
@@ -567,7 +567,7 @@ class CZR_post_list {
   * hook : __before_loop
   * @since Customizr 3.4+
   */
-  function tc_maybe_display_img_smartload_help( $the_content ) {
+  function czr_maybe_display_img_smartload_help( $the_content ) {
     if ( ! ( $this -> tc_post_list_controller() && CZR_placeholders::tc_is_img_smartload_help_on( $text = '', $min_img_num = 0 ) ) )
       return;
 

--- a/inc/parts/class-content-post_list.php
+++ b/inc/parts/class-content-post_list.php
@@ -17,17 +17,17 @@ class CZR_post_list {
   function __construct () {
     self::$instance =& $this;
     //Set new image size can be set here ( => wp hook would be too late) (since 3.2.0)
-    add_action( 'init'                    , array( $this, 'tc_set_thumb_early_options') );
+    add_action( 'init'                    , array( $this, 'czr_set_thumb_early_options') );
     //modify the query with pre_get_posts
     //! wp_loaded is fired after WordPress is fully loaded but before the query is set
-    add_action( 'wp_loaded'               , array( $this, 'tc_set_early_hooks') );
+    add_action( 'wp_loaded'               , array( $this, 'czr_set_early_hooks') );
     //Set __loop hooks and customizer options (since 3.2.0)
-    add_action( 'wp_head'                 , array( $this, 'tc_set_post_list_hooks'));
+    add_action( 'wp_head'                 , array( $this, 'czr_set_post_list_hooks'));
     //append inline style to the custom stylesheet
     //! tc_user_options_style filter is shared by several classes => must always check the local context inside the callback before appending new css
     //fired on hook : wp_enqueue_scripts
     //Set thumbnail specific design based on user options
-    add_filter( 'tc_user_options_style'   , array( $this , 'tc_write_thumbnail_inline_css') );
+    add_filter( 'tc_user_options_style'   , array( $this , 'czr_write_thumbnail_inline_css') );
   }
 
 
@@ -44,7 +44,7 @@ class CZR_post_list {
   */
   function czr_set_thumb_early_options() {
     //Set thumb size depending on the customizer thumbnail position options (since 3.2.0)
-    add_filter ( 'tc_thumb_size_name'     , array( $this , 'tc_set_thumb_size') );
+    add_filter ( 'tc_thumb_size_name'     , array( $this , 'czr_set_thumb_size') );
   }
 
 
@@ -57,11 +57,11 @@ class CZR_post_list {
   */
   function czr_set_early_hooks() {
     //Filter home/blog postsa (priority 9 is to make it act before the grid hook for expanded post)
-    add_action ( 'pre_get_posts'         , array( $this , 'tc_filter_home_blog_posts_by_tax' ), 9);
+    add_action ( 'pre_get_posts'         , array( $this , 'czr_filter_home_blog_posts_by_tax' ), 9);
     //Include attachments in search results
-    add_action ( 'pre_get_posts'         , array( $this , 'tc_include_attachments_in_search' ));
+    add_action ( 'pre_get_posts'         , array( $this , 'czr_include_attachments_in_search' ));
     //Include all post types in archive pages
-    add_action ( 'pre_get_posts'         , array( $this , 'tc_include_cpt_in_lists' ));
+    add_action ( 'pre_get_posts'         , array( $this , 'czr_include_cpt_in_lists' ));
   }
 
 
@@ -76,27 +76,27 @@ class CZR_post_list {
     if ( ! $this -> czr_post_list_controller() )
       return;
     //displays the article with filtered layout : content + thumbnail
-    add_action ( '__loop'               , array( $this , 'tc_prepare_section_view') );
+    add_action ( '__loop'               , array( $this , 'czr_prepare_section_view') );
 
     //page help blocks
-    add_filter( '__before_loop'         , array( $this , 'tc_maybe_display_img_smartload_help') );
+    add_filter( '__before_loop'         , array( $this , 'czr_maybe_display_img_smartload_help') );
 
     //based on customizer user options
-    add_filter( 'tc_post_list_layout'   , array( $this , 'tc_set_post_list_layout') );
-    add_filter( 'post_class'            , array( $this , 'tc_set_content_class') );
-    add_filter( 'excerpt_length'        , array( $this , 'tc_set_excerpt_length') , 999 );
-    add_filter( 'post_class'            , array( $this , 'tc_add_thumb_shape_name') );
+    add_filter( 'tc_post_list_layout'   , array( $this , 'czr_set_post_list_layout') );
+    add_filter( 'post_class'            , array( $this , 'czr_set_content_class') );
+    add_filter( 'excerpt_length'        , array( $this , 'czr_set_excerpt_length') , 999 );
+    add_filter( 'post_class'            , array( $this , 'czr_add_thumb_shape_name') );
 
     //add current context to the body class
-    add_filter( 'body_class'            , array( $this , 'tc_add_post_list_context') );
+    add_filter( 'body_class'            , array( $this , 'czr_add_post_list_context') );
     //Set thumb shape with customizer options (since 3.2.0)
-    add_filter( 'tc_post_thumb_wrapper' , array( $this , 'tc_set_thumb_shape'), 10 , 2 );
+    add_filter( 'tc_post_thumb_wrapper' , array( $this , 'czr_set_thumb_shape'), 10 , 2 );
 
-    add_filter( 'tc_the_content'        , array( $this , 'tc_add_support_for_shortcode_special_chars') );
+    add_filter( 'tc_the_content'        , array( $this , 'czr_add_support_for_shortcode_special_chars') );
 
     // => filter the thumbnail inline style tc_post_thumb_inline_style and replace width:auto by width:100%
     // 3 args = $style, $_width, $_height
-    add_filter( 'tc_post_thumb_inline_style'  , array( $this , 'tc_change_thumbnail_inline_css_width'), 20, 3 );
+    add_filter( 'tc_post_thumb_inline_style'  , array( $this , 'czr_change_thumbnail_inline_css_width'), 20, 3 );
   }
 
 
@@ -160,7 +160,7 @@ class CZR_post_list {
     //When do we show the post excerpt?
     //1) when set in options
     //2) + other filters conditions
-    return (bool) apply_filters( 'tc_show_excerpt', 'full' != esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_length' ) ) );
+    return (bool) apply_filters( 'czr_show_excerpt', 'full' != esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_length' ) ) );
   }
 
 
@@ -175,7 +175,7 @@ class CZR_post_list {
     //2) the excerpt option is not set to full
     //3) user settings in customizer
     //4) filter's conditions
-    return apply_filters( 'tc_show_thumb', array_product(
+    return apply_filters( 'czr_show_thumb', array_product(
         array(
           $this -> czr_show_excerpt(),
           CZR_post_thumbnails::$instance -> czr_has_thumb(),
@@ -323,7 +323,7 @@ class CZR_post_list {
   public function czr_post_list_controller() {
     global $wp_query;
     //must be archive or search result. Returns false if home is empty in options.
-    return apply_filters( 'tc_post_list_controller',
+    return apply_filters( 'czr_post_list_controller',
       ! is_singular()
       && ! is_404()
       && 0 != $wp_query -> post_count
@@ -409,7 +409,7 @@ class CZR_post_list {
      // we have to ignore sticky posts (do not prepend them)
      // disable grid sticky post expansion
      $cats = CZR_utils::$inst -> czr_opt('tc_blog_restrict_by_cat');
-     $cats = array_filter( $cats, array( CZR_utils::$inst , 'tc_category_id_exists' ) );
+     $cats = array_filter( $cats, array( CZR_utils::$inst , 'czr_category_id_exists' ) );
 
      if ( is_array( $cats ) && ! empty( $cats ) ){
          $query->set('category__in', $cats );

--- a/inc/parts/class-content-post_list.php
+++ b/inc/parts/class-content-post_list.php
@@ -73,7 +73,7 @@ class CZR_post_list {
   * @since Customizr 3.2.0
   */
   function czr_set_post_list_hooks() {
-    if ( ! $this -> tc_post_list_controller() )
+    if ( ! $this -> czr_post_list_controller() )
       return;
     //displays the article with filtered layout : content + thumbnail
     add_action ( '__loop'               , array( $this , 'tc_prepare_section_view') );
@@ -112,15 +112,15 @@ class CZR_post_list {
   */
   function czr_prepare_section_view() {
     global $post;
-    if ( ! isset( $post ) || empty( $post ) || ! apply_filters( 'tc_show_post_in_post_list', $this -> tc_post_list_controller() , $post ) )
+    if ( ! isset( $post ) || empty( $post ) || ! apply_filters( 'tc_show_post_in_post_list', $this -> czr_post_list_controller() , $post ) )
       return;
 
     //get the filtered post list layout
     $_layout        = apply_filters( 'tc_post_list_layout', CZR_init::$instance -> post_list_layout );
-    $_content_model = $this -> tc_get_content_model( $_layout );
-    $_thumb_model   = $this -> tc_show_thumb() ? CZR_post_thumbnails::$instance -> tc_get_thumbnail_model() : array();
+    $_content_model = $this -> czr_get_content_model( $_layout );
+    $_thumb_model   = $this -> czr_show_thumb() ? CZR_post_thumbnails::$instance -> czr_get_thumbnail_model() : array();
 
-    $this -> tc_render_section_view( $_layout, $_content_model, $_thumb_model );
+    $this -> czr_render_section_view( $_layout, $_content_model, $_thumb_model );
   }
 
 
@@ -133,14 +133,14 @@ class CZR_post_list {
   */
   private function czr_get_content_model($_layout) {
     $_content      = '';
-    if ( $this -> tc_show_excerpt() )
+    if ( $this -> czr_show_excerpt() )
       $_content = apply_filters( 'the_excerpt', get_the_excerpt() );
     else
       $_content = apply_filters( 'tc_the_content', get_the_content() );
 
     //what is determining the layout ? if no thumbnail then full width + filter's conditions
-    $_layout_class = $this -> tc_show_thumb() ? $_layout['content'] : 'span12';
-    $_layout_class = implode( " " , apply_filters( 'tc_post_list_content_class', array($_layout_class) , $this -> tc_show_thumb() , $_layout ) );
+    $_layout_class = $this -> czr_show_thumb() ? $_layout['content'] : 'span12';
+    $_layout_class = implode( " " , apply_filters( 'tc_post_list_content_class', array($_layout_class) , $this -> czr_show_thumb() , $_layout ) );
 
     //display an icon for div if there is no title
     $_icon_class    = in_array(get_post_format(), array(  'quote' , 'aside' , 'status' , 'link' )) ? apply_filters( 'tc_post_list_content_icon', 'format-icon' ) :'';
@@ -160,7 +160,7 @@ class CZR_post_list {
     //When do we show the post excerpt?
     //1) when set in options
     //2) + other filters conditions
-    return (bool) apply_filters( 'tc_show_excerpt', 'full' != esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_length' ) ) );
+    return (bool) apply_filters( 'tc_show_excerpt', 'full' != esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_length' ) ) );
   }
 
 
@@ -177,9 +177,9 @@ class CZR_post_list {
     //4) filter's conditions
     return apply_filters( 'tc_show_thumb', array_product(
         array(
-          $this -> tc_show_excerpt(),
-          CZR_post_thumbnails::$instance -> tc_has_thumb(),
-          0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_show_thumb' ) )
+          $this -> czr_show_excerpt(),
+          CZR_post_thumbnails::$instance -> czr_has_thumb(),
+          0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_show_thumb' ) )
         )
       )
     );
@@ -200,21 +200,21 @@ class CZR_post_list {
     //Renders the filtered layout for content + thumbnail
     if ( isset($_layout['alternate']) && $_layout['alternate'] ) {
       if ( 0 == $wp_query->current_post % 2 ) {
-        $this -> tc_render_content_view( $_content_model ) ;
-        CZR_post_thumbnails::$instance -> tc_render_thumb_view( $_thumb_model , $_layout['thumb'] );
+        $this -> czr_render_content_view( $_content_model ) ;
+        CZR_post_thumbnails::$instance -> czr_render_thumb_view( $_thumb_model , $_layout['thumb'] );
       }
       else {
-        CZR_post_thumbnails::$instance -> tc_render_thumb_view( $_thumb_model , $_layout['thumb'] );
-        $this -> tc_render_content_view( $_content_model );
+        CZR_post_thumbnails::$instance -> czr_render_thumb_view( $_thumb_model , $_layout['thumb'] );
+        $this -> czr_render_content_view( $_content_model );
       }
     }
     else if ( isset($_layout['show_thumb_first']) && ! $_layout['show_thumb_first'] ) {
-        $this -> tc_render_content_view( $_content_model );
-        CZR_post_thumbnails::$instance -> tc_render_thumb_view( $_thumb_model , $_layout['thumb'] );
+        $this -> czr_render_content_view( $_content_model );
+        CZR_post_thumbnails::$instance -> czr_render_thumb_view( $_thumb_model , $_layout['thumb'] );
     }
     else {
-      CZR_post_thumbnails::$instance -> tc_render_thumb_view( $_thumb_model , $_layout['thumb'] );
-      $this -> tc_render_content_view( $_content_model );
+      CZR_post_thumbnails::$instance -> czr_render_thumb_view( $_thumb_model , $_layout['thumb'] );
+      $this -> czr_render_content_view( $_content_model );
     }
 
     //renders the hr separator after each article
@@ -285,13 +285,13 @@ class CZR_post_list {
   * @since Customizr 3.2.0
   */
   function czr_set_thumb_shape( $thumb_wrapper, $thumb_img ) {
-    $_shape = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_thumb_shape') );
+    $_shape = esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_thumb_shape') );
 
     //1) check if shape is rounded, squared on rectangular
     if ( ! $_shape || false !== strpos($_shape, 'rounded') || false !== strpos($_shape, 'squared') )
       return $thumb_wrapper;
 
-    $_position = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_thumb_position' ) );
+    $_position = esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_thumb_position' ) );
     return sprintf('<div class="%4$s"><a class="tc-rectangular-thumb" href="%1$s" title="%2s">%3$s</a></div>',
           get_permalink( get_the_ID() ),
           esc_attr( strip_tags( get_the_title( get_the_ID() ) ) ),
@@ -327,7 +327,7 @@ class CZR_post_list {
       ! is_singular()
       && ! is_404()
       && 0 != $wp_query -> post_count
-      && ! tc__f( '__is_home_empty')
+      && ! czr__f( '__is_home_empty')
     );
   }
 
@@ -408,7 +408,7 @@ class CZR_post_list {
      // categories
      // we have to ignore sticky posts (do not prepend them)
      // disable grid sticky post expansion
-     $cats = CZR_utils::$inst -> tc_opt('tc_blog_restrict_by_cat');
+     $cats = CZR_utils::$inst -> czr_opt('tc_blog_restrict_by_cat');
      $cats = array_filter( $cats, array( CZR_utils::$inst , 'tc_category_id_exists' ) );
 
      if ( is_array( $cats ) && ! empty( $cats ) ){
@@ -424,7 +424,7 @@ class CZR_post_list {
   * @since Customizr 3.2.0
   */
   function czr_add_thumb_shape_name( $_classes ) {
-    return array_merge( $_classes , array(esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_thumb_shape') ) ) );
+    return array_merge( $_classes , array(esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_thumb_shape') ) ) );
   }
 
 
@@ -435,7 +435,7 @@ class CZR_post_list {
   * @since Customizr 3.2.0
   */
   function czr_set_excerpt_length( $length ) {
-    $_custom = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_excerpt_length' ) );
+    $_custom = esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_excerpt_length' ) );
     return ( false === $_custom || !is_numeric($_custom) ) ? $length : $_custom;
   }
 
@@ -447,9 +447,9 @@ class CZR_post_list {
   * @since Customizr 3.2.0
   */
   function czr_set_post_list_layout( $_layout ) {
-    $_position                  = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_thumb_position' ) );
+    $_position                  = esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_thumb_position' ) );
     //since 3.4.16 the alternate layout is not available when the position is top or bottom
-    $_layout['alternate']        = ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_thumb_alternate' ) )
+    $_layout['alternate']        = ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_thumb_alternate' ) )
                                    || in_array( $_position, array( 'top', 'bottom') ) ) ? false : true;
     $_layout['show_thumb_first'] = ( 'left' == $_position || 'top' == $_position ) ? true : false;
     $_layout['content']          = ( 'left' == $_position || 'right' == $_position ) ? $_layout['content'] : 'span12';
@@ -465,7 +465,7 @@ class CZR_post_list {
   * @since Customizr 3.2.0
   */
   function czr_set_content_class( $_classes ) {
-    $_position                  = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_thumb_position' ) );
+    $_position                  = esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_thumb_position' ) );
     return array_merge( $_classes , array( "thumb-position-{$_position}") );
   }
 
@@ -484,7 +484,7 @@ class CZR_post_list {
     //note : handled with javascript if tc_center_img option enabled
     $_bool = array_product(
       array(
-        ! esc_attr( CZR_utils::$inst->tc_opt( 'tc_center_img') ),
+        ! esc_attr( CZR_utils::$inst->czr_opt( 'tc_center_img') ),
         false != $image,
         ! empty($image),
         isset($_filtered_thumb_size['width']),
@@ -496,7 +496,7 @@ class CZR_post_list {
 
     $_width     = $_filtered_thumb_size['width'];
     $_height    = $_filtered_thumb_size['height'];
-    $_shape     = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_thumb_shape') );
+    $_shape     = esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_thumb_shape') );
     $_is_rectangular = ! $_shape || false !== strpos($_shape, 'rounded') || false !== strpos($_shape, 'squared') ? false : true;
     if ( ! is_single() && ! $_is_rectangular )
       return $_style;
@@ -513,9 +513,9 @@ class CZR_post_list {
   * @since Customizr 3.2.6
   */
   function czr_write_thumbnail_inline_css( $_css ) {
-    if ( ! $this -> tc_post_list_controller() )
+    if ( ! $this -> czr_post_list_controller() )
       return $_css;
-    $_list_thumb_height     = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_thumb_height' ) );
+    $_list_thumb_height     = esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_thumb_height' ) );
     $_list_thumb_height     = (! $_list_thumb_height || ! is_numeric($_list_thumb_height) ) ? 250 : $_list_thumb_height;
 
     return sprintf("%s\n%s",
@@ -535,11 +535,11 @@ class CZR_post_list {
   * @since Customizr 3.2.0
   */
   function czr_set_thumb_size( $_default_size ) {
-    $_shape = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_thumb_shape') );
+    $_shape = esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_thumb_shape') );
     if ( ! $_shape || false !== strpos($_shape, 'rounded') || false !== strpos($_shape, 'squared') )
       return $_default_size;
 
-    $_position                  = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_thumb_position' ) );
+    $_position                  = esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_thumb_position' ) );
     return ( 'top' == $_position || 'bottom' == $_position ) ? 'tc_rectangular_size' : $_default_size;
   }
 
@@ -568,10 +568,10 @@ class CZR_post_list {
   * @since Customizr 3.4+
   */
   function czr_maybe_display_img_smartload_help( $the_content ) {
-    if ( ! ( $this -> tc_post_list_controller() && CZR_placeholders::tc_is_img_smartload_help_on( $text = '', $min_img_num = 0 ) ) )
+    if ( ! ( $this -> czr_post_list_controller() && CZR_placeholders::czr_is_img_smartload_help_on( $text = '', $min_img_num = 0 ) ) )
       return;
 
-    CZR_placeholders::tc_get_smartload_help_block( $echo = true );
+    CZR_placeholders::czr_get_smartload_help_block( $echo = true );
   }
 
 }//end of class

--- a/inc/parts/class-content-post_list.php
+++ b/inc/parts/class-content-post_list.php
@@ -17,17 +17,17 @@ class CZR_post_list {
   function __construct () {
     self::$instance =& $this;
     //Set new image size can be set here ( => wp hook would be too late) (since 3.2.0)
-    add_action( 'init'                    , array( $this, 'czr_set_thumb_early_options') );
+    add_action( 'init'                    , array( $this, 'czr_fn_set_thumb_early_options') );
     //modify the query with pre_get_posts
     //! wp_loaded is fired after WordPress is fully loaded but before the query is set
-    add_action( 'wp_loaded'               , array( $this, 'czr_set_early_hooks') );
+    add_action( 'wp_loaded'               , array( $this, 'czr_fn_set_early_hooks') );
     //Set __loop hooks and customizer options (since 3.2.0)
-    add_action( 'wp_head'                 , array( $this, 'czr_set_post_list_hooks'));
+    add_action( 'wp_head'                 , array( $this, 'czr_fn_set_post_list_hooks'));
     //append inline style to the custom stylesheet
     //! tc_user_options_style filter is shared by several classes => must always check the local context inside the callback before appending new css
     //fired on hook : wp_enqueue_scripts
     //Set thumbnail specific design based on user options
-    add_filter( 'tc_user_options_style'   , array( $this , 'czr_write_thumbnail_inline_css') );
+    add_filter( 'tc_user_options_style'   , array( $this , 'czr_fn_write_thumbnail_inline_css') );
   }
 
 
@@ -42,9 +42,9 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.2.6
   */
-  function czr_set_thumb_early_options() {
+  function czr_fn_set_thumb_early_options() {
     //Set thumb size depending on the customizer thumbnail position options (since 3.2.0)
-    add_filter ( 'tc_thumb_size_name'     , array( $this , 'czr_set_thumb_size') );
+    add_filter ( 'tc_thumb_size_name'     , array( $this , 'czr_fn_set_thumb_size') );
   }
 
 
@@ -55,13 +55,13 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.2.0
   */
-  function czr_set_early_hooks() {
+  function czr_fn_set_early_hooks() {
     //Filter home/blog postsa (priority 9 is to make it act before the grid hook for expanded post)
-    add_action ( 'pre_get_posts'         , array( $this , 'czr_filter_home_blog_posts_by_tax' ), 9);
+    add_action ( 'pre_get_posts'         , array( $this , 'czr_fn_filter_home_blog_posts_by_tax' ), 9);
     //Include attachments in search results
-    add_action ( 'pre_get_posts'         , array( $this , 'czr_include_attachments_in_search' ));
+    add_action ( 'pre_get_posts'         , array( $this , 'czr_fn_include_attachments_in_search' ));
     //Include all post types in archive pages
-    add_action ( 'pre_get_posts'         , array( $this , 'czr_include_cpt_in_lists' ));
+    add_action ( 'pre_get_posts'         , array( $this , 'czr_fn_include_cpt_in_lists' ));
   }
 
 
@@ -72,31 +72,31 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.2.0
   */
-  function czr_set_post_list_hooks() {
-    if ( ! $this -> czr_post_list_controller() )
+  function czr_fn_set_post_list_hooks() {
+    if ( ! $this -> czr_fn_post_list_controller() )
       return;
     //displays the article with filtered layout : content + thumbnail
-    add_action ( '__loop'               , array( $this , 'czr_prepare_section_view') );
+    add_action ( '__loop'               , array( $this , 'czr_fn_prepare_section_view') );
 
     //page help blocks
-    add_filter( '__before_loop'         , array( $this , 'czr_maybe_display_img_smartload_help') );
+    add_filter( '__before_loop'         , array( $this , 'czr_fn_maybe_display_img_smartload_help') );
 
     //based on customizer user options
-    add_filter( 'tc_post_list_layout'   , array( $this , 'czr_set_post_list_layout') );
-    add_filter( 'post_class'            , array( $this , 'czr_set_content_class') );
-    add_filter( 'excerpt_length'        , array( $this , 'czr_set_excerpt_length') , 999 );
-    add_filter( 'post_class'            , array( $this , 'czr_add_thumb_shape_name') );
+    add_filter( 'tc_post_list_layout'   , array( $this , 'czr_fn_set_post_list_layout') );
+    add_filter( 'post_class'            , array( $this , 'czr_fn_set_content_class') );
+    add_filter( 'excerpt_length'        , array( $this , 'czr_fn_set_excerpt_length') , 999 );
+    add_filter( 'post_class'            , array( $this , 'czr_fn_add_thumb_shape_name') );
 
     //add current context to the body class
-    add_filter( 'body_class'            , array( $this , 'czr_add_post_list_context') );
+    add_filter( 'body_class'            , array( $this , 'czr_fn_add_post_list_context') );
     //Set thumb shape with customizer options (since 3.2.0)
-    add_filter( 'tc_post_thumb_wrapper' , array( $this , 'czr_set_thumb_shape'), 10 , 2 );
+    add_filter( 'tc_post_thumb_wrapper' , array( $this , 'czr_fn_set_thumb_shape'), 10 , 2 );
 
-    add_filter( 'tc_the_content'        , array( $this , 'czr_add_support_for_shortcode_special_chars') );
+    add_filter( 'tc_the_content'        , array( $this , 'czr_fn_add_support_for_shortcode_special_chars') );
 
     // => filter the thumbnail inline style tc_post_thumb_inline_style and replace width:auto by width:100%
     // 3 args = $style, $_width, $_height
-    add_filter( 'tc_post_thumb_inline_style'  , array( $this , 'czr_change_thumbnail_inline_css_width'), 20, 3 );
+    add_filter( 'tc_post_thumb_inline_style'  , array( $this , 'czr_fn_change_thumbnail_inline_css_width'), 20, 3 );
   }
 
 
@@ -110,17 +110,17 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.0.10
   */
-  function czr_prepare_section_view() {
+  function czr_fn_prepare_section_view() {
     global $post;
-    if ( ! isset( $post ) || empty( $post ) || ! apply_filters( 'tc_show_post_in_post_list', $this -> czr_post_list_controller() , $post ) )
+    if ( ! isset( $post ) || empty( $post ) || ! apply_filters( 'tc_show_post_in_post_list', $this -> czr_fn_post_list_controller() , $post ) )
       return;
 
     //get the filtered post list layout
     $_layout        = apply_filters( 'tc_post_list_layout', CZR_init::$instance -> post_list_layout );
-    $_content_model = $this -> czr_get_content_model( $_layout );
-    $_thumb_model   = $this -> czr_show_thumb() ? CZR_post_thumbnails::$instance -> czr_get_thumbnail_model() : array();
+    $_content_model = $this -> czr_fn_get_content_model( $_layout );
+    $_thumb_model   = $this -> czr_fn_show_thumb() ? CZR_post_thumbnails::$instance -> czr_fn_get_thumbnail_model() : array();
 
-    $this -> czr_render_section_view( $_layout, $_content_model, $_thumb_model );
+    $this -> czr_fn_render_section_view( $_layout, $_content_model, $_thumb_model );
   }
 
 
@@ -131,16 +131,16 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.3.2
   */
-  private function czr_get_content_model($_layout) {
+  private function czr_fn_get_content_model($_layout) {
     $_content      = '';
-    if ( $this -> czr_show_excerpt() )
+    if ( $this -> czr_fn_show_excerpt() )
       $_content = apply_filters( 'the_excerpt', get_the_excerpt() );
     else
       $_content = apply_filters( 'tc_the_content', get_the_content() );
 
     //what is determining the layout ? if no thumbnail then full width + filter's conditions
-    $_layout_class = $this -> czr_show_thumb() ? $_layout['content'] : 'span12';
-    $_layout_class = implode( " " , apply_filters( 'tc_post_list_content_class', array($_layout_class) , $this -> czr_show_thumb() , $_layout ) );
+    $_layout_class = $this -> czr_fn_show_thumb() ? $_layout['content'] : 'span12';
+    $_layout_class = implode( " " , apply_filters( 'tc_post_list_content_class', array($_layout_class) , $this -> czr_fn_show_thumb() , $_layout ) );
 
     //display an icon for div if there is no title
     $_icon_class    = in_array(get_post_format(), array(  'quote' , 'aside' , 'status' , 'link' )) ? apply_filters( 'tc_post_list_content_icon', 'format-icon' ) :'';
@@ -156,11 +156,11 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.3.2
   */
-  private function czr_show_excerpt() {
+  private function czr_fn_show_excerpt() {
     //When do we show the post excerpt?
     //1) when set in options
     //2) + other filters conditions
-    return (bool) apply_filters( 'czr_show_excerpt', 'full' != esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_length' ) ) );
+    return (bool) apply_filters( 'czr_fn_show_excerpt', 'full' != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_post_list_length' ) ) );
   }
 
 
@@ -169,17 +169,17 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.3.2
   */
-  private function czr_show_thumb() {
+  private function czr_fn_show_thumb() {
     //when do we display the thumbnail ?
     //1) there must be a thumbnail
     //2) the excerpt option is not set to full
     //3) user settings in customizer
     //4) filter's conditions
-    return apply_filters( 'czr_show_thumb', array_product(
+    return apply_filters( 'czr_fn_show_thumb', array_product(
         array(
-          $this -> czr_show_excerpt(),
-          CZR_post_thumbnails::$instance -> czr_has_thumb(),
-          0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_show_thumb' ) )
+          $this -> czr_fn_show_excerpt(),
+          CZR_post_thumbnails::$instance -> czr_fn_has_thumb(),
+          0 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_post_list_show_thumb' ) )
         )
       )
     );
@@ -195,26 +195,26 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.0.10
   */
-  private function czr_render_section_view( $_layout, $_content_model, $_thumb_model ) {
+  private function czr_fn_render_section_view( $_layout, $_content_model, $_thumb_model ) {
     global $wp_query;
     //Renders the filtered layout for content + thumbnail
     if ( isset($_layout['alternate']) && $_layout['alternate'] ) {
       if ( 0 == $wp_query->current_post % 2 ) {
-        $this -> czr_render_content_view( $_content_model ) ;
-        CZR_post_thumbnails::$instance -> czr_render_thumb_view( $_thumb_model , $_layout['thumb'] );
+        $this -> czr_fn_render_content_view( $_content_model ) ;
+        CZR_post_thumbnails::$instance -> czr_fn_render_thumb_view( $_thumb_model , $_layout['thumb'] );
       }
       else {
-        CZR_post_thumbnails::$instance -> czr_render_thumb_view( $_thumb_model , $_layout['thumb'] );
-        $this -> czr_render_content_view( $_content_model );
+        CZR_post_thumbnails::$instance -> czr_fn_render_thumb_view( $_thumb_model , $_layout['thumb'] );
+        $this -> czr_fn_render_content_view( $_content_model );
       }
     }
     else if ( isset($_layout['show_thumb_first']) && ! $_layout['show_thumb_first'] ) {
-        $this -> czr_render_content_view( $_content_model );
-        CZR_post_thumbnails::$instance -> czr_render_thumb_view( $_thumb_model , $_layout['thumb'] );
+        $this -> czr_fn_render_content_view( $_content_model );
+        CZR_post_thumbnails::$instance -> czr_fn_render_thumb_view( $_thumb_model , $_layout['thumb'] );
     }
     else {
-      CZR_post_thumbnails::$instance -> czr_render_thumb_view( $_thumb_model , $_layout['thumb'] );
-      $this -> czr_render_content_view( $_content_model );
+      CZR_post_thumbnails::$instance -> czr_fn_render_thumb_view( $_thumb_model , $_layout['thumb'] );
+      $this -> czr_fn_render_content_view( $_content_model );
     }
 
     //renders the hr separator after each article
@@ -229,7 +229,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.0
   */
-  private function czr_render_content_view( $_content_model ) {
+  private function czr_fn_render_content_view( $_content_model ) {
     //extract "_layout_class" , "_icon_class" , "_content"
     extract($_content_model);
     $_sub_class = 'entry-summary';
@@ -284,14 +284,14 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.2.0
   */
-  function czr_set_thumb_shape( $thumb_wrapper, $thumb_img ) {
-    $_shape = esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_thumb_shape') );
+  function czr_fn_set_thumb_shape( $thumb_wrapper, $thumb_img ) {
+    $_shape = esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_post_list_thumb_shape') );
 
     //1) check if shape is rounded, squared on rectangular
     if ( ! $_shape || false !== strpos($_shape, 'rounded') || false !== strpos($_shape, 'squared') )
       return $thumb_wrapper;
 
-    $_position = esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_thumb_position' ) );
+    $_position = esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_post_list_thumb_position' ) );
     return sprintf('<div class="%4$s"><a class="tc-rectangular-thumb" href="%1$s" title="%2s">%3$s</a></div>',
           get_permalink( get_the_ID() ),
           esc_attr( strip_tags( get_the_title( get_the_ID() ) ) ),
@@ -308,7 +308,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.3.2
   */
-  function czr_add_post_list_context( $_classes ) {
+  function czr_fn_add_post_list_context( $_classes ) {
     return array_merge( $_classes , array( 'tc-post-list-context' ) );
   }
 
@@ -320,14 +320,14 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.2.0
   */
-  public function czr_post_list_controller() {
+  public function czr_fn_post_list_controller() {
     global $wp_query;
     //must be archive or search result. Returns false if home is empty in options.
-    return apply_filters( 'czr_post_list_controller',
+    return apply_filters( 'czr_fn_post_list_controller',
       ! is_singular()
       && ! is_404()
       && 0 != $wp_query -> post_count
-      && ! czr__f( '__is_home_empty')
+      && ! czr_fn__f( '__is_home_empty')
     );
   }
 
@@ -340,7 +340,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.1.20
   */
-  function czr_include_cpt_in_lists( $query ) {
+  function czr_fn_include_cpt_in_lists( $query ) {
     if (
       is_admin()
       || ! $query->is_main_query()
@@ -375,7 +375,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.0.10
   */
-  function czr_include_attachments_in_search( $query ) {
+  function czr_fn_include_attachments_in_search( $query ) {
       if (! is_search() || ! apply_filters( 'tc_include_attachments_in_search_results' , false ) )
         return;
 
@@ -396,7 +396,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.4.10
   */
-  function czr_filter_home_blog_posts_by_tax( $query ) {
+  function czr_fn_filter_home_blog_posts_by_tax( $query ) {
       // when we have to filter?
       // in home and blog page
       if (
@@ -408,8 +408,8 @@ class CZR_post_list {
      // categories
      // we have to ignore sticky posts (do not prepend them)
      // disable grid sticky post expansion
-     $cats = CZR_utils::$inst -> czr_opt('tc_blog_restrict_by_cat');
-     $cats = array_filter( $cats, array( CZR_utils::$inst , 'czr_category_id_exists' ) );
+     $cats = CZR_utils::$inst -> czr_fn_opt('tc_blog_restrict_by_cat');
+     $cats = array_filter( $cats, array( CZR_utils::$inst , 'czr_fn_category_id_exists' ) );
 
      if ( is_array( $cats ) && ! empty( $cats ) ){
          $query->set('category__in', $cats );
@@ -423,8 +423,8 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.2.0
   */
-  function czr_add_thumb_shape_name( $_classes ) {
-    return array_merge( $_classes , array(esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_thumb_shape') ) ) );
+  function czr_fn_add_thumb_shape_name( $_classes ) {
+    return array_merge( $_classes , array(esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_post_list_thumb_shape') ) ) );
   }
 
 
@@ -434,8 +434,8 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.2.0
   */
-  function czr_set_excerpt_length( $length ) {
-    $_custom = esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_excerpt_length' ) );
+  function czr_fn_set_excerpt_length( $length ) {
+    $_custom = esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_post_list_excerpt_length' ) );
     return ( false === $_custom || !is_numeric($_custom) ) ? $length : $_custom;
   }
 
@@ -446,10 +446,10 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.2.0
   */
-  function czr_set_post_list_layout( $_layout ) {
-    $_position                  = esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_thumb_position' ) );
+  function czr_fn_set_post_list_layout( $_layout ) {
+    $_position                  = esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_post_list_thumb_position' ) );
     //since 3.4.16 the alternate layout is not available when the position is top or bottom
-    $_layout['alternate']        = ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_thumb_alternate' ) )
+    $_layout['alternate']        = ( 0 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_post_list_thumb_alternate' ) )
                                    || in_array( $_position, array( 'top', 'bottom') ) ) ? false : true;
     $_layout['show_thumb_first'] = ( 'left' == $_position || 'top' == $_position ) ? true : false;
     $_layout['content']          = ( 'left' == $_position || 'right' == $_position ) ? $_layout['content'] : 'span12';
@@ -464,8 +464,8 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.2.0
   */
-  function czr_set_content_class( $_classes ) {
-    $_position                  = esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_thumb_position' ) );
+  function czr_fn_set_content_class( $_classes ) {
+    $_position                  = esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_post_list_thumb_position' ) );
     return array_merge( $_classes , array( "thumb-position-{$_position}") );
   }
 
@@ -479,12 +479,12 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.2.6
   */
-  function czr_change_thumbnail_inline_css_width( $_style,  $image, $_filtered_thumb_size) {
+  function czr_fn_change_thumbnail_inline_css_width( $_style,  $image, $_filtered_thumb_size) {
     //conditions :
     //note : handled with javascript if tc_center_img option enabled
     $_bool = array_product(
       array(
-        ! esc_attr( CZR_utils::$inst->czr_opt( 'tc_center_img') ),
+        ! esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_center_img') ),
         false != $image,
         ! empty($image),
         isset($_filtered_thumb_size['width']),
@@ -496,7 +496,7 @@ class CZR_post_list {
 
     $_width     = $_filtered_thumb_size['width'];
     $_height    = $_filtered_thumb_size['height'];
-    $_shape     = esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_thumb_shape') );
+    $_shape     = esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_post_list_thumb_shape') );
     $_is_rectangular = ! $_shape || false !== strpos($_shape, 'rounded') || false !== strpos($_shape, 'squared') ? false : true;
     if ( ! is_single() && ! $_is_rectangular )
       return $_style;
@@ -512,10 +512,10 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.2.6
   */
-  function czr_write_thumbnail_inline_css( $_css ) {
-    if ( ! $this -> czr_post_list_controller() )
+  function czr_fn_write_thumbnail_inline_css( $_css ) {
+    if ( ! $this -> czr_fn_post_list_controller() )
       return $_css;
-    $_list_thumb_height     = esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_thumb_height' ) );
+    $_list_thumb_height     = esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_post_list_thumb_height' ) );
     $_list_thumb_height     = (! $_list_thumb_height || ! is_numeric($_list_thumb_height) ) ? 250 : $_list_thumb_height;
 
     return sprintf("%s\n%s",
@@ -534,12 +534,12 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.2.0
   */
-  function czr_set_thumb_size( $_default_size ) {
-    $_shape = esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_thumb_shape') );
+  function czr_fn_set_thumb_size( $_default_size ) {
+    $_shape = esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_post_list_thumb_shape') );
     if ( ! $_shape || false !== strpos($_shape, 'rounded') || false !== strpos($_shape, 'squared') )
       return $_default_size;
 
-    $_position                  = esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_thumb_position' ) );
+    $_position                  = esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_post_list_thumb_position' ) );
     return ( 'top' == $_position || 'bottom' == $_position ) ? 'tc_rectangular_size' : $_default_size;
   }
 
@@ -554,7 +554,7 @@ class CZR_post_list {
   * @package Customizr
   * @since Customizr 3.3+
   */
-  function czr_add_support_for_shortcode_special_chars( $_content ) {
+  function czr_fn_add_support_for_shortcode_special_chars( $_content ) {
     return str_replace( ']]>', ']]&gt;', apply_filters( 'the_content', $_content ) );
   }
 
@@ -567,11 +567,11 @@ class CZR_post_list {
   * hook : __before_loop
   * @since Customizr 3.4+
   */
-  function czr_maybe_display_img_smartload_help( $the_content ) {
-    if ( ! ( $this -> czr_post_list_controller() && CZR_placeholders::czr_is_img_smartload_help_on( $text = '', $min_img_num = 0 ) ) )
+  function czr_fn_maybe_display_img_smartload_help( $the_content ) {
+    if ( ! ( $this -> czr_fn_post_list_controller() && CZR_placeholders::czr_fn_is_img_smartload_help_on( $text = '', $min_img_num = 0 ) ) )
       return;
 
-    CZR_placeholders::czr_get_smartload_help_block( $echo = true );
+    CZR_placeholders::czr_fn_get_smartload_help_block( $echo = true );
   }
 
 }//end of class

--- a/inc/parts/class-content-post_list.php
+++ b/inc/parts/class-content-post_list.php
@@ -11,8 +11,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_post_list' ) ) :
-class TC_post_list {
+if ( ! class_exists( 'CZR_post_list' ) ) :
+class CZR_post_list {
   static $instance;
   function __construct () {
     self::$instance =& $this;
@@ -77,7 +77,7 @@ class TC_post_list {
       return;
     //displays the article with filtered layout : content + thumbnail
     add_action ( '__loop'               , array( $this , 'tc_prepare_section_view') );
-    
+
     //page help blocks
     add_filter( '__before_loop'         , array( $this , 'tc_maybe_display_img_smartload_help') );
 
@@ -116,9 +116,9 @@ class TC_post_list {
       return;
 
     //get the filtered post list layout
-    $_layout        = apply_filters( 'tc_post_list_layout', TC_init::$instance -> post_list_layout );
+    $_layout        = apply_filters( 'tc_post_list_layout', CZR_init::$instance -> post_list_layout );
     $_content_model = $this -> tc_get_content_model( $_layout );
-    $_thumb_model   = $this -> tc_show_thumb() ? TC_post_thumbnails::$instance -> tc_get_thumbnail_model() : array();
+    $_thumb_model   = $this -> tc_show_thumb() ? CZR_post_thumbnails::$instance -> tc_get_thumbnail_model() : array();
 
     $this -> tc_render_section_view( $_layout, $_content_model, $_thumb_model );
   }
@@ -160,7 +160,7 @@ class TC_post_list {
     //When do we show the post excerpt?
     //1) when set in options
     //2) + other filters conditions
-    return (bool) apply_filters( 'tc_show_excerpt', 'full' != esc_attr( TC_utils::$inst->tc_opt( 'tc_post_list_length' ) ) );
+    return (bool) apply_filters( 'tc_show_excerpt', 'full' != esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_length' ) ) );
   }
 
 
@@ -178,8 +178,8 @@ class TC_post_list {
     return apply_filters( 'tc_show_thumb', array_product(
         array(
           $this -> tc_show_excerpt(),
-          TC_post_thumbnails::$instance -> tc_has_thumb(),
-          0 != esc_attr( TC_utils::$inst->tc_opt( 'tc_post_list_show_thumb' ) )
+          CZR_post_thumbnails::$instance -> tc_has_thumb(),
+          0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_show_thumb' ) )
         )
       )
     );
@@ -201,19 +201,19 @@ class TC_post_list {
     if ( isset($_layout['alternate']) && $_layout['alternate'] ) {
       if ( 0 == $wp_query->current_post % 2 ) {
         $this -> tc_render_content_view( $_content_model ) ;
-        TC_post_thumbnails::$instance -> tc_render_thumb_view( $_thumb_model , $_layout['thumb'] );
+        CZR_post_thumbnails::$instance -> tc_render_thumb_view( $_thumb_model , $_layout['thumb'] );
       }
       else {
-        TC_post_thumbnails::$instance -> tc_render_thumb_view( $_thumb_model , $_layout['thumb'] );
+        CZR_post_thumbnails::$instance -> tc_render_thumb_view( $_thumb_model , $_layout['thumb'] );
         $this -> tc_render_content_view( $_content_model );
       }
     }
     else if ( isset($_layout['show_thumb_first']) && ! $_layout['show_thumb_first'] ) {
         $this -> tc_render_content_view( $_content_model );
-        TC_post_thumbnails::$instance -> tc_render_thumb_view( $_thumb_model , $_layout['thumb'] );
+        CZR_post_thumbnails::$instance -> tc_render_thumb_view( $_thumb_model , $_layout['thumb'] );
     }
     else {
-      TC_post_thumbnails::$instance -> tc_render_thumb_view( $_thumb_model , $_layout['thumb'] );
+      CZR_post_thumbnails::$instance -> tc_render_thumb_view( $_thumb_model , $_layout['thumb'] );
       $this -> tc_render_content_view( $_content_model );
     }
 
@@ -285,13 +285,13 @@ class TC_post_list {
   * @since Customizr 3.2.0
   */
   function tc_set_thumb_shape( $thumb_wrapper, $thumb_img ) {
-    $_shape = esc_attr( TC_utils::$inst->tc_opt( 'tc_post_list_thumb_shape') );
+    $_shape = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_thumb_shape') );
 
     //1) check if shape is rounded, squared on rectangular
     if ( ! $_shape || false !== strpos($_shape, 'rounded') || false !== strpos($_shape, 'squared') )
       return $thumb_wrapper;
 
-    $_position = esc_attr( TC_utils::$inst->tc_opt( 'tc_post_list_thumb_position' ) );
+    $_position = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_thumb_position' ) );
     return sprintf('<div class="%4$s"><a class="tc-rectangular-thumb" href="%1$s" title="%2s">%3$s</a></div>',
           get_permalink( get_the_ID() ),
           esc_attr( strip_tags( get_the_title( get_the_ID() ) ) ),
@@ -352,17 +352,17 @@ class TC_post_list {
     //filter the post types to include, they must be public and not excluded from search
     //we also exclude the built-in types, to exclude pages and attachments, we'll add standard posts later
     $post_types         = get_post_types( array( 'public' => true, 'exclude_from_search' => false, '_builtin' => false) );
-    
+
     //add standard posts
     $post_types['post'] = 'post';
     if ( $query -> is_search ){
       // add standard pages in search results => new wp behavior
       $post_types['page'] = 'page';
       // allow attachments to be included in search results by tc_include_attachments_in_search method
-      if ( apply_filters( 'tc_include_attachments_in_search_results' , false ) )      
-        $post_types['attachment'] = 'attachment';    
+      if ( apply_filters( 'tc_include_attachments_in_search_results' , false ) )
+        $post_types['attachment'] = 'attachment';
     }
-    
+
     // add standard pages in search results
     $query->set('post_type', $post_types );
   }
@@ -406,14 +406,14 @@ class TC_post_list {
         return;
 
      // categories
-     // we have to ignore sticky posts (do not prepend them) 
+     // we have to ignore sticky posts (do not prepend them)
      // disable grid sticky post expansion
-     $cats = TC_utils::$inst -> tc_opt('tc_blog_restrict_by_cat');
-     $cats = array_filter( $cats, array( TC_utils::$inst , 'tc_category_id_exists' ) ); 
-     
+     $cats = CZR_utils::$inst -> tc_opt('tc_blog_restrict_by_cat');
+     $cats = array_filter( $cats, array( CZR_utils::$inst , 'tc_category_id_exists' ) );
+
      if ( is_array( $cats ) && ! empty( $cats ) ){
-         $query->set('category__in', $cats );     
-         $query->set('ignore_sticky_posts', 1 );     
+         $query->set('category__in', $cats );
+         $query->set('ignore_sticky_posts', 1 );
          add_filter('tc_grid_expand_featured', '__return_false');
      }
   }
@@ -424,7 +424,7 @@ class TC_post_list {
   * @since Customizr 3.2.0
   */
   function tc_add_thumb_shape_name( $_classes ) {
-    return array_merge( $_classes , array(esc_attr( TC_utils::$inst->tc_opt( 'tc_post_list_thumb_shape') ) ) );
+    return array_merge( $_classes , array(esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_thumb_shape') ) ) );
   }
 
 
@@ -435,7 +435,7 @@ class TC_post_list {
   * @since Customizr 3.2.0
   */
   function tc_set_excerpt_length( $length ) {
-    $_custom = esc_attr( TC_utils::$inst->tc_opt( 'tc_post_list_excerpt_length' ) );
+    $_custom = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_excerpt_length' ) );
     return ( false === $_custom || !is_numeric($_custom) ) ? $length : $_custom;
   }
 
@@ -447,9 +447,9 @@ class TC_post_list {
   * @since Customizr 3.2.0
   */
   function tc_set_post_list_layout( $_layout ) {
-    $_position                  = esc_attr( TC_utils::$inst->tc_opt( 'tc_post_list_thumb_position' ) );
+    $_position                  = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_thumb_position' ) );
     //since 3.4.16 the alternate layout is not available when the position is top or bottom
-    $_layout['alternate']        = ( 0 == esc_attr( TC_utils::$inst->tc_opt( 'tc_post_list_thumb_alternate' ) ) 
+    $_layout['alternate']        = ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_thumb_alternate' ) )
                                    || in_array( $_position, array( 'top', 'bottom') ) ) ? false : true;
     $_layout['show_thumb_first'] = ( 'left' == $_position || 'top' == $_position ) ? true : false;
     $_layout['content']          = ( 'left' == $_position || 'right' == $_position ) ? $_layout['content'] : 'span12';
@@ -465,13 +465,13 @@ class TC_post_list {
   * @since Customizr 3.2.0
   */
   function tc_set_content_class( $_classes ) {
-    $_position                  = esc_attr( TC_utils::$inst->tc_opt( 'tc_post_list_thumb_position' ) );
+    $_position                  = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_thumb_position' ) );
     return array_merge( $_classes , array( "thumb-position-{$_position}") );
   }
 
 
   /**
-  * hook tc_post_thumb_inline_style (declared in TC_post_thumbnails)
+  * hook tc_post_thumb_inline_style (declared in CZR_post_thumbnails)
   * Replace default widht:auto by width:100%
   * @param array of args passed by apply_filters_ref_array method
   * @return  string
@@ -484,7 +484,7 @@ class TC_post_list {
     //note : handled with javascript if tc_center_img option enabled
     $_bool = array_product(
       array(
-        ! esc_attr( TC_utils::$inst->tc_opt( 'tc_center_img') ),
+        ! esc_attr( CZR_utils::$inst->tc_opt( 'tc_center_img') ),
         false != $image,
         ! empty($image),
         isset($_filtered_thumb_size['width']),
@@ -496,7 +496,7 @@ class TC_post_list {
 
     $_width     = $_filtered_thumb_size['width'];
     $_height    = $_filtered_thumb_size['height'];
-    $_shape     = esc_attr( TC_utils::$inst->tc_opt( 'tc_post_list_thumb_shape') );
+    $_shape     = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_thumb_shape') );
     $_is_rectangular = ! $_shape || false !== strpos($_shape, 'rounded') || false !== strpos($_shape, 'squared') ? false : true;
     if ( ! is_single() && ! $_is_rectangular )
       return $_style;
@@ -515,7 +515,7 @@ class TC_post_list {
   function tc_write_thumbnail_inline_css( $_css ) {
     if ( ! $this -> tc_post_list_controller() )
       return $_css;
-    $_list_thumb_height     = esc_attr( TC_utils::$inst->tc_opt( 'tc_post_list_thumb_height' ) );
+    $_list_thumb_height     = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_thumb_height' ) );
     $_list_thumb_height     = (! $_list_thumb_height || ! is_numeric($_list_thumb_height) ) ? 250 : $_list_thumb_height;
 
     return sprintf("%s\n%s",
@@ -529,17 +529,17 @@ class TC_post_list {
 
 
   /**
-  * hook : tc_thumb_size_name (declared in TC_post_thumbnails)
+  * hook : tc_thumb_size_name (declared in CZR_post_thumbnails)
   *
   * @package Customizr
   * @since Customizr 3.2.0
   */
   function tc_set_thumb_size( $_default_size ) {
-    $_shape = esc_attr( TC_utils::$inst->tc_opt( 'tc_post_list_thumb_shape') );
+    $_shape = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_thumb_shape') );
     if ( ! $_shape || false !== strpos($_shape, 'rounded') || false !== strpos($_shape, 'squared') )
       return $_default_size;
 
-    $_position                  = esc_attr( TC_utils::$inst->tc_opt( 'tc_post_list_thumb_position' ) );
+    $_position                  = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_thumb_position' ) );
     return ( 'top' == $_position || 'bottom' == $_position ) ? 'tc_rectangular_size' : $_default_size;
   }
 
@@ -568,10 +568,10 @@ class TC_post_list {
   * @since Customizr 3.4+
   */
   function tc_maybe_display_img_smartload_help( $the_content ) {
-    if ( ! ( $this -> tc_post_list_controller() && TC_placeholders::tc_is_img_smartload_help_on( $text = '', $min_img_num = 0 ) ) )
+    if ( ! ( $this -> tc_post_list_controller() && CZR_placeholders::tc_is_img_smartload_help_on( $text = '', $min_img_num = 0 ) ) )
       return;
-    
-    TC_placeholders::tc_get_smartload_help_block( $echo = true );
+
+    CZR_placeholders::tc_get_smartload_help_block( $echo = true );
   }
 
 }//end of class

--- a/inc/parts/class-content-post_list.php
+++ b/inc/parts/class-content-post_list.php
@@ -160,7 +160,7 @@ class CZR_post_list {
     //When do we show the post excerpt?
     //1) when set in options
     //2) + other filters conditions
-    return (bool) apply_filters( 'czr_fn_show_excerpt', 'full' != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_post_list_length' ) ) );
+    return (bool) apply_filters( 'tc_show_excerpt', 'full' != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_post_list_length' ) ) );
   }
 
 
@@ -175,7 +175,7 @@ class CZR_post_list {
     //2) the excerpt option is not set to full
     //3) user settings in customizer
     //4) filter's conditions
-    return apply_filters( 'czr_fn_show_thumb', array_product(
+    return apply_filters( 'tc_show_thumb', array_product(
         array(
           $this -> czr_fn_show_excerpt(),
           CZR_post_thumbnails::$instance -> czr_fn_has_thumb(),
@@ -323,7 +323,7 @@ class CZR_post_list {
   public function czr_fn_post_list_controller() {
     global $wp_query;
     //must be archive or search result. Returns false if home is empty in options.
-    return apply_filters( 'czr_fn_post_list_controller',
+    return apply_filters( 'tc_post_list_controller',
       ! is_singular()
       && ! is_404()
       && 0 != $wp_query -> post_count

--- a/inc/parts/class-content-post_list_grid.php
+++ b/inc/parts/class-content-post_list_grid.php
@@ -26,12 +26,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
 
           //Font size filter
           //Updates the array of font sizes for a given sidebar layout
-          add_filter( 'czr_fn_get_grid_font_sizes'      , array( $this , 'czr_fn_set_layout_font_size' ), 10, 4 );
-
-          //Various CSS filters
-          //those filters are fired on hook : tc_user_options_style => fired on hook : wp_enqueue_scripts
-          add_filter( 'tc_grid_title_sizes'         , array( $this , 'tc_set_grid_title_size'), 10, 2 );
-          add_filter( 'tc_grid_p_sizes'             , array( $this , 'tc_set_grid_p_size'), 10, 2 );
+          add_filter( 'tc_get_grid_font_sizes'      , array( $this , 'czr_fn_set_layout_font_size' ), 10, 4 );
 
           //append inline style to the custom stylesheet
           //! tc_user_options_style filter is shared by several classes => must always check the local context inside the callback before appending new css
@@ -62,7 +57,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
           //icon option
           add_filter( 'tc-grid-thumb-html'          , array( $this, 'czr_fn_set_grid_icon_visibility') );
           //Layout filter
-          add_filter( 'czr_fn_get_grid_cols'            , array( $this, 'czr_fn_set_grid_section_cols'), 20 , 2 );
+          add_filter( 'tc_get_grid_cols'            , array( $this, 'czr_fn_set_grid_section_cols'), 20 , 2 );
           //pre loop hooks
           add_action( '__before_article_container'  , array( $this, 'czr_fn_set_grid_before_loop_hooks'), 5 );
           //loop hooks
@@ -92,14 +87,14 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
           add_action( '__grid_single_post_content'  , array( $this, 'czr_fn_grid_display_post_link'), $_content_priorities['link'] );
           add_action( '__grid_single_post_content'  , array( $this, 'czr_fn_grid_display_fade_excerpt'), 100 );
           //expanded sticky post : filter the figcaption content to include the post title
-          add_filter( 'czr_fn_grid_display_figcaption_content' , array( $this, 'czr_fn_grid_set_expanded_post_title') );
+          add_filter( 'tc_grid_display_figcaption_content' , array( $this, 'czr_fn_grid_set_expanded_post_title') );
 
           //ARTICLE CONTAINER CSS CLASSES TO HANDLE EFFECT LIKE SHADOWS
           add_filter( 'tc_article_container_class'  , array( $this, 'czr_fn_grid_container_set_classes' ) );
 
           //COMMENT BUBBLE
           remove_filter( 'tc_the_title'             , array( CZR_comments::$instance, 'czr_fn_display_comment_bubble' ) , 1 );
-          add_filter( 'czr_fn_grid_get_single_post_html'  , array( $this, 'czr_fn_grid_display_comment_bubble' ) );
+          add_filter( 'tc_grid_get_single_post_html'  , array( $this, 'czr_fn_grid_display_comment_bubble' ) );
 
           //POST METAS
           remove_filter( 'tc_meta_utility_text'     , array( CZR_post_metas::$instance , 'czr_fn_add_link_to_post_after_metas'), 20 );
@@ -122,8 +117,8 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
           remove_action( '__loop'                   , array( CZR_post_list::$instance, 'czr_fn_prepare_section_view') );
           add_action( '__loop'                      , array( $this, 'czr_fn_grid_prepare_single_post') );
 
-          if ( CZR_headings::$instance -> czr_fn_is_edit_enabled() && apply_filters( 'czr_fn_grid_render_expanded_edit_link', true ) )
-            add_filter( 'czr_fn_grid_get_single_post_html' , array( $this, 'czr_fn_grid_render_expanded_edit_link' ), 50 );
+          if ( CZR_headings::$instance -> czr_fn_is_edit_enabled() && apply_filters( 'tc_grid_render_expanded_edit_link', true ) )
+            add_filter( 'tc_grid_get_single_post_html' , array( $this, 'czr_fn_grid_render_expanded_edit_link' ), 50 );
         }
 
 
@@ -248,7 +243,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * hook : __grid_single_post_content
         */
         function czr_fn_grid_display_post_link(){
-          if ( ! apply_filters( 'czr_fn_grid_display_post_link' , true ) )
+          if ( ! apply_filters( 'tc_grid_display_post_link' , true ) )
             return;
           printf( '<a class="tc-grid-bg-link" href="%1$s" title="%2$s"></a>',
               get_permalink( get_the_ID() ),
@@ -275,7 +270,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
           ?>
               <div class="entry-summary">
                 <?php
-                  echo apply_filters( 'czr_fn_grid_display_figcaption_content',
+                  echo apply_filters( 'tc_grid_display_figcaption_content',
                     sprintf('<div class="tc-g-cont">%s</div>',
                       get_the_excerpt()
                     )
@@ -458,7 +453,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
             <?php
           $html = ob_get_contents();
           if ($html) ob_end_clean();
-          return apply_filters( 'czr_fn_grid_get_single_post_html', $html, $post_list_content_class );
+          return apply_filters( 'tc_grid_get_single_post_html', $html, $post_list_content_class );
         }
 
 
@@ -633,7 +628,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
           }
 
           return apply_filters(
-            'czr_fn_get_grid_font_sizes',
+            'tc_get_grid_font_sizes',
             isset($_col_media_matrix[$_col_nb]) ? $_col_media_matrix[$_col_nb] : array( 'xl' , 'l' , 'm', 'l', 'm' ),
             $_col_nb,
             $_col_media_matrix,
@@ -689,7 +684,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * returns ratio of size / body size for a given selector type ( headings or paragraphs )
         */
         private function czr_fn_get_grid_font_ratios( $_size = 'xl' , $_sel = 'h' ) {
-          $_ratios =  apply_filters( 'czr_fn_get_grid_font_ratios' , array(
+          $_ratios =  apply_filters( 'tc_get_grid_font_ratios' , array(
               'xxxl' => array( 'h' => 2.10, 'p' => 1 ),
               'xxl' => array( 'h' => 1.86, 'p' => 1 ),
               'xl' => array( 'h' => 1.60, 'p' => 0.93 ),
@@ -823,7 +818,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
           }
 
           $_h = isset( $_grid_col_height_map[$_cols_nb][$_key] ) ? $_grid_col_height_map[$_cols_nb][$_key] : $_h;
-          return apply_filters( 'czr_fn_get_grid_column_height' , $_h, $_cols_nb, $_current_layout );
+          return apply_filters( 'tc_get_grid_column_height' , $_h, $_cols_nb, $_current_layout );
         }
 
 
@@ -909,13 +904,13 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return bool
         */
         public function czr_fn_is_grid_enabled() {
-          return apply_filters( 'czr_fn_is_grid_enabled', 'grid' == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_post_list_grid') ) && $this -> czr_fn_is_grid_context_matching() );
+          return apply_filters( 'tc_is_grid_enabled', 'grid' == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_post_list_grid') ) && $this -> czr_fn_is_grid_context_matching() );
         }
 
 
         /* retrieves number of cols option, and wrap it into a filter */
         private function czr_fn_get_grid_cols() {
-          return apply_filters( 'czr_fn_get_grid_cols',
+          return apply_filters( 'tc_get_grid_cols',
             esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_grid_columns') ),
             CZR_utils::czr_fn_get_layout( $this -> post_id , 'class' )
           );

--- a/inc/parts/class-content-post_list_grid.php
+++ b/inc/parts/class-content-post_list_grid.php
@@ -42,7 +42,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * hook : wp
         */
         function czr_fn_set_grid_hooks(){
-          if ( ! apply_filters( 'czr_fn_set_grid_hooks' , $this -> czr_fn_is_grid_enabled() ) )
+          if ( ! apply_filters( 'tc_set_grid_hooks' , $this -> czr_fn_is_grid_enabled() ) )
               return;
 
           $this -> post_id = CZR_utils::czr_fn_id();

--- a/inc/parts/class-content-post_list_grid.php
+++ b/inc/parts/class-content-post_list_grid.php
@@ -47,10 +47,10 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * hook : wp
         */
         function czr_set_grid_hooks(){
-          if ( ! apply_filters( 'tc_set_grid_hooks' , $this -> tc_is_grid_enabled() ) )
+          if ( ! apply_filters( 'tc_set_grid_hooks' , $this -> czr_is_grid_enabled() ) )
               return;
 
-          $this -> post_id = CZR_utils::tc_id();
+          $this -> post_id = CZR_utils::czr_id();
 
           do_action( '__post_list_grid' );
           //Disable icon titles
@@ -122,7 +122,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
           remove_action( '__loop'                   , array( CZR_post_list::$instance, 'tc_prepare_section_view') );
           add_action( '__loop'                      , array( $this, 'tc_grid_prepare_single_post') );
 
-          if ( CZR_headings::$instance -> tc_is_edit_enabled() && apply_filters( 'tc_grid_render_expanded_edit_link', true ) )
+          if ( CZR_headings::$instance -> czr_is_edit_enabled() && apply_filters( 'tc_grid_render_expanded_edit_link', true ) )
             add_filter( 'tc_grid_get_single_post_html' , array( $this, 'tc_grid_render_expanded_edit_link' ), 50 );
         }
 
@@ -139,7 +139,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
           global $wp_query;
           $current_post   = $wp_query -> current_post;
           $start_post     = $this -> expanded_sticky ? 1 : 0;
-          $cols           = $this -> tc_get_grid_section_cols();
+          $cols           = $this -> czr_get_grid_section_cols();
 
           if ( '__before_article' == current_filter() &&
               ( $start_post == $current_post ||
@@ -168,7 +168,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         */
         function czr_grid_prepare_single_post() {
           global $post;
-          if ( ! isset($post) || empty($post) || ! apply_filters( 'tc_show_post_in_post_list', $this -> tc_is_grid_context_matching() , $post ) )
+          if ( ! isset($post) || empty($post) || ! apply_filters( 'tc_show_post_in_post_list', $this -> czr_is_grid_context_matching() , $post ) )
             return;
 
           // get the filtered post list layout
@@ -176,7 +176,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
 
           // SET HOOKS FOR POST TITLES AND METAS
           // Default condition : must be a non sticky post
-          if ( apply_filters( 'tc_render_grid_headings_view' , ! $this -> tc_force_current_post_expansion() ) ) {
+          if ( apply_filters( 'tc_render_grid_headings_view' , ! $this -> czr_force_current_post_expansion() ) ) {
               $hook_prefix = '__before';
               if ( $_layout['show_thumb_first'] )
                   $hook_prefix = '__after';
@@ -187,33 +187,33 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
           // THUMBNAIL : cache the post format icon first
           //add thumbnail html (src, width, height) if any
           $_thumb_html = '';
-          if ( $this -> tc_grid_show_thumb() ) {
+          if ( $this -> czr_grid_show_thumb() ) {
             //return an array( $tc_thumb(image object), $tc_thumb_width(string), $tc_thumb_height(string) )
-            $_thumb_model = CZR_post_thumbnails::$instance -> tc_get_thumbnail_model();
+            $_thumb_model = CZR_post_thumbnails::$instance -> czr_get_thumbnail_model();
             if ( isset($_thumb_model['tc_thumb']) )
               $_thumb_html  = $_thumb_model['tc_thumb'];
           }
           $_thumb_html = apply_filters( 'tc-grid-thumb-html' , $_thumb_html );
 
           // CONTENT : get the figcaption content => post content
-          $_post_content_html               = $this -> tc_grid_get_single_post_html( isset( $_layout['content'] ) ? $_layout['content'] : 'span6' );
+          $_post_content_html               = $this -> czr_grid_get_single_post_html( isset( $_layout['content'] ) ? $_layout['content'] : 'span6' );
 
           // ADD A WRAPPER CLASS : build single grid post wrapper class
           $_classes  = array('tc-grid-figure');
           //may be add class no-thumb
-          if ( ! $this -> tc_grid_show_thumb() )
+          if ( ! $this -> czr_grid_show_thumb() )
             array_push( $_classes, 'no-thumb' );
           else
             array_push( $_classes, 'has-thumb' );
 
           //if 1 col layout or current post is the expanded => golden ratio should be disabled
-          if ( ( '1' == $this -> tc_get_grid_cols() || $this -> tc_force_current_post_expansion() ) && ! wp_is_mobile() )
+          if ( ( '1' == $this -> czr_get_grid_cols() || $this -> czr_force_current_post_expansion() ) && ! wp_is_mobile() )
             array_push( $_classes, 'no-gold-ratio' );
 
           $_classes  = implode( ' ' , apply_filters('tc_single_grid_post_wrapper_class', $_classes ) );
 
           //RENDER VIEW
-          $this -> tc_grid_render_single_post( $_classes, $_thumb_html, $_post_content_html );
+          $this -> czr_grid_render_single_post( $_classes, $_thumb_html, $_post_content_html );
           //return apply_filters( 'tc_prepare_grid_single_post_content' , compact( '_classes', '_thumb_html', '_post_content_html') );
         }
 
@@ -261,7 +261,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * hook : __grid_single_post_content
         */
         function czr_grid_display_fade_excerpt(){
-          if ( ! apply_filters( 'tc_grid_fade_excerpt' , ! $this -> tc_force_current_post_expansion() ) )
+          if ( ! apply_filters( 'tc_grid_fade_excerpt' , ! $this -> czr_force_current_post_expansion() ) )
             return;
           printf( '<span class="tc-grid-fade_expt"></span>' );
         }
@@ -307,7 +307,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return string
         */
         function czr_grid_set_title_length( $_title ) {
-          $_max = esc_attr( CZR_utils::$inst->tc_opt( 'tc_grid_num_words') );
+          $_max = esc_attr( CZR_utils::$inst->czr_opt( 'tc_grid_num_words') );
           $_max = ( empty($_max) || ! $_max ) ? 10 : $_max;
           $_max = $_max <= 0 ? 1 : $_max;
 
@@ -329,7 +329,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * exclude the first sticky post
         */
         function czr_maybe_excl_first_sticky( $query ){
-          if ( $this -> tc_is_grid_enabled() && $this -> tc_is_sticky_expanded( $query ) )
+          if ( $this -> czr_is_grid_enabled() && $this -> czr_is_sticky_expanded( $query ) )
             $query->set('post__not_in', array( $this -> expanded_sticky ) );
         }
 
@@ -388,8 +388,8 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         */
         function czr_grid_set_article_selectors($selectors){
           $_class = sprintf( '%1$s tc-grid span%2$s',
-            apply_filters( 'tc_grid_add_expanded_class', $this -> tc_force_current_post_expansion() ) ? 'expanded' : '',
-            is_numeric( $this -> tc_get_grid_section_cols() ) ? 12 / $this -> tc_get_grid_section_cols() : 6
+            apply_filters( 'tc_grid_add_expanded_class', $this -> czr_force_current_post_expansion() ) ? 'expanded' : '',
+            is_numeric( $this -> czr_get_grid_section_cols() ) ? 12 / $this -> czr_get_grid_section_cols() : 6
           );
           return str_replace( 'row-fluid', $_class, $selectors );
         }
@@ -400,7 +400,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         */
         function czr_grid_prepare_expand_sticky(){
           global $wp_query;
-          if ( ! ( $this -> tc_is_sticky_expanded() &&
+          if ( ! ( $this -> czr_is_sticky_expanded() &&
                  $wp_query -> query_vars[ 'paged' ] == 0 ) ){
             $this -> expanded_sticky = null;
             return;
@@ -416,7 +416,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * hook : tc_thumb_size_name
         */
         function czr_set_thumb_size_name(){
-          return ( $this -> tc_get_grid_section_cols() == '1' ) ? 'tc-grid-full' : 'tc-grid';
+          return ( $this -> czr_get_grid_section_cols() == '1' ) ? 'tc-grid-full' : 'tc-grid';
         }
 
 
@@ -424,7 +424,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * hook : tc_thumb_size
         */
         function czr_set_thumb_size(){
-          $thumb = ( $this -> tc_get_grid_section_cols() == '1' ) ? 'tc_grid_full_size' : 'tc_grid_size';
+          $thumb = ( $this -> czr_get_grid_section_cols() == '1' ) ? 'tc_grid_full_size' : 'tc_grid_size';
           return CZR_init::$instance -> $thumb;
         }
 
@@ -436,9 +436,9 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         */
         function czr_grid_container_set_classes( $_classes ) {
           array_push( $_classes, 'tc-post-list-grid' );
-          if ( esc_attr( CZR_utils::$inst->tc_opt( 'tc_grid_shadow') ) )
+          if ( esc_attr( CZR_utils::$inst->czr_opt( 'tc_grid_shadow') ) )
             array_push( $_classes, 'tc-grid-shadow' );
-          if ( esc_attr( CZR_utils::$inst->tc_opt( 'tc_grid_bottom_border') ) )
+          if ( esc_attr( CZR_utils::$inst->czr_opt( 'tc_grid_bottom_border') ) )
             array_push( $_classes, 'tc-grid-border' );
           return $_classes;
         }
@@ -468,7 +468,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * inside loop
         */
         function czr_grid_display_comment_bubble( $_html ) {
-          return CZR_comments::$instance -> tc_display_comment_bubble() . $_html;
+          return CZR_comments::$instance -> czr_display_comment_bubble() . $_html;
         }
 
 
@@ -479,7 +479,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * hook : tc_grid_display_figcaption_content
         */
         function czr_grid_set_expanded_post_title( $_html ){
-          if ( ! $this -> tc_force_current_post_expansion() )
+          if ( ! $this -> czr_force_current_post_expansion() )
               return $_html;
           global $post;
           $_title = apply_filters( 'tc_grid_expanded_title' , $post->post_title );
@@ -497,7 +497,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @since Customizr 3.4.18
         */
         function czr_grid_disable_edit_in_title_expanded( $_bool ){
-          return $this -> tc_force_current_post_expansion() ? false : $_bool;
+          return $this -> czr_force_current_post_expansion() ? false : $_bool;
         }
 
 
@@ -507,8 +507,8 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @since Customizr 3.4.18
         */
         function czr_grid_render_expanded_edit_link( $_html ) {
-          if ( $this -> tc_force_current_post_expansion() )
-            $_html .= CZR_headings::$instance -> tc_render_edit_link_view( $_echo = false );
+          if ( $this -> czr_force_current_post_expansion() )
+            $_html .= CZR_headings::$instance -> czr_render_edit_link_view( $_echo = false );
           return $_html;
         }
 
@@ -519,16 +519,16 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @since Customizr 3.2.18
         */
         function czr_grid_write_inline_css( $_css ){
-          if ( ! $this -> tc_is_grid_enabled() )
+          if ( ! $this -> czr_is_grid_enabled() )
             return $_css;
 
-          $_col_nb  = $this -> tc_get_grid_cols();
+          $_col_nb  = $this -> czr_get_grid_cols();
 
           //GENERATE THE FIGURE HEIGHT CSS
-          $_current_col_figure_css  = $this -> tc_grid_get_figure_css( $_col_nb );
+          $_current_col_figure_css  = $this -> czr_grid_get_figure_css( $_col_nb );
 
           //GENERATE THE MEDIA QUERY CSS FOR FONT-SIZES
-          $_current_col_media_css   = $this -> tc_get_grid_font_css( $_col_nb );
+          $_current_col_media_css   = $this -> czr_get_grid_font_css( $_col_nb );
 
           $_css = sprintf("%s\n%s\n%s\n",
               $_css,
@@ -545,8 +545,8 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return modified html string
         */
         function czr_set_grid_icon_visibility( $_html ) {
-          $_icon_enabled = (bool) esc_attr( CZR_utils::$inst->tc_opt( 'tc_grid_icons') );
-          if ( CZR___::$instance -> tc_is_customizing() )
+          $_icon_enabled = (bool) esc_attr( CZR_utils::$inst->czr_opt( 'tc_grid_icons') );
+          if ( CZR___::$instance -> czr_is_customizing() )
             return sprintf('<div class="tc-grid-icon format-icon" style="display:%1$s"></div>%2$s',
                 $_icon_enabled ? 'inline-block' : 'none',
                 $_html
@@ -570,8 +570,8 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * Returns the paragraph and title media queries for a given layout
         */
         private function czr_get_grid_font_css( $_col_nb = '3' ) {
-          $_media_queries     = $this -> tc_get_grid_media_queries();//returns the simple array of media queries
-          $_grid_font_sizes = $this -> tc_get_grid_font_sizes( $_col_nb );//return the array of sizes (ordered by @media queries) for a given column layout
+          $_media_queries     = $this -> czr_get_grid_media_queries();//returns the simple array of media queries
+          $_grid_font_sizes = $this -> czr_get_grid_font_sizes( $_col_nb );//return the array of sizes (ordered by @media queries) for a given column layout
           $_col_rules         = array();
           $_media_queries_css = '';
 
@@ -579,10 +579,10 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
           foreach ($_media_queries as $key => $_med_query_sizes ) {
             $_size = $_grid_font_sizes[$key];//=> size like 'xxl'
             $_css_prop = array(
-              'h' => $this -> tc_grid_build_css_rules( $_size , 'h' ),
-              'p' => $this -> tc_grid_build_css_rules( $_size , 'p' )
+              'h' => $this -> czr_grid_build_css_rules( $_size , 'h' ),
+              'p' => $this -> czr_grid_build_css_rules( $_size , 'p' )
             );
-            $_rules = $this -> tc_grid_assign_css_rules_to_selectors( $_med_query_sizes , $_css_prop, $_col_nb );
+            $_rules = $this -> czr_grid_assign_css_rules_to_selectors( $_med_query_sizes , $_css_prop, $_col_nb );
             $_media_queries_css .= "
               @media {$_med_query_sizes} {{$_rules}}
             ";
@@ -623,7 +623,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
           );
           //if a specific media query is requested, return a string
           if ( ! is_null($_requested_media_size) ) {
-            $_media_queries = $this -> tc_get_grid_media_queries();
+            $_media_queries = $this -> czr_get_grid_media_queries();
             //get the key = position of requested size in the current layout
             $_key = array_search( $_requested_media_size, $_media_queries);
             return apply_filters(
@@ -637,7 +637,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
             isset($_col_media_matrix[$_col_nb]) ? $_col_media_matrix[$_col_nb] : array( 'xl' , 'l' , 'm', 'l', 'm' ),
             $_col_nb,
             $_col_media_matrix,
-            CZR_utils::tc_get_layout( $this -> post_id , 'class' )
+            CZR_utils::czr_get_layout( $this -> post_id , 'class' )
           );
         }
 
@@ -717,10 +717,10 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         private function czr_grid_assign_css_rules_to_selectors( $_media_query, $_css_prop, $_col_nb ) {
           $_css = '';
           //Add one column font rules if there's a sticky post
-          if ( $this -> tc_is_sticky_expanded() || '1' == $_col_nb ) {
-            $_size      = $this -> tc_get_grid_font_sizes( $_col_nb = '1', $_media_query );//size like xxl
-            $_h_one_col = $this -> tc_grid_build_css_rules( $_size , 'h' );
-            $_p_one_col = $this -> tc_grid_build_css_rules( $_size , 'p' );
+          if ( $this -> czr_is_sticky_expanded() || '1' == $_col_nb ) {
+            $_size      = $this -> czr_get_grid_font_sizes( $_col_nb = '1', $_media_query );//size like xxl
+            $_h_one_col = $this -> czr_grid_build_css_rules( $_size , 'h' );
+            $_p_one_col = $this -> czr_grid_build_css_rules( $_size , 'p' );
             $_css .= "
                 .tc-post-list-grid .grid-cols-1 .entry-title {{$_h_one_col}}
                 .tc-post-list-grid .grid-cols-1 .tc-g-cont {{$_p_one_col}}
@@ -744,12 +744,12 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * 2) user layout is one column
         */
         private function czr_grid_get_figure_css( $_col_nb = '3' ) {
-          $_height = $this -> tc_get_grid_column_height( $_col_nb );
+          $_height = $this -> czr_get_grid_column_height( $_col_nb );
           $_cols_class      = sprintf( 'grid-cols-%s' , $_col_nb );
           $_css = '';
           //Add one column height if there's a sticky post
-          if ( $this -> tc_is_sticky_expanded() && '1' != $_col_nb ) {
-            $_height_col_one = $this -> tc_get_grid_column_height( '1' );
+          if ( $this -> czr_is_sticky_expanded() && '1' != $_col_nb ) {
+            $_height_col_one = $this -> czr_get_grid_column_height( '1' );
             $_css .= ".grid-cols-1 figure {
                   height:{$_height_col_one}px;
                   max-height:{$_height_col_one}px;
@@ -774,9 +774,9 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         */
         private function czr_grid_build_css_rules( $_size = 'xl', $_wot = 'h' ) {
           $_lh_ratio = apply_filters( 'tc_grid_line_height_ratio' , 1.28 ); //line-height / font-size
-          $_ratio = $this -> tc_get_grid_font_ratios( $_size , $_wot );
+          $_ratio = $this -> czr_get_grid_font_ratios( $_size , $_wot );
           //body font size
-          $_bs = esc_attr( CZR_utils::$inst->tc_opt( 'tc_body_font_size') );
+          $_bs = esc_attr( CZR_utils::$inst->czr_opt( 'tc_body_font_size') );
           $_bs = is_numeric($_bs) && 1 >= $_bs ? $_bs : 15;
 
           return sprintf( 'font-size:%spx;line-height:%spx;' ,
@@ -796,8 +796,8 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         *
         */
         private function czr_get_grid_column_height( $_cols_nb = '3' ) {
-          $_h               = $this -> tc_grid_get_thumb_height();
-          $_current_layout  = CZR_utils::tc_get_layout( $this -> post_id , 'sidebar' );
+          $_h               = $this -> czr_grid_get_thumb_height();
+          $_current_layout  = CZR_utils::czr_get_layout( $this -> post_id , 'sidebar' );
           $_layouts         = array('b', 'l', 'r' , 'f');//both, left, right, full (no sidebar)
           $_key             = 3;//default value == full
           if ( in_array( $_current_layout, $_layouts ) )
@@ -819,7 +819,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
 
           //parse the array to ensure that all values are <= user height
           foreach ( $_grid_col_height_map as $_c => $_heights ) {
-            $_grid_col_height_map[$_c] = $this -> tc_set_max_col_height ( $_heights ,$_h );
+            $_grid_col_height_map[$_c] = $this -> czr_set_max_col_height ( $_heights ,$_h );
           }
 
           $_h = isset( $_grid_col_height_map[$_cols_nb][$_key] ) ? $_grid_col_height_map[$_cols_nb][$_key] : $_h;
@@ -849,7 +849,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return (number) customizer user defined height for the grid thumbnails
         */
         private function czr_grid_get_thumb_height() {
-          $_opt = esc_attr( CZR_utils::$inst->tc_opt( 'tc_grid_thumb_height') );
+          $_opt = esc_attr( CZR_utils::$inst->czr_opt( 'tc_grid_thumb_height') );
           return ( is_numeric($_opt) && $_opt > 1 ) ? $_opt : 350;
         }
 
@@ -868,7 +868,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
                   $wp_query->is_posts_page ) )
               return false;
 
-          $_expand_feat_post_opt = apply_filters( 'tc_grid_expand_featured', esc_attr( CZR_utils::$inst->tc_opt( 'tc_grid_expand_featured') ) );
+          $_expand_feat_post_opt = apply_filters( 'tc_grid_expand_featured', esc_attr( CZR_utils::$inst->czr_opt( 'tc_grid_expand_featured') ) );
 
           if ( ! $this -> expanded_sticky ) {
             $_sticky_posts = get_option('sticky_posts');
@@ -909,15 +909,15 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return bool
         */
         public function czr_is_grid_enabled() {
-          return apply_filters( 'tc_is_grid_enabled', 'grid' == esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_grid') ) && $this -> tc_is_grid_context_matching() );
+          return apply_filters( 'tc_is_grid_enabled', 'grid' == esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_grid') ) && $this -> czr_is_grid_context_matching() );
         }
 
 
         /* retrieves number of cols option, and wrap it into a filter */
         private function czr_get_grid_cols() {
           return apply_filters( 'tc_get_grid_cols',
-            esc_attr( CZR_utils::$inst->tc_opt( 'tc_grid_columns') ),
-            CZR_utils::tc_get_layout( $this -> post_id , 'class' )
+            esc_attr( CZR_utils::$inst->czr_opt( 'tc_grid_columns') ),
+            CZR_utils::czr_get_layout( $this -> post_id , 'class' )
           );
         }
 
@@ -925,7 +925,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         /* returns articles wrapper section columns */
         private function czr_get_grid_section_cols() {
           return apply_filters( 'tc_grid_section_cols',
-            $this -> tc_force_current_post_expansion() ? '1' : $this -> tc_get_grid_cols()
+            $this -> czr_force_current_post_expansion() ? '1' : $this -> czr_get_grid_cols()
           );
         }
 
@@ -949,8 +949,8 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         /* performs the match between the option where to use post list grid
          * and the post list we're in */
         private function czr_is_grid_context_matching() {
-          $_type = $this -> tc_get_grid_context();
-          $_apply_grid_to_post_type = apply_filters( 'tc_grid_in_' . $_type, esc_attr( CZR_utils::$inst->tc_opt( 'tc_grid_in_' . $_type ) ) );
+          $_type = $this -> czr_get_grid_context();
+          $_apply_grid_to_post_type = apply_filters( 'tc_grid_in_' . $_type, esc_attr( CZR_utils::$inst->czr_opt( 'tc_grid_in_' . $_type ) ) );
           return apply_filters('tc_grid_do',  $_type && $_apply_grid_to_post_type );
         }
 
@@ -959,7 +959,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return  boolean
         */
         private function czr_grid_show_thumb() {
-          return CZR_post_thumbnails::$instance -> tc_has_thumb() && 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_show_thumb' ) );
+          return CZR_post_thumbnails::$instance -> czr_has_thumb() && 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_show_thumb' ) );
         }
   }//end of class
 endif;

--- a/inc/parts/class-content-post_list_grid.php
+++ b/inc/parts/class-content-post_list_grid.php
@@ -21,12 +21,12 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
           self::$instance =& $this;
           $this -> expanded_sticky = null;
 
-          add_action ( 'pre_get_posts'              , array( $this , 'czr_maybe_excl_first_sticky') );
-          add_action ( 'wp_head'                    , array( $this , 'czr_set_grid_hooks') );
+          add_action ( 'pre_get_posts'              , array( $this , 'czr_fn_maybe_excl_first_sticky') );
+          add_action ( 'wp_head'                    , array( $this , 'czr_fn_set_grid_hooks') );
 
           //Font size filter
           //Updates the array of font sizes for a given sidebar layout
-          add_filter( 'czr_get_grid_font_sizes'      , array( $this , 'czr_set_layout_font_size' ), 10, 4 );
+          add_filter( 'czr_fn_get_grid_font_sizes'      , array( $this , 'czr_fn_set_layout_font_size' ), 10, 4 );
 
           //Various CSS filters
           //those filters are fired on hook : tc_user_options_style => fired on hook : wp_enqueue_scripts
@@ -36,7 +36,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
           //append inline style to the custom stylesheet
           //! tc_user_options_style filter is shared by several classes => must always check the local context inside the callback before appending new css
           //fired on hook : wp_enqueue_scripts
-          add_filter( 'tc_user_options_style'       , array( $this , 'czr_grid_write_inline_css'), 100 );
+          add_filter( 'tc_user_options_style'       , array( $this , 'czr_fn_grid_write_inline_css'), 100 );
         }
 
 
@@ -46,27 +46,27 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         /*
         * hook : wp
         */
-        function czr_set_grid_hooks(){
-          if ( ! apply_filters( 'czr_set_grid_hooks' , $this -> czr_is_grid_enabled() ) )
+        function czr_fn_set_grid_hooks(){
+          if ( ! apply_filters( 'czr_fn_set_grid_hooks' , $this -> czr_fn_is_grid_enabled() ) )
               return;
 
-          $this -> post_id = CZR_utils::czr_id();
+          $this -> post_id = CZR_utils::czr_fn_id();
 
           do_action( '__post_list_grid' );
           //Disable icon titles
           //add_filter( 'tc_archive_icon'             , '__return_false', 50 );
           //disable edit link (it's added afterwards) for the expanded post
-          add_filter( 'tc_edit_in_title'            , array( $this, 'czr_grid_disable_edit_in_title_expanded' ) );
+          add_filter( 'tc_edit_in_title'            , array( $this, 'czr_fn_grid_disable_edit_in_title_expanded' ) );
 
           add_filter( 'tc_content_title_icon'       , '__return_false', 50 );
           //icon option
-          add_filter( 'tc-grid-thumb-html'          , array( $this, 'czr_set_grid_icon_visibility') );
+          add_filter( 'tc-grid-thumb-html'          , array( $this, 'czr_fn_set_grid_icon_visibility') );
           //Layout filter
-          add_filter( 'czr_get_grid_cols'            , array( $this, 'czr_set_grid_section_cols'), 20 , 2 );
+          add_filter( 'czr_fn_get_grid_cols'            , array( $this, 'czr_fn_set_grid_section_cols'), 20 , 2 );
           //pre loop hooks
-          add_action( '__before_article_container'  , array( $this, 'czr_set_grid_before_loop_hooks'), 5 );
+          add_action( '__before_article_container'  , array( $this, 'czr_fn_set_grid_before_loop_hooks'), 5 );
           //loop hooks
-          add_action( '__before_loop'               , array( $this, 'czr_set_grid_loop_hooks'), 0 );
+          add_action( '__before_loop'               , array( $this, 'czr_fn_set_grid_loop_hooks'), 0 );
         }
 
 
@@ -74,38 +74,38 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * hook : __before_article_container
         * before loop
         */
-        function czr_set_grid_before_loop_hooks(){
+        function czr_fn_set_grid_before_loop_hooks(){
           // LAYOUT
-          add_filter( 'tc_post_list_layout'         , array( $this, 'czr_grid_set_content_layout') );
-          add_filter( 'tc_post_list_selectors'      , array( $this, 'czr_grid_set_article_selectors') );
-          add_action( '__before_article_container'  , array( $this, 'czr_grid_prepare_expand_sticky' ) );
+          add_filter( 'tc_post_list_layout'         , array( $this, 'czr_fn_grid_set_content_layout') );
+          add_filter( 'tc_post_list_selectors'      , array( $this, 'czr_fn_grid_set_article_selectors') );
+          add_action( '__before_article_container'  , array( $this, 'czr_fn_grid_prepare_expand_sticky' ) );
 
           // THUMBNAILS
-          remove_filter( 'post_class'               , array( CZR_post_list::$instance , 'czr_add_thumb_shape_name'));
-          remove_filter( 'tc_thumb_size_name'       , array( CZR_post_thumbnails::$instance, 'czr_set_thumb_size') );
-          add_filter( 'tc_thumb_size_name'          , array( $this, 'czr_set_thumb_size_name') );
-          add_filter( 'tc_thumb_size'               , array( $this, 'czr_set_thumb_size') );
+          remove_filter( 'post_class'               , array( CZR_post_list::$instance , 'czr_fn_add_thumb_shape_name'));
+          remove_filter( 'tc_thumb_size_name'       , array( CZR_post_thumbnails::$instance, 'czr_fn_set_thumb_size') );
+          add_filter( 'tc_thumb_size_name'          , array( $this, 'czr_fn_set_thumb_size_name') );
+          add_filter( 'tc_thumb_size'               , array( $this, 'czr_fn_set_thumb_size') );
 
           // SINGLE POST CONTENT IN GRID
           $_content_priorities = apply_filters('tc_grid_post_content_priorities' , array( 'content' => 20, 'link' =>30 ));
-          add_action( '__grid_single_post_content'  , array( $this, 'czr_grid_display_figcaption_content') , $_content_priorities['content'] );
-          add_action( '__grid_single_post_content'  , array( $this, 'czr_grid_display_post_link'), $_content_priorities['link'] );
-          add_action( '__grid_single_post_content'  , array( $this, 'czr_grid_display_fade_excerpt'), 100 );
+          add_action( '__grid_single_post_content'  , array( $this, 'czr_fn_grid_display_figcaption_content') , $_content_priorities['content'] );
+          add_action( '__grid_single_post_content'  , array( $this, 'czr_fn_grid_display_post_link'), $_content_priorities['link'] );
+          add_action( '__grid_single_post_content'  , array( $this, 'czr_fn_grid_display_fade_excerpt'), 100 );
           //expanded sticky post : filter the figcaption content to include the post title
-          add_filter( 'czr_grid_display_figcaption_content' , array( $this, 'czr_grid_set_expanded_post_title') );
+          add_filter( 'czr_fn_grid_display_figcaption_content' , array( $this, 'czr_fn_grid_set_expanded_post_title') );
 
           //ARTICLE CONTAINER CSS CLASSES TO HANDLE EFFECT LIKE SHADOWS
-          add_filter( 'tc_article_container_class'  , array( $this, 'czr_grid_container_set_classes' ) );
+          add_filter( 'tc_article_container_class'  , array( $this, 'czr_fn_grid_container_set_classes' ) );
 
           //COMMENT BUBBLE
-          remove_filter( 'tc_the_title'             , array( CZR_comments::$instance, 'czr_display_comment_bubble' ) , 1 );
-          add_filter( 'czr_grid_get_single_post_html'  , array( $this, 'czr_grid_display_comment_bubble' ) );
+          remove_filter( 'tc_the_title'             , array( CZR_comments::$instance, 'czr_fn_display_comment_bubble' ) , 1 );
+          add_filter( 'czr_fn_grid_get_single_post_html'  , array( $this, 'czr_fn_grid_display_comment_bubble' ) );
 
           //POST METAS
-          remove_filter( 'tc_meta_utility_text'     , array( CZR_post_metas::$instance , 'czr_add_link_to_post_after_metas'), 20 );
+          remove_filter( 'tc_meta_utility_text'     , array( CZR_post_metas::$instance , 'czr_fn_add_link_to_post_after_metas'), 20 );
 
           //TITLE LENGTH
-          add_filter( 'tc_title_text'               , array( $this, 'czr_grid_set_title_length' ) );
+          add_filter( 'tc_title_text'               , array( $this, 'czr_fn_grid_set_title_length' ) );
         }
 
 
@@ -114,16 +114,16 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * actions and filters inside loop
         * @return  void
         */
-        function czr_set_grid_loop_hooks() {
-          add_action( '__before_article'            , array( $this, 'czr_print_row_fluid_section_wrapper' ), 1 );
-          add_action( '__after_article'             , array( $this, 'czr_print_article_sep' ), 0 );
-          add_action( '__after_article'             , array( $this, 'czr_print_row_fluid_section_wrapper' ), 1 );
+        function czr_fn_set_grid_loop_hooks() {
+          add_action( '__before_article'            , array( $this, 'czr_fn_print_row_fluid_section_wrapper' ), 1 );
+          add_action( '__after_article'             , array( $this, 'czr_fn_print_article_sep' ), 0 );
+          add_action( '__after_article'             , array( $this, 'czr_fn_print_row_fluid_section_wrapper' ), 1 );
 
-          remove_action( '__loop'                   , array( CZR_post_list::$instance, 'czr_prepare_section_view') );
-          add_action( '__loop'                      , array( $this, 'czr_grid_prepare_single_post') );
+          remove_action( '__loop'                   , array( CZR_post_list::$instance, 'czr_fn_prepare_section_view') );
+          add_action( '__loop'                      , array( $this, 'czr_fn_grid_prepare_single_post') );
 
-          if ( CZR_headings::$instance -> czr_is_edit_enabled() && apply_filters( 'czr_grid_render_expanded_edit_link', true ) )
-            add_filter( 'czr_grid_get_single_post_html' , array( $this, 'czr_grid_render_expanded_edit_link' ), 50 );
+          if ( CZR_headings::$instance -> czr_fn_is_edit_enabled() && apply_filters( 'czr_fn_grid_render_expanded_edit_link', true ) )
+            add_filter( 'czr_fn_grid_get_single_post_html' , array( $this, 'czr_fn_grid_render_expanded_edit_link' ), 50 );
         }
 
 
@@ -135,11 +135,11 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * hook : __before_article
         * Wrap articles in a grid section
         */
-        function czr_print_row_fluid_section_wrapper(){
+        function czr_fn_print_row_fluid_section_wrapper(){
           global $wp_query;
           $current_post   = $wp_query -> current_post;
           $start_post     = $this -> expanded_sticky ? 1 : 0;
-          $cols           = $this -> czr_get_grid_section_cols();
+          $cols           = $this -> czr_fn_get_grid_section_cols();
 
           if ( '__before_article' == current_filter() &&
               ( $start_post == $current_post ||
@@ -166,9 +166,9 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return the figcation content parts as an array of html strings
         * inside loop
         */
-        function czr_grid_prepare_single_post() {
+        function czr_fn_grid_prepare_single_post() {
           global $post;
-          if ( ! isset($post) || empty($post) || ! apply_filters( 'tc_show_post_in_post_list', $this -> czr_is_grid_context_matching() , $post ) )
+          if ( ! isset($post) || empty($post) || ! apply_filters( 'tc_show_post_in_post_list', $this -> czr_fn_is_grid_context_matching() , $post ) )
             return;
 
           // get the filtered post list layout
@@ -176,44 +176,44 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
 
           // SET HOOKS FOR POST TITLES AND METAS
           // Default condition : must be a non sticky post
-          if ( apply_filters( 'tc_render_grid_headings_view' , ! $this -> czr_force_current_post_expansion() ) ) {
+          if ( apply_filters( 'tc_render_grid_headings_view' , ! $this -> czr_fn_force_current_post_expansion() ) ) {
               $hook_prefix = '__before';
               if ( $_layout['show_thumb_first'] )
                   $hook_prefix = '__after';
 
-              add_action( "{$hook_prefix}_grid_single_post",  array( CZR_headings::$instance, 'czr_render_headings_view' ) );
+              add_action( "{$hook_prefix}_grid_single_post",  array( CZR_headings::$instance, 'czr_fn_render_headings_view' ) );
           }
 
           // THUMBNAIL : cache the post format icon first
           //add thumbnail html (src, width, height) if any
           $_thumb_html = '';
-          if ( $this -> czr_grid_show_thumb() ) {
+          if ( $this -> czr_fn_grid_show_thumb() ) {
             //return an array( $tc_thumb(image object), $tc_thumb_width(string), $tc_thumb_height(string) )
-            $_thumb_model = CZR_post_thumbnails::$instance -> czr_get_thumbnail_model();
+            $_thumb_model = CZR_post_thumbnails::$instance -> czr_fn_get_thumbnail_model();
             if ( isset($_thumb_model['tc_thumb']) )
               $_thumb_html  = $_thumb_model['tc_thumb'];
           }
           $_thumb_html = apply_filters( 'tc-grid-thumb-html' , $_thumb_html );
 
           // CONTENT : get the figcaption content => post content
-          $_post_content_html               = $this -> czr_grid_get_single_post_html( isset( $_layout['content'] ) ? $_layout['content'] : 'span6' );
+          $_post_content_html               = $this -> czr_fn_grid_get_single_post_html( isset( $_layout['content'] ) ? $_layout['content'] : 'span6' );
 
           // ADD A WRAPPER CLASS : build single grid post wrapper class
           $_classes  = array('tc-grid-figure');
           //may be add class no-thumb
-          if ( ! $this -> czr_grid_show_thumb() )
+          if ( ! $this -> czr_fn_grid_show_thumb() )
             array_push( $_classes, 'no-thumb' );
           else
             array_push( $_classes, 'has-thumb' );
 
           //if 1 col layout or current post is the expanded => golden ratio should be disabled
-          if ( ( '1' == $this -> czr_get_grid_cols() || $this -> czr_force_current_post_expansion() ) && ! wp_is_mobile() )
+          if ( ( '1' == $this -> czr_fn_get_grid_cols() || $this -> czr_fn_force_current_post_expansion() ) && ! wp_is_mobile() )
             array_push( $_classes, 'no-gold-ratio' );
 
           $_classes  = implode( ' ' , apply_filters('tc_single_grid_post_wrapper_class', $_classes ) );
 
           //RENDER VIEW
-          $this -> czr_grid_render_single_post( $_classes, $_thumb_html, $_post_content_html );
+          $this -> czr_fn_grid_render_single_post( $_classes, $_thumb_html, $_post_content_html );
           //return apply_filters( 'tc_prepare_grid_single_post_content' , compact( '_classes', '_thumb_html', '_post_content_html') );
         }
 
@@ -224,7 +224,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return html string
         *
         */
-        private function czr_grid_render_single_post( $_classes, $_thumb_html, $_post_content_html ) {
+        private function czr_fn_grid_render_single_post( $_classes, $_thumb_html, $_post_content_html ) {
           ob_start();
             do_action( '__before_grid_single_post');//<= open <section> and maybe display title + metas
 
@@ -247,8 +247,8 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         /**
         * hook : __grid_single_post_content
         */
-        function czr_grid_display_post_link(){
-          if ( ! apply_filters( 'czr_grid_display_post_link' , true ) )
+        function czr_fn_grid_display_post_link(){
+          if ( ! apply_filters( 'czr_fn_grid_display_post_link' , true ) )
             return;
           printf( '<a class="tc-grid-bg-link" href="%1$s" title="%2$s"></a>',
               get_permalink( get_the_ID() ),
@@ -260,8 +260,8 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         /**
         * hook : __grid_single_post_content
         */
-        function czr_grid_display_fade_excerpt(){
-          if ( ! apply_filters( 'tc_grid_fade_excerpt' , ! $this -> czr_force_current_post_expansion() ) )
+        function czr_fn_grid_display_fade_excerpt(){
+          if ( ! apply_filters( 'tc_grid_fade_excerpt' , ! $this -> czr_fn_force_current_post_expansion() ) )
             return;
           printf( '<span class="tc-grid-fade_expt"></span>' );
         }
@@ -271,11 +271,11 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         /*
         * hook : __grid_single_post_content
         */
-        function czr_grid_display_figcaption_content() {
+        function czr_fn_grid_display_figcaption_content() {
           ?>
               <div class="entry-summary">
                 <?php
-                  echo apply_filters( 'czr_grid_display_figcaption_content',
+                  echo apply_filters( 'czr_fn_grid_display_figcaption_content',
                     sprintf('<div class="tc-g-cont">%s</div>',
                       get_the_excerpt()
                     )
@@ -291,7 +291,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * hook : __after_article (declared in index.php)
         * print a separator after each article => revealed in responsive mode
         */
-        function czr_print_article_sep() {
+        function czr_fn_print_article_sep() {
           //renders the hr separator after each article
           echo apply_filters( 'tc_grid_single_post_sep', '<hr class="featurette-divider '.current_filter().'">' );
         }
@@ -306,8 +306,8 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * Limits the length of the post titles in grids to a custom number of characters
         * @return string
         */
-        function czr_grid_set_title_length( $_title ) {
-          $_max = esc_attr( CZR_utils::$inst->czr_opt( 'tc_grid_num_words') );
+        function czr_fn_grid_set_title_length( $_title ) {
+          $_max = esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_grid_num_words') );
           $_max = ( empty($_max) || ! $_max ) ? 10 : $_max;
           $_max = $_max <= 0 ? 1 : $_max;
 
@@ -328,8 +328,8 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * hook : pre_get_posts
         * exclude the first sticky post
         */
-        function czr_maybe_excl_first_sticky( $query ){
-          if ( $this -> czr_is_grid_enabled() && $this -> czr_is_sticky_expanded( $query ) )
+        function czr_fn_maybe_excl_first_sticky( $query ){
+          if ( $this -> czr_fn_is_grid_enabled() && $this -> czr_fn_is_sticky_expanded( $query ) )
             $query->set('post__not_in', array( $this -> expanded_sticky ) );
         }
 
@@ -339,7 +339,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * force content + thumb layout : Force the title to be displayed always on bottom
         * @param current layout array()
         */
-        function czr_grid_set_content_layout( $_layout ){
+        function czr_fn_grid_set_content_layout( $_layout ){
           $_layout['show_thumb_first'] = true;
           $_layout['content']          = 'tc-grid-excerpt';
           $_layout['thumb']            = 'span12 tc-grid-post-container';
@@ -355,7 +355,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @param $_col_nb = string possible values : 1, 2, 3, 4
         * @param $_current_layout string of layout class like span4
         */
-        function czr_set_grid_section_cols( $_col_nb, $_current_layout ) {
+        function czr_fn_set_grid_section_cols( $_col_nb, $_current_layout ) {
           $_map = apply_filters(
             'tc_grid_col_layout_map',
             array(
@@ -386,10 +386,10 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * Apply proper class to articles selectors to control articles width
         * hook : tc_post_list_selectors
         */
-        function czr_grid_set_article_selectors($selectors){
+        function czr_fn_grid_set_article_selectors($selectors){
           $_class = sprintf( '%1$s tc-grid span%2$s',
-            apply_filters( 'tc_grid_add_expanded_class', $this -> czr_force_current_post_expansion() ) ? 'expanded' : '',
-            is_numeric( $this -> czr_get_grid_section_cols() ) ? 12 / $this -> czr_get_grid_section_cols() : 6
+            apply_filters( 'tc_grid_add_expanded_class', $this -> czr_fn_force_current_post_expansion() ) ? 'expanded' : '',
+            is_numeric( $this -> czr_fn_get_grid_section_cols() ) ? 12 / $this -> czr_fn_get_grid_section_cols() : 6
           );
           return str_replace( 'row-fluid', $_class, $selectors );
         }
@@ -398,9 +398,9 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         /*
         * hook : __before_article_container
         */
-        function czr_grid_prepare_expand_sticky(){
+        function czr_fn_grid_prepare_expand_sticky(){
           global $wp_query;
-          if ( ! ( $this -> czr_is_sticky_expanded() &&
+          if ( ! ( $this -> czr_fn_is_sticky_expanded() &&
                  $wp_query -> query_vars[ 'paged' ] == 0 ) ){
             $this -> expanded_sticky = null;
             return;
@@ -415,16 +415,16 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         /*
         * hook : tc_thumb_size_name
         */
-        function czr_set_thumb_size_name(){
-          return ( $this -> czr_get_grid_section_cols() == '1' ) ? 'tc-grid-full' : 'tc-grid';
+        function czr_fn_set_thumb_size_name(){
+          return ( $this -> czr_fn_get_grid_section_cols() == '1' ) ? 'tc-grid-full' : 'tc-grid';
         }
 
 
         /*
         * hook : tc_thumb_size
         */
-        function czr_set_thumb_size(){
-          $thumb = ( $this -> czr_get_grid_section_cols() == '1' ) ? 'tc_grid_full_size' : 'tc_grid_size';
+        function czr_fn_set_thumb_size(){
+          $thumb = ( $this -> czr_fn_get_grid_section_cols() == '1' ) ? 'tc_grid_full_size' : 'tc_grid_size';
           return CZR_init::$instance -> $thumb;
         }
 
@@ -434,11 +434,11 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * inside loop
         * add custom classes to the grid .article-container element
         */
-        function czr_grid_container_set_classes( $_classes ) {
+        function czr_fn_grid_container_set_classes( $_classes ) {
           array_push( $_classes, 'tc-post-list-grid' );
-          if ( esc_attr( CZR_utils::$inst->czr_opt( 'tc_grid_shadow') ) )
+          if ( esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_grid_shadow') ) )
             array_push( $_classes, 'tc-grid-shadow' );
-          if ( esc_attr( CZR_utils::$inst->czr_opt( 'tc_grid_bottom_border') ) )
+          if ( esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_grid_bottom_border') ) )
             array_push( $_classes, 'tc-grid-border' );
           return $_classes;
         }
@@ -448,7 +448,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return the figcation content as a string
         * inside loop
         */
-        private function czr_grid_get_single_post_html( $post_list_content_class ) {
+        private function czr_fn_grid_get_single_post_html( $post_list_content_class ) {
           global $post;
           ob_start();
             ?>
@@ -458,7 +458,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
             <?php
           $html = ob_get_contents();
           if ($html) ob_end_clean();
-          return apply_filters( 'czr_grid_get_single_post_html', $html, $post_list_content_class );
+          return apply_filters( 'czr_fn_grid_get_single_post_html', $html, $post_list_content_class );
         }
 
 
@@ -467,8 +467,8 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return the comment_bubble as a string
         * inside loop
         */
-        function czr_grid_display_comment_bubble( $_html ) {
-          return CZR_comments::$instance -> czr_display_comment_bubble() . $_html;
+        function czr_fn_grid_display_comment_bubble( $_html ) {
+          return CZR_comments::$instance -> czr_fn_display_comment_bubble() . $_html;
         }
 
 
@@ -478,8 +478,8 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return  html string
         * hook : tc_grid_display_figcaption_content
         */
-        function czr_grid_set_expanded_post_title( $_html ){
-          if ( ! $this -> czr_force_current_post_expansion() )
+        function czr_fn_grid_set_expanded_post_title( $_html ){
+          if ( ! $this -> czr_fn_force_current_post_expansion() )
               return $_html;
           global $post;
           $_title = apply_filters( 'tc_grid_expanded_title' , $post->post_title );
@@ -496,8 +496,8 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * hook : tc_edit_in_title
         * @since Customizr 3.4.18
         */
-        function czr_grid_disable_edit_in_title_expanded( $_bool ){
-          return $this -> czr_force_current_post_expansion() ? false : $_bool;
+        function czr_fn_grid_disable_edit_in_title_expanded( $_bool ){
+          return $this -> czr_fn_force_current_post_expansion() ? false : $_bool;
         }
 
 
@@ -506,9 +506,9 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * hook : tc_grid_get_single_post_html
         * @since Customizr 3.4.18
         */
-        function czr_grid_render_expanded_edit_link( $_html ) {
-          if ( $this -> czr_force_current_post_expansion() )
-            $_html .= CZR_headings::$instance -> czr_render_edit_link_view( $_echo = false );
+        function czr_fn_grid_render_expanded_edit_link( $_html ) {
+          if ( $this -> czr_fn_force_current_post_expansion() )
+            $_html .= CZR_headings::$instance -> czr_fn_render_edit_link_view( $_echo = false );
           return $_html;
         }
 
@@ -518,17 +518,17 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * hook : tc_user_options_style
         * @since Customizr 3.2.18
         */
-        function czr_grid_write_inline_css( $_css ){
-          if ( ! $this -> czr_is_grid_enabled() )
+        function czr_fn_grid_write_inline_css( $_css ){
+          if ( ! $this -> czr_fn_is_grid_enabled() )
             return $_css;
 
-          $_col_nb  = $this -> czr_get_grid_cols();
+          $_col_nb  = $this -> czr_fn_get_grid_cols();
 
           //GENERATE THE FIGURE HEIGHT CSS
-          $_current_col_figure_css  = $this -> czr_grid_get_figure_css( $_col_nb );
+          $_current_col_figure_css  = $this -> czr_fn_grid_get_figure_css( $_col_nb );
 
           //GENERATE THE MEDIA QUERY CSS FOR FONT-SIZES
-          $_current_col_media_css   = $this -> czr_get_grid_font_css( $_col_nb );
+          $_current_col_media_css   = $this -> czr_fn_get_grid_font_css( $_col_nb );
 
           $_css = sprintf("%s\n%s\n%s\n",
               $_css,
@@ -544,9 +544,9 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * hook : tc-grid-thumb-html
         * @return modified html string
         */
-        function czr_set_grid_icon_visibility( $_html ) {
-          $_icon_enabled = (bool) esc_attr( CZR_utils::$inst->czr_opt( 'tc_grid_icons') );
-          if ( CZR___::$instance -> czr_is_customizing() )
+        function czr_fn_set_grid_icon_visibility( $_html ) {
+          $_icon_enabled = (bool) esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_grid_icons') );
+          if ( CZR___::$instance -> czr_fn_is_customizing() )
             return sprintf('<div class="tc-grid-icon format-icon" style="display:%1$s"></div>%2$s',
                 $_icon_enabled ? 'inline-block' : 'none',
                 $_html
@@ -569,9 +569,9 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return css media query string
         * Returns the paragraph and title media queries for a given layout
         */
-        private function czr_get_grid_font_css( $_col_nb = '3' ) {
-          $_media_queries     = $this -> czr_get_grid_media_queries();//returns the simple array of media queries
-          $_grid_font_sizes = $this -> czr_get_grid_font_sizes( $_col_nb );//return the array of sizes (ordered by @media queries) for a given column layout
+        private function czr_fn_get_grid_font_css( $_col_nb = '3' ) {
+          $_media_queries     = $this -> czr_fn_get_grid_media_queries();//returns the simple array of media queries
+          $_grid_font_sizes = $this -> czr_fn_get_grid_font_sizes( $_col_nb );//return the array of sizes (ordered by @media queries) for a given column layout
           $_col_rules         = array();
           $_media_queries_css = '';
 
@@ -579,10 +579,10 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
           foreach ($_media_queries as $key => $_med_query_sizes ) {
             $_size = $_grid_font_sizes[$key];//=> size like 'xxl'
             $_css_prop = array(
-              'h' => $this -> czr_grid_build_css_rules( $_size , 'h' ),
-              'p' => $this -> czr_grid_build_css_rules( $_size , 'p' )
+              'h' => $this -> czr_fn_grid_build_css_rules( $_size , 'h' ),
+              'p' => $this -> czr_fn_grid_build_css_rules( $_size , 'p' )
             );
-            $_rules = $this -> czr_grid_assign_css_rules_to_selectors( $_med_query_sizes , $_css_prop, $_col_nb );
+            $_rules = $this -> czr_fn_grid_assign_css_rules_to_selectors( $_med_query_sizes , $_css_prop, $_col_nb );
             $_media_queries_css .= "
               @media {$_med_query_sizes} {{$_rules}}
             ";
@@ -594,7 +594,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         /**
         * @return simple array of media queries
         */
-        private function czr_get_grid_media_queries() {
+        private function czr_fn_get_grid_media_queries() {
           return apply_filters( 'tc_grid_media_queries' ,  array(
               '(min-width: 1200px)', '(max-width: 1199px) and (min-width: 980px)', '(max-width: 979px) and (min-width: 768px)', '(max-width: 767px)', '(max-width: 480px)'
             )
@@ -611,7 +611,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * Note : When all sizes are requested (default case), the returned array can be filtered with the current layout param
         * Size array must have the same length of the media query array
         */
-        private function czr_get_grid_font_sizes( $_col_nb = '3', $_requested_media_size = null ) {
+        private function czr_fn_get_grid_font_sizes( $_col_nb = '3', $_requested_media_size = null ) {
           $_col_media_matrix = apply_filters( 'tc_grid_font_matrix' , array(
               //=> matrix col nb / media queries
               //            1200 | 1199-980 | 979-768 | 767   | 480
@@ -623,7 +623,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
           );
           //if a specific media query is requested, return a string
           if ( ! is_null($_requested_media_size) ) {
-            $_media_queries = $this -> czr_get_grid_media_queries();
+            $_media_queries = $this -> czr_fn_get_grid_media_queries();
             //get the key = position of requested size in the current layout
             $_key = array_search( $_requested_media_size, $_media_queries);
             return apply_filters(
@@ -633,18 +633,18 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
           }
 
           return apply_filters(
-            'czr_get_grid_font_sizes',
+            'czr_fn_get_grid_font_sizes',
             isset($_col_media_matrix[$_col_nb]) ? $_col_media_matrix[$_col_nb] : array( 'xl' , 'l' , 'm', 'l', 'm' ),
             $_col_nb,
             $_col_media_matrix,
-            CZR_utils::czr_get_layout( $this -> post_id , 'class' )
+            CZR_utils::czr_fn_get_layout( $this -> post_id , 'class' )
           );
         }
 
 
 
         /**
-        * hook : 'czr_get_grid_font_sizes'
+        * hook : 'czr_fn_get_grid_font_sizes'
         * Updates the array of sizes for a given sidebar layout
         * @param  $_sizes array. ex : array( 'xl' , 'l' , 'm', 'l', 'm' )
         * @param  $_col_nb string. Ex: '2'
@@ -652,7 +652,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @param  $_current_layout string. Ex : 'span9'
         * @return array()
         */
-        function czr_set_layout_font_size( $_sizes, $_col_nb, $_col_media_matrix, $_current_layout ) {
+        function czr_fn_set_layout_font_size( $_sizes, $_col_nb, $_col_media_matrix, $_current_layout ) {
           //max possible font size key in the col_media_queries matrix for a given sidebar layout
           $_map = apply_filters(
             'tc_layout_font_size_map',
@@ -688,8 +688,8 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @param selector type string
         * returns ratio of size / body size for a given selector type ( headings or paragraphs )
         */
-        private function czr_get_grid_font_ratios( $_size = 'xl' , $_sel = 'h' ) {
-          $_ratios =  apply_filters( 'czr_get_grid_font_ratios' , array(
+        private function czr_fn_get_grid_font_ratios( $_size = 'xl' , $_sel = 'h' ) {
+          $_ratios =  apply_filters( 'czr_fn_get_grid_font_ratios' , array(
               'xxxl' => array( 'h' => 2.10, 'p' => 1 ),
               'xxl' => array( 'h' => 1.86, 'p' => 1 ),
               'xl' => array( 'h' => 1.60, 'p' => 0.93 ),
@@ -714,13 +714,13 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * 1) there's a sticky post
         * 2) user layout is one column
         */
-        private function czr_grid_assign_css_rules_to_selectors( $_media_query, $_css_prop, $_col_nb ) {
+        private function czr_fn_grid_assign_css_rules_to_selectors( $_media_query, $_css_prop, $_col_nb ) {
           $_css = '';
           //Add one column font rules if there's a sticky post
-          if ( $this -> czr_is_sticky_expanded() || '1' == $_col_nb ) {
-            $_size      = $this -> czr_get_grid_font_sizes( $_col_nb = '1', $_media_query );//size like xxl
-            $_h_one_col = $this -> czr_grid_build_css_rules( $_size , 'h' );
-            $_p_one_col = $this -> czr_grid_build_css_rules( $_size , 'p' );
+          if ( $this -> czr_fn_is_sticky_expanded() || '1' == $_col_nb ) {
+            $_size      = $this -> czr_fn_get_grid_font_sizes( $_col_nb = '1', $_media_query );//size like xxl
+            $_h_one_col = $this -> czr_fn_grid_build_css_rules( $_size , 'h' );
+            $_p_one_col = $this -> czr_fn_grid_build_css_rules( $_size , 'p' );
             $_css .= "
                 .tc-post-list-grid .grid-cols-1 .entry-title {{$_h_one_col}}
                 .tc-post-list-grid .grid-cols-1 .tc-g-cont {{$_p_one_col}}
@@ -743,13 +743,13 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * 1) there's a sticky post
         * 2) user layout is one column
         */
-        private function czr_grid_get_figure_css( $_col_nb = '3' ) {
-          $_height = $this -> czr_get_grid_column_height( $_col_nb );
+        private function czr_fn_grid_get_figure_css( $_col_nb = '3' ) {
+          $_height = $this -> czr_fn_get_grid_column_height( $_col_nb );
           $_cols_class      = sprintf( 'grid-cols-%s' , $_col_nb );
           $_css = '';
           //Add one column height if there's a sticky post
-          if ( $this -> czr_is_sticky_expanded() && '1' != $_col_nb ) {
-            $_height_col_one = $this -> czr_get_grid_column_height( '1' );
+          if ( $this -> czr_fn_is_sticky_expanded() && '1' != $_col_nb ) {
+            $_height_col_one = $this -> czr_fn_get_grid_column_height( '1' );
             $_css .= ".grid-cols-1 figure {
                   height:{$_height_col_one}px;
                   max-height:{$_height_col_one}px;
@@ -772,11 +772,11 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @param selector type string
         * returns the font-size and line-height css rules
         */
-        private function czr_grid_build_css_rules( $_size = 'xl', $_wot = 'h' ) {
+        private function czr_fn_grid_build_css_rules( $_size = 'xl', $_wot = 'h' ) {
           $_lh_ratio = apply_filters( 'tc_grid_line_height_ratio' , 1.28 ); //line-height / font-size
-          $_ratio = $this -> czr_get_grid_font_ratios( $_size , $_wot );
+          $_ratio = $this -> czr_fn_get_grid_font_ratios( $_size , $_wot );
           //body font size
-          $_bs = esc_attr( CZR_utils::$inst->czr_opt( 'tc_body_font_size') );
+          $_bs = esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_body_font_size') );
           $_bs = is_numeric($_bs) && 1 >= $_bs ? $_bs : 15;
 
           return sprintf( 'font-size:%spx;line-height:%spx;' ,
@@ -795,9 +795,9 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return string
         *
         */
-        private function czr_get_grid_column_height( $_cols_nb = '3' ) {
-          $_h               = $this -> czr_grid_get_thumb_height();
-          $_current_layout  = CZR_utils::czr_get_layout( $this -> post_id , 'sidebar' );
+        private function czr_fn_get_grid_column_height( $_cols_nb = '3' ) {
+          $_h               = $this -> czr_fn_grid_get_thumb_height();
+          $_current_layout  = CZR_utils::czr_fn_get_layout( $this -> post_id , 'sidebar' );
           $_layouts         = array('b', 'l', 'r' , 'f');//both, left, right, full (no sidebar)
           $_key             = 3;//default value == full
           if ( in_array( $_current_layout, $_layouts ) )
@@ -819,11 +819,11 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
 
           //parse the array to ensure that all values are <= user height
           foreach ( $_grid_col_height_map as $_c => $_heights ) {
-            $_grid_col_height_map[$_c] = $this -> czr_set_max_col_height ( $_heights ,$_h );
+            $_grid_col_height_map[$_c] = $this -> czr_fn_set_max_col_height ( $_heights ,$_h );
           }
 
           $_h = isset( $_grid_col_height_map[$_cols_nb][$_key] ) ? $_grid_col_height_map[$_cols_nb][$_key] : $_h;
-          return apply_filters( 'czr_get_grid_column_height' , $_h, $_cols_nb, $_current_layout );
+          return apply_filters( 'czr_fn_get_grid_column_height' , $_h, $_cols_nb, $_current_layout );
         }
 
 
@@ -835,7 +835,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return string
         *
         */
-        private function czr_set_max_col_height( $_heights ,$_h ) {
+        private function czr_fn_set_max_col_height( $_heights ,$_h ) {
           $_return = array();
           foreach ($_heights as $_value) {
             $_return[] = $_value >= $_h ? $_h : $_value;
@@ -848,8 +848,8 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         /**
         * @return (number) customizer user defined height for the grid thumbnails
         */
-        private function czr_grid_get_thumb_height() {
-          $_opt = esc_attr( CZR_utils::$inst->czr_opt( 'tc_grid_thumb_height') );
+        private function czr_fn_grid_get_thumb_height() {
+          $_opt = esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_grid_thumb_height') );
           return ( is_numeric($_opt) && $_opt > 1 ) ? $_opt : 350;
         }
 
@@ -858,7 +858,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return bool
         * check if we have to expand the first sticky post
         */
-        private function czr_is_sticky_expanded( $query = null ){
+        private function czr_fn_is_sticky_expanded( $query = null ){
           global $wp_query, $wpdb;
           $query = ( $query ) ? $query : $wp_query;
 
@@ -868,7 +868,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
                   $wp_query->is_posts_page ) )
               return false;
 
-          $_expand_feat_post_opt = apply_filters( 'tc_grid_expand_featured', esc_attr( CZR_utils::$inst->czr_opt( 'tc_grid_expand_featured') ) );
+          $_expand_feat_post_opt = apply_filters( 'tc_grid_expand_featured', esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_grid_expand_featured') ) );
 
           if ( ! $this -> expanded_sticky ) {
             $_sticky_posts = get_option('sticky_posts');
@@ -899,7 +899,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return bool
         * returns if the current post is the expanded one
         */
-        private function czr_force_current_post_expansion(){
+        private function czr_fn_force_current_post_expansion(){
           global $wp_query;
           return ( $this -> expanded_sticky && 0 == $wp_query -> current_post );
         }
@@ -908,31 +908,31 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         /*
         * @return bool
         */
-        public function czr_is_grid_enabled() {
-          return apply_filters( 'czr_is_grid_enabled', 'grid' == esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_grid') ) && $this -> czr_is_grid_context_matching() );
+        public function czr_fn_is_grid_enabled() {
+          return apply_filters( 'czr_fn_is_grid_enabled', 'grid' == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_post_list_grid') ) && $this -> czr_fn_is_grid_context_matching() );
         }
 
 
         /* retrieves number of cols option, and wrap it into a filter */
-        private function czr_get_grid_cols() {
-          return apply_filters( 'czr_get_grid_cols',
-            esc_attr( CZR_utils::$inst->czr_opt( 'tc_grid_columns') ),
-            CZR_utils::czr_get_layout( $this -> post_id , 'class' )
+        private function czr_fn_get_grid_cols() {
+          return apply_filters( 'czr_fn_get_grid_cols',
+            esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_grid_columns') ),
+            CZR_utils::czr_fn_get_layout( $this -> post_id , 'class' )
           );
         }
 
 
         /* returns articles wrapper section columns */
-        private function czr_get_grid_section_cols() {
+        private function czr_fn_get_grid_section_cols() {
           return apply_filters( 'tc_grid_section_cols',
-            $this -> czr_force_current_post_expansion() ? '1' : $this -> czr_get_grid_cols()
+            $this -> czr_fn_force_current_post_expansion() ? '1' : $this -> czr_fn_get_grid_cols()
           );
         }
 
 
 
         /* returns the type of post list we're in if any, an empty string otherwise */
-        private function czr_get_grid_context() {
+        private function czr_fn_get_grid_context() {
           global $wp_query;
 
           if ( ( is_home() && 'posts' == get_option('show_on_front') ) ||
@@ -948,9 +948,9 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
 
         /* performs the match between the option where to use post list grid
          * and the post list we're in */
-        private function czr_is_grid_context_matching() {
-          $_type = $this -> czr_get_grid_context();
-          $_apply_grid_to_post_type = apply_filters( 'tc_grid_in_' . $_type, esc_attr( CZR_utils::$inst->czr_opt( 'tc_grid_in_' . $_type ) ) );
+        private function czr_fn_is_grid_context_matching() {
+          $_type = $this -> czr_fn_get_grid_context();
+          $_apply_grid_to_post_type = apply_filters( 'tc_grid_in_' . $_type, esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_grid_in_' . $_type ) ) );
           return apply_filters('tc_grid_do',  $_type && $_apply_grid_to_post_type );
         }
 
@@ -958,8 +958,8 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         /**
         * @return  boolean
         */
-        private function czr_grid_show_thumb() {
-          return CZR_post_thumbnails::$instance -> czr_has_thumb() && 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_show_thumb' ) );
+        private function czr_fn_grid_show_thumb() {
+          return CZR_post_thumbnails::$instance -> czr_fn_has_thumb() && 0 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_post_list_show_thumb' ) );
         }
   }//end of class
 endif;

--- a/inc/parts/class-content-post_list_grid.php
+++ b/inc/parts/class-content-post_list_grid.php
@@ -639,7 +639,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
 
 
         /**
-        * hook : 'czr_fn_get_grid_font_sizes'
+        * hook : 'tc_get_grid_font_sizes'
         * Updates the array of sizes for a given sidebar layout
         * @param  $_sizes array. ex : array( 'xl' , 'l' , 'm', 'l', 'm' )
         * @param  $_col_nb string. Ex: '2'

--- a/inc/parts/class-content-post_list_grid.php
+++ b/inc/parts/class-content-post_list_grid.php
@@ -21,12 +21,12 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
           self::$instance =& $this;
           $this -> expanded_sticky = null;
 
-          add_action ( 'pre_get_posts'              , array( $this , 'tc_maybe_excl_first_sticky') );
-          add_action ( 'wp_head'                    , array( $this , 'tc_set_grid_hooks') );
+          add_action ( 'pre_get_posts'              , array( $this , 'czr_maybe_excl_first_sticky') );
+          add_action ( 'wp_head'                    , array( $this , 'czr_set_grid_hooks') );
 
           //Font size filter
           //Updates the array of font sizes for a given sidebar layout
-          add_filter( 'tc_get_grid_font_sizes'      , array( $this , 'tc_set_layout_font_size' ), 10, 4 );
+          add_filter( 'czr_get_grid_font_sizes'      , array( $this , 'czr_set_layout_font_size' ), 10, 4 );
 
           //Various CSS filters
           //those filters are fired on hook : tc_user_options_style => fired on hook : wp_enqueue_scripts
@@ -36,7 +36,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
           //append inline style to the custom stylesheet
           //! tc_user_options_style filter is shared by several classes => must always check the local context inside the callback before appending new css
           //fired on hook : wp_enqueue_scripts
-          add_filter( 'tc_user_options_style'       , array( $this , 'tc_grid_write_inline_css'), 100 );
+          add_filter( 'tc_user_options_style'       , array( $this , 'czr_grid_write_inline_css'), 100 );
         }
 
 
@@ -47,7 +47,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * hook : wp
         */
         function czr_set_grid_hooks(){
-          if ( ! apply_filters( 'tc_set_grid_hooks' , $this -> czr_is_grid_enabled() ) )
+          if ( ! apply_filters( 'czr_set_grid_hooks' , $this -> czr_is_grid_enabled() ) )
               return;
 
           $this -> post_id = CZR_utils::czr_id();
@@ -56,17 +56,17 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
           //Disable icon titles
           //add_filter( 'tc_archive_icon'             , '__return_false', 50 );
           //disable edit link (it's added afterwards) for the expanded post
-          add_filter( 'tc_edit_in_title'            , array( $this, 'tc_grid_disable_edit_in_title_expanded' ) );
+          add_filter( 'tc_edit_in_title'            , array( $this, 'czr_grid_disable_edit_in_title_expanded' ) );
 
           add_filter( 'tc_content_title_icon'       , '__return_false', 50 );
           //icon option
-          add_filter( 'tc-grid-thumb-html'          , array( $this, 'tc_set_grid_icon_visibility') );
+          add_filter( 'tc-grid-thumb-html'          , array( $this, 'czr_set_grid_icon_visibility') );
           //Layout filter
-          add_filter( 'tc_get_grid_cols'            , array( $this, 'tc_set_grid_section_cols'), 20 , 2 );
+          add_filter( 'czr_get_grid_cols'            , array( $this, 'czr_set_grid_section_cols'), 20 , 2 );
           //pre loop hooks
-          add_action( '__before_article_container'  , array( $this, 'tc_set_grid_before_loop_hooks'), 5 );
+          add_action( '__before_article_container'  , array( $this, 'czr_set_grid_before_loop_hooks'), 5 );
           //loop hooks
-          add_action( '__before_loop'               , array( $this, 'tc_set_grid_loop_hooks'), 0 );
+          add_action( '__before_loop'               , array( $this, 'czr_set_grid_loop_hooks'), 0 );
         }
 
 
@@ -76,36 +76,36 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         */
         function czr_set_grid_before_loop_hooks(){
           // LAYOUT
-          add_filter( 'tc_post_list_layout'         , array( $this, 'tc_grid_set_content_layout') );
-          add_filter( 'tc_post_list_selectors'      , array( $this, 'tc_grid_set_article_selectors') );
-          add_action( '__before_article_container'  , array( $this, 'tc_grid_prepare_expand_sticky' ) );
+          add_filter( 'tc_post_list_layout'         , array( $this, 'czr_grid_set_content_layout') );
+          add_filter( 'tc_post_list_selectors'      , array( $this, 'czr_grid_set_article_selectors') );
+          add_action( '__before_article_container'  , array( $this, 'czr_grid_prepare_expand_sticky' ) );
 
           // THUMBNAILS
-          remove_filter( 'post_class'               , array( CZR_post_list::$instance , 'tc_add_thumb_shape_name'));
-          remove_filter( 'tc_thumb_size_name'       , array( CZR_post_thumbnails::$instance, 'tc_set_thumb_size') );
-          add_filter( 'tc_thumb_size_name'          , array( $this, 'tc_set_thumb_size_name') );
-          add_filter( 'tc_thumb_size'               , array( $this, 'tc_set_thumb_size') );
+          remove_filter( 'post_class'               , array( CZR_post_list::$instance , 'czr_add_thumb_shape_name'));
+          remove_filter( 'tc_thumb_size_name'       , array( CZR_post_thumbnails::$instance, 'czr_set_thumb_size') );
+          add_filter( 'tc_thumb_size_name'          , array( $this, 'czr_set_thumb_size_name') );
+          add_filter( 'tc_thumb_size'               , array( $this, 'czr_set_thumb_size') );
 
           // SINGLE POST CONTENT IN GRID
           $_content_priorities = apply_filters('tc_grid_post_content_priorities' , array( 'content' => 20, 'link' =>30 ));
-          add_action( '__grid_single_post_content'  , array( $this, 'tc_grid_display_figcaption_content') , $_content_priorities['content'] );
-          add_action( '__grid_single_post_content'  , array( $this, 'tc_grid_display_post_link'), $_content_priorities['link'] );
-          add_action( '__grid_single_post_content'  , array( $this, 'tc_grid_display_fade_excerpt'), 100 );
+          add_action( '__grid_single_post_content'  , array( $this, 'czr_grid_display_figcaption_content') , $_content_priorities['content'] );
+          add_action( '__grid_single_post_content'  , array( $this, 'czr_grid_display_post_link'), $_content_priorities['link'] );
+          add_action( '__grid_single_post_content'  , array( $this, 'czr_grid_display_fade_excerpt'), 100 );
           //expanded sticky post : filter the figcaption content to include the post title
-          add_filter( 'tc_grid_display_figcaption_content' , array( $this, 'tc_grid_set_expanded_post_title') );
+          add_filter( 'czr_grid_display_figcaption_content' , array( $this, 'czr_grid_set_expanded_post_title') );
 
           //ARTICLE CONTAINER CSS CLASSES TO HANDLE EFFECT LIKE SHADOWS
-          add_filter( 'tc_article_container_class'  , array( $this, 'tc_grid_container_set_classes' ) );
+          add_filter( 'tc_article_container_class'  , array( $this, 'czr_grid_container_set_classes' ) );
 
           //COMMENT BUBBLE
-          remove_filter( 'tc_the_title'             , array( CZR_comments::$instance, 'tc_display_comment_bubble' ) , 1 );
-          add_filter( 'tc_grid_get_single_post_html'  , array( $this, 'tc_grid_display_comment_bubble' ) );
+          remove_filter( 'tc_the_title'             , array( CZR_comments::$instance, 'czr_display_comment_bubble' ) , 1 );
+          add_filter( 'czr_grid_get_single_post_html'  , array( $this, 'czr_grid_display_comment_bubble' ) );
 
           //POST METAS
-          remove_filter( 'tc_meta_utility_text'     , array( CZR_post_metas::$instance , 'tc_add_link_to_post_after_metas'), 20 );
+          remove_filter( 'tc_meta_utility_text'     , array( CZR_post_metas::$instance , 'czr_add_link_to_post_after_metas'), 20 );
 
           //TITLE LENGTH
-          add_filter( 'tc_title_text'               , array( $this, 'tc_grid_set_title_length' ) );
+          add_filter( 'tc_title_text'               , array( $this, 'czr_grid_set_title_length' ) );
         }
 
 
@@ -115,15 +115,15 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return  void
         */
         function czr_set_grid_loop_hooks() {
-          add_action( '__before_article'            , array( $this, 'tc_print_row_fluid_section_wrapper' ), 1 );
-          add_action( '__after_article'             , array( $this, 'tc_print_article_sep' ), 0 );
-          add_action( '__after_article'             , array( $this, 'tc_print_row_fluid_section_wrapper' ), 1 );
+          add_action( '__before_article'            , array( $this, 'czr_print_row_fluid_section_wrapper' ), 1 );
+          add_action( '__after_article'             , array( $this, 'czr_print_article_sep' ), 0 );
+          add_action( '__after_article'             , array( $this, 'czr_print_row_fluid_section_wrapper' ), 1 );
 
-          remove_action( '__loop'                   , array( CZR_post_list::$instance, 'tc_prepare_section_view') );
-          add_action( '__loop'                      , array( $this, 'tc_grid_prepare_single_post') );
+          remove_action( '__loop'                   , array( CZR_post_list::$instance, 'czr_prepare_section_view') );
+          add_action( '__loop'                      , array( $this, 'czr_grid_prepare_single_post') );
 
-          if ( CZR_headings::$instance -> czr_is_edit_enabled() && apply_filters( 'tc_grid_render_expanded_edit_link', true ) )
-            add_filter( 'tc_grid_get_single_post_html' , array( $this, 'tc_grid_render_expanded_edit_link' ), 50 );
+          if ( CZR_headings::$instance -> czr_is_edit_enabled() && apply_filters( 'czr_grid_render_expanded_edit_link', true ) )
+            add_filter( 'czr_grid_get_single_post_html' , array( $this, 'czr_grid_render_expanded_edit_link' ), 50 );
         }
 
 
@@ -181,7 +181,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
               if ( $_layout['show_thumb_first'] )
                   $hook_prefix = '__after';
 
-              add_action( "{$hook_prefix}_grid_single_post",  array( CZR_headings::$instance, 'tc_render_headings_view' ) );
+              add_action( "{$hook_prefix}_grid_single_post",  array( CZR_headings::$instance, 'czr_render_headings_view' ) );
           }
 
           // THUMBNAIL : cache the post format icon first
@@ -248,7 +248,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * hook : __grid_single_post_content
         */
         function czr_grid_display_post_link(){
-          if ( ! apply_filters( 'tc_grid_display_post_link' , true ) )
+          if ( ! apply_filters( 'czr_grid_display_post_link' , true ) )
             return;
           printf( '<a class="tc-grid-bg-link" href="%1$s" title="%2$s"></a>',
               get_permalink( get_the_ID() ),
@@ -275,7 +275,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
           ?>
               <div class="entry-summary">
                 <?php
-                  echo apply_filters( 'tc_grid_display_figcaption_content',
+                  echo apply_filters( 'czr_grid_display_figcaption_content',
                     sprintf('<div class="tc-g-cont">%s</div>',
                       get_the_excerpt()
                     )
@@ -458,7 +458,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
             <?php
           $html = ob_get_contents();
           if ($html) ob_end_clean();
-          return apply_filters( 'tc_grid_get_single_post_html', $html, $post_list_content_class );
+          return apply_filters( 'czr_grid_get_single_post_html', $html, $post_list_content_class );
         }
 
 
@@ -633,7 +633,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
           }
 
           return apply_filters(
-            'tc_get_grid_font_sizes',
+            'czr_get_grid_font_sizes',
             isset($_col_media_matrix[$_col_nb]) ? $_col_media_matrix[$_col_nb] : array( 'xl' , 'l' , 'm', 'l', 'm' ),
             $_col_nb,
             $_col_media_matrix,
@@ -644,7 +644,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
 
 
         /**
-        * hook : 'tc_get_grid_font_sizes'
+        * hook : 'czr_get_grid_font_sizes'
         * Updates the array of sizes for a given sidebar layout
         * @param  $_sizes array. ex : array( 'xl' , 'l' , 'm', 'l', 'm' )
         * @param  $_col_nb string. Ex: '2'
@@ -689,7 +689,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * returns ratio of size / body size for a given selector type ( headings or paragraphs )
         */
         private function czr_get_grid_font_ratios( $_size = 'xl' , $_sel = 'h' ) {
-          $_ratios =  apply_filters( 'tc_get_grid_font_ratios' , array(
+          $_ratios =  apply_filters( 'czr_get_grid_font_ratios' , array(
               'xxxl' => array( 'h' => 2.10, 'p' => 1 ),
               'xxl' => array( 'h' => 1.86, 'p' => 1 ),
               'xl' => array( 'h' => 1.60, 'p' => 0.93 ),
@@ -823,7 +823,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
           }
 
           $_h = isset( $_grid_col_height_map[$_cols_nb][$_key] ) ? $_grid_col_height_map[$_cols_nb][$_key] : $_h;
-          return apply_filters( 'tc_get_grid_column_height' , $_h, $_cols_nb, $_current_layout );
+          return apply_filters( 'czr_get_grid_column_height' , $_h, $_cols_nb, $_current_layout );
         }
 
 
@@ -909,13 +909,13 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return bool
         */
         public function czr_is_grid_enabled() {
-          return apply_filters( 'tc_is_grid_enabled', 'grid' == esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_grid') ) && $this -> czr_is_grid_context_matching() );
+          return apply_filters( 'czr_is_grid_enabled', 'grid' == esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_grid') ) && $this -> czr_is_grid_context_matching() );
         }
 
 
         /* retrieves number of cols option, and wrap it into a filter */
         private function czr_get_grid_cols() {
-          return apply_filters( 'tc_get_grid_cols',
+          return apply_filters( 'czr_get_grid_cols',
             esc_attr( CZR_utils::$inst->czr_opt( 'tc_grid_columns') ),
             CZR_utils::czr_get_layout( $this -> post_id , 'class' )
           );

--- a/inc/parts/class-content-post_list_grid.php
+++ b/inc/parts/class-content-post_list_grid.php
@@ -11,8 +11,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_post_list_grid' ) ) :
-    class TC_post_list_grid {
+if ( ! class_exists( 'CZR_post_list_grid' ) ) :
+    class CZR_post_list_grid {
         static $instance;
         private $expanded_sticky;
         private $post_id;
@@ -50,7 +50,7 @@ if ( ! class_exists( 'TC_post_list_grid' ) ) :
           if ( ! apply_filters( 'tc_set_grid_hooks' , $this -> tc_is_grid_enabled() ) )
               return;
 
-          $this -> post_id = TC_utils::tc_id();
+          $this -> post_id = CZR_utils::tc_id();
 
           do_action( '__post_list_grid' );
           //Disable icon titles
@@ -81,8 +81,8 @@ if ( ! class_exists( 'TC_post_list_grid' ) ) :
           add_action( '__before_article_container'  , array( $this, 'tc_grid_prepare_expand_sticky' ) );
 
           // THUMBNAILS
-          remove_filter( 'post_class'               , array( TC_post_list::$instance , 'tc_add_thumb_shape_name'));
-          remove_filter( 'tc_thumb_size_name'       , array( TC_post_thumbnails::$instance, 'tc_set_thumb_size') );
+          remove_filter( 'post_class'               , array( CZR_post_list::$instance , 'tc_add_thumb_shape_name'));
+          remove_filter( 'tc_thumb_size_name'       , array( CZR_post_thumbnails::$instance, 'tc_set_thumb_size') );
           add_filter( 'tc_thumb_size_name'          , array( $this, 'tc_set_thumb_size_name') );
           add_filter( 'tc_thumb_size'               , array( $this, 'tc_set_thumb_size') );
 
@@ -98,11 +98,11 @@ if ( ! class_exists( 'TC_post_list_grid' ) ) :
           add_filter( 'tc_article_container_class'  , array( $this, 'tc_grid_container_set_classes' ) );
 
           //COMMENT BUBBLE
-          remove_filter( 'tc_the_title'             , array( TC_comments::$instance, 'tc_display_comment_bubble' ) , 1 );
+          remove_filter( 'tc_the_title'             , array( CZR_comments::$instance, 'tc_display_comment_bubble' ) , 1 );
           add_filter( 'tc_grid_get_single_post_html'  , array( $this, 'tc_grid_display_comment_bubble' ) );
 
           //POST METAS
-          remove_filter( 'tc_meta_utility_text'     , array( TC_post_metas::$instance , 'tc_add_link_to_post_after_metas'), 20 );
+          remove_filter( 'tc_meta_utility_text'     , array( CZR_post_metas::$instance , 'tc_add_link_to_post_after_metas'), 20 );
 
           //TITLE LENGTH
           add_filter( 'tc_title_text'               , array( $this, 'tc_grid_set_title_length' ) );
@@ -119,10 +119,10 @@ if ( ! class_exists( 'TC_post_list_grid' ) ) :
           add_action( '__after_article'             , array( $this, 'tc_print_article_sep' ), 0 );
           add_action( '__after_article'             , array( $this, 'tc_print_row_fluid_section_wrapper' ), 1 );
 
-          remove_action( '__loop'                   , array( TC_post_list::$instance, 'tc_prepare_section_view') );
+          remove_action( '__loop'                   , array( CZR_post_list::$instance, 'tc_prepare_section_view') );
           add_action( '__loop'                      , array( $this, 'tc_grid_prepare_single_post') );
 
-          if ( TC_headings::$instance -> tc_is_edit_enabled() && apply_filters( 'tc_grid_render_expanded_edit_link', true ) )
+          if ( CZR_headings::$instance -> tc_is_edit_enabled() && apply_filters( 'tc_grid_render_expanded_edit_link', true ) )
             add_filter( 'tc_grid_get_single_post_html' , array( $this, 'tc_grid_render_expanded_edit_link' ), 50 );
         }
 
@@ -172,7 +172,7 @@ if ( ! class_exists( 'TC_post_list_grid' ) ) :
             return;
 
           // get the filtered post list layout
-          $_layout   = apply_filters( 'tc_post_list_layout', TC_init::$instance -> post_list_layout );
+          $_layout   = apply_filters( 'tc_post_list_layout', CZR_init::$instance -> post_list_layout );
 
           // SET HOOKS FOR POST TITLES AND METAS
           // Default condition : must be a non sticky post
@@ -181,7 +181,7 @@ if ( ! class_exists( 'TC_post_list_grid' ) ) :
               if ( $_layout['show_thumb_first'] )
                   $hook_prefix = '__after';
 
-              add_action( "{$hook_prefix}_grid_single_post",  array( TC_headings::$instance, 'tc_render_headings_view' ) );
+              add_action( "{$hook_prefix}_grid_single_post",  array( CZR_headings::$instance, 'tc_render_headings_view' ) );
           }
 
           // THUMBNAIL : cache the post format icon first
@@ -189,7 +189,7 @@ if ( ! class_exists( 'TC_post_list_grid' ) ) :
           $_thumb_html = '';
           if ( $this -> tc_grid_show_thumb() ) {
             //return an array( $tc_thumb(image object), $tc_thumb_width(string), $tc_thumb_height(string) )
-            $_thumb_model = TC_post_thumbnails::$instance -> tc_get_thumbnail_model();
+            $_thumb_model = CZR_post_thumbnails::$instance -> tc_get_thumbnail_model();
             if ( isset($_thumb_model['tc_thumb']) )
               $_thumb_html  = $_thumb_model['tc_thumb'];
           }
@@ -307,7 +307,7 @@ if ( ! class_exists( 'TC_post_list_grid' ) ) :
         * @return string
         */
         function tc_grid_set_title_length( $_title ) {
-          $_max = esc_attr( TC_utils::$inst->tc_opt( 'tc_grid_num_words') );
+          $_max = esc_attr( CZR_utils::$inst->tc_opt( 'tc_grid_num_words') );
           $_max = ( empty($_max) || ! $_max ) ? 10 : $_max;
           $_max = $_max <= 0 ? 1 : $_max;
 
@@ -425,7 +425,7 @@ if ( ! class_exists( 'TC_post_list_grid' ) ) :
         */
         function tc_set_thumb_size(){
           $thumb = ( $this -> tc_get_grid_section_cols() == '1' ) ? 'tc_grid_full_size' : 'tc_grid_size';
-          return TC_init::$instance -> $thumb;
+          return CZR_init::$instance -> $thumb;
         }
 
 
@@ -436,9 +436,9 @@ if ( ! class_exists( 'TC_post_list_grid' ) ) :
         */
         function tc_grid_container_set_classes( $_classes ) {
           array_push( $_classes, 'tc-post-list-grid' );
-          if ( esc_attr( TC_utils::$inst->tc_opt( 'tc_grid_shadow') ) )
+          if ( esc_attr( CZR_utils::$inst->tc_opt( 'tc_grid_shadow') ) )
             array_push( $_classes, 'tc-grid-shadow' );
-          if ( esc_attr( TC_utils::$inst->tc_opt( 'tc_grid_bottom_border') ) )
+          if ( esc_attr( CZR_utils::$inst->tc_opt( 'tc_grid_bottom_border') ) )
             array_push( $_classes, 'tc-grid-border' );
           return $_classes;
         }
@@ -468,7 +468,7 @@ if ( ! class_exists( 'TC_post_list_grid' ) ) :
         * inside loop
         */
         function tc_grid_display_comment_bubble( $_html ) {
-          return TC_comments::$instance -> tc_display_comment_bubble() . $_html;
+          return CZR_comments::$instance -> tc_display_comment_bubble() . $_html;
         }
 
 
@@ -495,7 +495,7 @@ if ( ! class_exists( 'TC_post_list_grid' ) ) :
         * @return  bool
         * hook : tc_edit_in_title
         * @since Customizr 3.4.18
-        */       
+        */
         function tc_grid_disable_edit_in_title_expanded( $_bool ){
           return $this -> tc_force_current_post_expansion() ? false : $_bool;
         }
@@ -505,10 +505,10 @@ if ( ! class_exists( 'TC_post_list_grid' ) ) :
         * Append the edit link to the expanded post figcaption
         * hook : tc_grid_get_single_post_html
         * @since Customizr 3.4.18
-        */    
+        */
         function tc_grid_render_expanded_edit_link( $_html ) {
           if ( $this -> tc_force_current_post_expansion() )
-            $_html .= TC_headings::$instance -> tc_render_edit_link_view( $_echo = false );
+            $_html .= CZR_headings::$instance -> tc_render_edit_link_view( $_echo = false );
           return $_html;
         }
 
@@ -545,8 +545,8 @@ if ( ! class_exists( 'TC_post_list_grid' ) ) :
         * @return modified html string
         */
         function tc_set_grid_icon_visibility( $_html ) {
-          $_icon_enabled = (bool) esc_attr( TC_utils::$inst->tc_opt( 'tc_grid_icons') );
-          if ( TC___::$instance -> tc_is_customizing() )
+          $_icon_enabled = (bool) esc_attr( CZR_utils::$inst->tc_opt( 'tc_grid_icons') );
+          if ( CZR___::$instance -> tc_is_customizing() )
             return sprintf('<div class="tc-grid-icon format-icon" style="display:%1$s"></div>%2$s',
                 $_icon_enabled ? 'inline-block' : 'none',
                 $_html
@@ -637,7 +637,7 @@ if ( ! class_exists( 'TC_post_list_grid' ) ) :
             isset($_col_media_matrix[$_col_nb]) ? $_col_media_matrix[$_col_nb] : array( 'xl' , 'l' , 'm', 'l', 'm' ),
             $_col_nb,
             $_col_media_matrix,
-            TC_utils::tc_get_layout( $this -> post_id , 'class' )
+            CZR_utils::tc_get_layout( $this -> post_id , 'class' )
           );
         }
 
@@ -776,7 +776,7 @@ if ( ! class_exists( 'TC_post_list_grid' ) ) :
           $_lh_ratio = apply_filters( 'tc_grid_line_height_ratio' , 1.28 ); //line-height / font-size
           $_ratio = $this -> tc_get_grid_font_ratios( $_size , $_wot );
           //body font size
-          $_bs = esc_attr( TC_utils::$inst->tc_opt( 'tc_body_font_size') );
+          $_bs = esc_attr( CZR_utils::$inst->tc_opt( 'tc_body_font_size') );
           $_bs = is_numeric($_bs) && 1 >= $_bs ? $_bs : 15;
 
           return sprintf( 'font-size:%spx;line-height:%spx;' ,
@@ -797,7 +797,7 @@ if ( ! class_exists( 'TC_post_list_grid' ) ) :
         */
         private function tc_get_grid_column_height( $_cols_nb = '3' ) {
           $_h               = $this -> tc_grid_get_thumb_height();
-          $_current_layout  = TC_utils::tc_get_layout( $this -> post_id , 'sidebar' );
+          $_current_layout  = CZR_utils::tc_get_layout( $this -> post_id , 'sidebar' );
           $_layouts         = array('b', 'l', 'r' , 'f');//both, left, right, full (no sidebar)
           $_key             = 3;//default value == full
           if ( in_array( $_current_layout, $_layouts ) )
@@ -849,7 +849,7 @@ if ( ! class_exists( 'TC_post_list_grid' ) ) :
         * @return (number) customizer user defined height for the grid thumbnails
         */
         private function tc_grid_get_thumb_height() {
-          $_opt = esc_attr( TC_utils::$inst->tc_opt( 'tc_grid_thumb_height') );
+          $_opt = esc_attr( CZR_utils::$inst->tc_opt( 'tc_grid_thumb_height') );
           return ( is_numeric($_opt) && $_opt > 1 ) ? $_opt : 350;
         }
 
@@ -868,14 +868,14 @@ if ( ! class_exists( 'TC_post_list_grid' ) ) :
                   $wp_query->is_posts_page ) )
               return false;
 
-          $_expand_feat_post_opt = apply_filters( 'tc_grid_expand_featured', esc_attr( TC_utils::$inst->tc_opt( 'tc_grid_expand_featured') ) );
+          $_expand_feat_post_opt = apply_filters( 'tc_grid_expand_featured', esc_attr( CZR_utils::$inst->tc_opt( 'tc_grid_expand_featured') ) );
 
           if ( ! $this -> expanded_sticky ) {
             $_sticky_posts = get_option('sticky_posts');
             // get last published sticky post
             if ( is_array($_sticky_posts) && ! empty( $_sticky_posts ) ) {
               $_where = implode(',', $_sticky_posts );
-              $this -> expanded_sticky = $wpdb->get_var( 
+              $this -> expanded_sticky = $wpdb->get_var(
                      "
                      SELECT ID
                      FROM $wpdb->posts
@@ -909,15 +909,15 @@ if ( ! class_exists( 'TC_post_list_grid' ) ) :
         * @return bool
         */
         public function tc_is_grid_enabled() {
-          return apply_filters( 'tc_is_grid_enabled', 'grid' == esc_attr( TC_utils::$inst->tc_opt( 'tc_post_list_grid') ) && $this -> tc_is_grid_context_matching() );
+          return apply_filters( 'tc_is_grid_enabled', 'grid' == esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_grid') ) && $this -> tc_is_grid_context_matching() );
         }
 
 
         /* retrieves number of cols option, and wrap it into a filter */
         private function tc_get_grid_cols() {
           return apply_filters( 'tc_get_grid_cols',
-            esc_attr( TC_utils::$inst->tc_opt( 'tc_grid_columns') ),
-            TC_utils::tc_get_layout( $this -> post_id , 'class' )
+            esc_attr( CZR_utils::$inst->tc_opt( 'tc_grid_columns') ),
+            CZR_utils::tc_get_layout( $this -> post_id , 'class' )
           );
         }
 
@@ -934,7 +934,7 @@ if ( ! class_exists( 'TC_post_list_grid' ) ) :
         /* returns the type of post list we're in if any, an empty string otherwise */
         private function tc_get_grid_context() {
           global $wp_query;
-            
+
           if ( ( is_home() && 'posts' == get_option('show_on_front') ) ||
                   $wp_query->is_posts_page )
               return 'blog';
@@ -950,7 +950,7 @@ if ( ! class_exists( 'TC_post_list_grid' ) ) :
          * and the post list we're in */
         private function tc_is_grid_context_matching() {
           $_type = $this -> tc_get_grid_context();
-          $_apply_grid_to_post_type = apply_filters( 'tc_grid_in_' . $_type, esc_attr( TC_utils::$inst->tc_opt( 'tc_grid_in_' . $_type ) ) );
+          $_apply_grid_to_post_type = apply_filters( 'tc_grid_in_' . $_type, esc_attr( CZR_utils::$inst->tc_opt( 'tc_grid_in_' . $_type ) ) );
           return apply_filters('tc_grid_do',  $_type && $_apply_grid_to_post_type );
         }
 
@@ -959,7 +959,7 @@ if ( ! class_exists( 'TC_post_list_grid' ) ) :
         * @return  boolean
         */
         private function tc_grid_show_thumb() {
-          return TC_post_thumbnails::$instance -> tc_has_thumb() && 0 != esc_attr( TC_utils::$inst->tc_opt( 'tc_post_list_show_thumb' ) );
+          return CZR_post_thumbnails::$instance -> tc_has_thumb() && 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_show_thumb' ) );
         }
   }//end of class
 endif;

--- a/inc/parts/class-content-post_list_grid.php
+++ b/inc/parts/class-content-post_list_grid.php
@@ -46,7 +46,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         /*
         * hook : wp
         */
-        function tc_set_grid_hooks(){
+        function czr_set_grid_hooks(){
           if ( ! apply_filters( 'tc_set_grid_hooks' , $this -> tc_is_grid_enabled() ) )
               return;
 
@@ -74,7 +74,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * hook : __before_article_container
         * before loop
         */
-        function tc_set_grid_before_loop_hooks(){
+        function czr_set_grid_before_loop_hooks(){
           // LAYOUT
           add_filter( 'tc_post_list_layout'         , array( $this, 'tc_grid_set_content_layout') );
           add_filter( 'tc_post_list_selectors'      , array( $this, 'tc_grid_set_article_selectors') );
@@ -114,7 +114,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * actions and filters inside loop
         * @return  void
         */
-        function tc_set_grid_loop_hooks() {
+        function czr_set_grid_loop_hooks() {
           add_action( '__before_article'            , array( $this, 'tc_print_row_fluid_section_wrapper' ), 1 );
           add_action( '__after_article'             , array( $this, 'tc_print_article_sep' ), 0 );
           add_action( '__after_article'             , array( $this, 'tc_print_row_fluid_section_wrapper' ), 1 );
@@ -135,7 +135,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * hook : __before_article
         * Wrap articles in a grid section
         */
-        function tc_print_row_fluid_section_wrapper(){
+        function czr_print_row_fluid_section_wrapper(){
           global $wp_query;
           $current_post   = $wp_query -> current_post;
           $start_post     = $this -> expanded_sticky ? 1 : 0;
@@ -166,7 +166,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return the figcation content parts as an array of html strings
         * inside loop
         */
-        function tc_grid_prepare_single_post() {
+        function czr_grid_prepare_single_post() {
           global $post;
           if ( ! isset($post) || empty($post) || ! apply_filters( 'tc_show_post_in_post_list', $this -> tc_is_grid_context_matching() , $post ) )
             return;
@@ -224,7 +224,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return html string
         *
         */
-        private function tc_grid_render_single_post( $_classes, $_thumb_html, $_post_content_html ) {
+        private function czr_grid_render_single_post( $_classes, $_thumb_html, $_post_content_html ) {
           ob_start();
             do_action( '__before_grid_single_post');//<= open <section> and maybe display title + metas
 
@@ -247,7 +247,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         /**
         * hook : __grid_single_post_content
         */
-        function tc_grid_display_post_link(){
+        function czr_grid_display_post_link(){
           if ( ! apply_filters( 'tc_grid_display_post_link' , true ) )
             return;
           printf( '<a class="tc-grid-bg-link" href="%1$s" title="%2$s"></a>',
@@ -260,7 +260,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         /**
         * hook : __grid_single_post_content
         */
-        function tc_grid_display_fade_excerpt(){
+        function czr_grid_display_fade_excerpt(){
           if ( ! apply_filters( 'tc_grid_fade_excerpt' , ! $this -> tc_force_current_post_expansion() ) )
             return;
           printf( '<span class="tc-grid-fade_expt"></span>' );
@@ -271,7 +271,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         /*
         * hook : __grid_single_post_content
         */
-        function tc_grid_display_figcaption_content() {
+        function czr_grid_display_figcaption_content() {
           ?>
               <div class="entry-summary">
                 <?php
@@ -291,7 +291,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * hook : __after_article (declared in index.php)
         * print a separator after each article => revealed in responsive mode
         */
-        function tc_print_article_sep() {
+        function czr_print_article_sep() {
           //renders the hr separator after each article
           echo apply_filters( 'tc_grid_single_post_sep', '<hr class="featurette-divider '.current_filter().'">' );
         }
@@ -306,7 +306,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * Limits the length of the post titles in grids to a custom number of characters
         * @return string
         */
-        function tc_grid_set_title_length( $_title ) {
+        function czr_grid_set_title_length( $_title ) {
           $_max = esc_attr( CZR_utils::$inst->tc_opt( 'tc_grid_num_words') );
           $_max = ( empty($_max) || ! $_max ) ? 10 : $_max;
           $_max = $_max <= 0 ? 1 : $_max;
@@ -328,7 +328,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * hook : pre_get_posts
         * exclude the first sticky post
         */
-        function tc_maybe_excl_first_sticky( $query ){
+        function czr_maybe_excl_first_sticky( $query ){
           if ( $this -> tc_is_grid_enabled() && $this -> tc_is_sticky_expanded( $query ) )
             $query->set('post__not_in', array( $this -> expanded_sticky ) );
         }
@@ -339,7 +339,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * force content + thumb layout : Force the title to be displayed always on bottom
         * @param current layout array()
         */
-        function tc_grid_set_content_layout( $_layout ){
+        function czr_grid_set_content_layout( $_layout ){
           $_layout['show_thumb_first'] = true;
           $_layout['content']          = 'tc-grid-excerpt';
           $_layout['thumb']            = 'span12 tc-grid-post-container';
@@ -355,7 +355,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @param $_col_nb = string possible values : 1, 2, 3, 4
         * @param $_current_layout string of layout class like span4
         */
-        function tc_set_grid_section_cols( $_col_nb, $_current_layout ) {
+        function czr_set_grid_section_cols( $_col_nb, $_current_layout ) {
           $_map = apply_filters(
             'tc_grid_col_layout_map',
             array(
@@ -386,7 +386,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * Apply proper class to articles selectors to control articles width
         * hook : tc_post_list_selectors
         */
-        function tc_grid_set_article_selectors($selectors){
+        function czr_grid_set_article_selectors($selectors){
           $_class = sprintf( '%1$s tc-grid span%2$s',
             apply_filters( 'tc_grid_add_expanded_class', $this -> tc_force_current_post_expansion() ) ? 'expanded' : '',
             is_numeric( $this -> tc_get_grid_section_cols() ) ? 12 / $this -> tc_get_grid_section_cols() : 6
@@ -398,7 +398,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         /*
         * hook : __before_article_container
         */
-        function tc_grid_prepare_expand_sticky(){
+        function czr_grid_prepare_expand_sticky(){
           global $wp_query;
           if ( ! ( $this -> tc_is_sticky_expanded() &&
                  $wp_query -> query_vars[ 'paged' ] == 0 ) ){
@@ -415,7 +415,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         /*
         * hook : tc_thumb_size_name
         */
-        function tc_set_thumb_size_name(){
+        function czr_set_thumb_size_name(){
           return ( $this -> tc_get_grid_section_cols() == '1' ) ? 'tc-grid-full' : 'tc-grid';
         }
 
@@ -423,7 +423,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         /*
         * hook : tc_thumb_size
         */
-        function tc_set_thumb_size(){
+        function czr_set_thumb_size(){
           $thumb = ( $this -> tc_get_grid_section_cols() == '1' ) ? 'tc_grid_full_size' : 'tc_grid_size';
           return CZR_init::$instance -> $thumb;
         }
@@ -434,7 +434,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * inside loop
         * add custom classes to the grid .article-container element
         */
-        function tc_grid_container_set_classes( $_classes ) {
+        function czr_grid_container_set_classes( $_classes ) {
           array_push( $_classes, 'tc-post-list-grid' );
           if ( esc_attr( CZR_utils::$inst->tc_opt( 'tc_grid_shadow') ) )
             array_push( $_classes, 'tc-grid-shadow' );
@@ -448,7 +448,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return the figcation content as a string
         * inside loop
         */
-        private function tc_grid_get_single_post_html( $post_list_content_class ) {
+        private function czr_grid_get_single_post_html( $post_list_content_class ) {
           global $post;
           ob_start();
             ?>
@@ -467,7 +467,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return the comment_bubble as a string
         * inside loop
         */
-        function tc_grid_display_comment_bubble( $_html ) {
+        function czr_grid_display_comment_bubble( $_html ) {
           return CZR_comments::$instance -> tc_display_comment_bubble() . $_html;
         }
 
@@ -478,7 +478,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return  html string
         * hook : tc_grid_display_figcaption_content
         */
-        function tc_grid_set_expanded_post_title( $_html ){
+        function czr_grid_set_expanded_post_title( $_html ){
           if ( ! $this -> tc_force_current_post_expansion() )
               return $_html;
           global $post;
@@ -496,7 +496,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * hook : tc_edit_in_title
         * @since Customizr 3.4.18
         */
-        function tc_grid_disable_edit_in_title_expanded( $_bool ){
+        function czr_grid_disable_edit_in_title_expanded( $_bool ){
           return $this -> tc_force_current_post_expansion() ? false : $_bool;
         }
 
@@ -506,7 +506,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * hook : tc_grid_get_single_post_html
         * @since Customizr 3.4.18
         */
-        function tc_grid_render_expanded_edit_link( $_html ) {
+        function czr_grid_render_expanded_edit_link( $_html ) {
           if ( $this -> tc_force_current_post_expansion() )
             $_html .= CZR_headings::$instance -> tc_render_edit_link_view( $_echo = false );
           return $_html;
@@ -518,7 +518,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * hook : tc_user_options_style
         * @since Customizr 3.2.18
         */
-        function tc_grid_write_inline_css( $_css ){
+        function czr_grid_write_inline_css( $_css ){
           if ( ! $this -> tc_is_grid_enabled() )
             return $_css;
 
@@ -544,7 +544,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * hook : tc-grid-thumb-html
         * @return modified html string
         */
-        function tc_set_grid_icon_visibility( $_html ) {
+        function czr_set_grid_icon_visibility( $_html ) {
           $_icon_enabled = (bool) esc_attr( CZR_utils::$inst->tc_opt( 'tc_grid_icons') );
           if ( CZR___::$instance -> tc_is_customizing() )
             return sprintf('<div class="tc-grid-icon format-icon" style="display:%1$s"></div>%2$s',
@@ -569,7 +569,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return css media query string
         * Returns the paragraph and title media queries for a given layout
         */
-        private function tc_get_grid_font_css( $_col_nb = '3' ) {
+        private function czr_get_grid_font_css( $_col_nb = '3' ) {
           $_media_queries     = $this -> tc_get_grid_media_queries();//returns the simple array of media queries
           $_grid_font_sizes = $this -> tc_get_grid_font_sizes( $_col_nb );//return the array of sizes (ordered by @media queries) for a given column layout
           $_col_rules         = array();
@@ -594,7 +594,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         /**
         * @return simple array of media queries
         */
-        private function tc_get_grid_media_queries() {
+        private function czr_get_grid_media_queries() {
           return apply_filters( 'tc_grid_media_queries' ,  array(
               '(min-width: 1200px)', '(max-width: 1199px) and (min-width: 980px)', '(max-width: 979px) and (min-width: 768px)', '(max-width: 767px)', '(max-width: 480px)'
             )
@@ -611,7 +611,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * Note : When all sizes are requested (default case), the returned array can be filtered with the current layout param
         * Size array must have the same length of the media query array
         */
-        private function tc_get_grid_font_sizes( $_col_nb = '3', $_requested_media_size = null ) {
+        private function czr_get_grid_font_sizes( $_col_nb = '3', $_requested_media_size = null ) {
           $_col_media_matrix = apply_filters( 'tc_grid_font_matrix' , array(
               //=> matrix col nb / media queries
               //            1200 | 1199-980 | 979-768 | 767   | 480
@@ -652,7 +652,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @param  $_current_layout string. Ex : 'span9'
         * @return array()
         */
-        function tc_set_layout_font_size( $_sizes, $_col_nb, $_col_media_matrix, $_current_layout ) {
+        function czr_set_layout_font_size( $_sizes, $_col_nb, $_col_media_matrix, $_current_layout ) {
           //max possible font size key in the col_media_queries matrix for a given sidebar layout
           $_map = apply_filters(
             'tc_layout_font_size_map',
@@ -688,7 +688,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @param selector type string
         * returns ratio of size / body size for a given selector type ( headings or paragraphs )
         */
-        private function tc_get_grid_font_ratios( $_size = 'xl' , $_sel = 'h' ) {
+        private function czr_get_grid_font_ratios( $_size = 'xl' , $_sel = 'h' ) {
           $_ratios =  apply_filters( 'tc_get_grid_font_ratios' , array(
               'xxxl' => array( 'h' => 2.10, 'p' => 1 ),
               'xxl' => array( 'h' => 1.86, 'p' => 1 ),
@@ -714,7 +714,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * 1) there's a sticky post
         * 2) user layout is one column
         */
-        private function tc_grid_assign_css_rules_to_selectors( $_media_query, $_css_prop, $_col_nb ) {
+        private function czr_grid_assign_css_rules_to_selectors( $_media_query, $_css_prop, $_col_nb ) {
           $_css = '';
           //Add one column font rules if there's a sticky post
           if ( $this -> tc_is_sticky_expanded() || '1' == $_col_nb ) {
@@ -743,7 +743,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * 1) there's a sticky post
         * 2) user layout is one column
         */
-        private function tc_grid_get_figure_css( $_col_nb = '3' ) {
+        private function czr_grid_get_figure_css( $_col_nb = '3' ) {
           $_height = $this -> tc_get_grid_column_height( $_col_nb );
           $_cols_class      = sprintf( 'grid-cols-%s' , $_col_nb );
           $_css = '';
@@ -772,7 +772,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @param selector type string
         * returns the font-size and line-height css rules
         */
-        private function tc_grid_build_css_rules( $_size = 'xl', $_wot = 'h' ) {
+        private function czr_grid_build_css_rules( $_size = 'xl', $_wot = 'h' ) {
           $_lh_ratio = apply_filters( 'tc_grid_line_height_ratio' , 1.28 ); //line-height / font-size
           $_ratio = $this -> tc_get_grid_font_ratios( $_size , $_wot );
           //body font size
@@ -795,7 +795,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return string
         *
         */
-        private function tc_get_grid_column_height( $_cols_nb = '3' ) {
+        private function czr_get_grid_column_height( $_cols_nb = '3' ) {
           $_h               = $this -> tc_grid_get_thumb_height();
           $_current_layout  = CZR_utils::tc_get_layout( $this -> post_id , 'sidebar' );
           $_layouts         = array('b', 'l', 'r' , 'f');//both, left, right, full (no sidebar)
@@ -835,7 +835,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return string
         *
         */
-        private function tc_set_max_col_height( $_heights ,$_h ) {
+        private function czr_set_max_col_height( $_heights ,$_h ) {
           $_return = array();
           foreach ($_heights as $_value) {
             $_return[] = $_value >= $_h ? $_h : $_value;
@@ -848,7 +848,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         /**
         * @return (number) customizer user defined height for the grid thumbnails
         */
-        private function tc_grid_get_thumb_height() {
+        private function czr_grid_get_thumb_height() {
           $_opt = esc_attr( CZR_utils::$inst->tc_opt( 'tc_grid_thumb_height') );
           return ( is_numeric($_opt) && $_opt > 1 ) ? $_opt : 350;
         }
@@ -858,7 +858,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return bool
         * check if we have to expand the first sticky post
         */
-        private function tc_is_sticky_expanded( $query = null ){
+        private function czr_is_sticky_expanded( $query = null ){
           global $wp_query, $wpdb;
           $query = ( $query ) ? $query : $wp_query;
 
@@ -899,7 +899,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         * @return bool
         * returns if the current post is the expanded one
         */
-        private function tc_force_current_post_expansion(){
+        private function czr_force_current_post_expansion(){
           global $wp_query;
           return ( $this -> expanded_sticky && 0 == $wp_query -> current_post );
         }
@@ -908,13 +908,13 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         /*
         * @return bool
         */
-        public function tc_is_grid_enabled() {
+        public function czr_is_grid_enabled() {
           return apply_filters( 'tc_is_grid_enabled', 'grid' == esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_grid') ) && $this -> tc_is_grid_context_matching() );
         }
 
 
         /* retrieves number of cols option, and wrap it into a filter */
-        private function tc_get_grid_cols() {
+        private function czr_get_grid_cols() {
           return apply_filters( 'tc_get_grid_cols',
             esc_attr( CZR_utils::$inst->tc_opt( 'tc_grid_columns') ),
             CZR_utils::tc_get_layout( $this -> post_id , 'class' )
@@ -923,7 +923,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
 
 
         /* returns articles wrapper section columns */
-        private function tc_get_grid_section_cols() {
+        private function czr_get_grid_section_cols() {
           return apply_filters( 'tc_grid_section_cols',
             $this -> tc_force_current_post_expansion() ? '1' : $this -> tc_get_grid_cols()
           );
@@ -932,7 +932,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
 
 
         /* returns the type of post list we're in if any, an empty string otherwise */
-        private function tc_get_grid_context() {
+        private function czr_get_grid_context() {
           global $wp_query;
 
           if ( ( is_home() && 'posts' == get_option('show_on_front') ) ||
@@ -948,7 +948,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
 
         /* performs the match between the option where to use post list grid
          * and the post list we're in */
-        private function tc_is_grid_context_matching() {
+        private function czr_is_grid_context_matching() {
           $_type = $this -> tc_get_grid_context();
           $_apply_grid_to_post_type = apply_filters( 'tc_grid_in_' . $_type, esc_attr( CZR_utils::$inst->tc_opt( 'tc_grid_in_' . $_type ) ) );
           return apply_filters('tc_grid_do',  $_type && $_apply_grid_to_post_type );
@@ -958,7 +958,7 @@ if ( ! class_exists( 'CZR_post_list_grid' ) ) :
         /**
         * @return  boolean
         */
-        private function tc_grid_show_thumb() {
+        private function czr_grid_show_thumb() {
           return CZR_post_thumbnails::$instance -> tc_has_thumb() && 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_show_thumb' ) );
         }
   }//end of class

--- a/inc/parts/class-content-post_metas.php
+++ b/inc/parts/class-content-post_metas.php
@@ -17,11 +17,11 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         function __construct () {
           self::$instance =& $this;
           //Show / hide metas based on customizer user options (@since 3.2.0)
-          add_action( 'template_redirect'                            , array( $this , 'czr_set_visibility_options' ) , 10 );
+          add_action( 'template_redirect'                            , array( $this , 'czr_fn_set_visibility_options' ) , 10 );
            //Show / hide metas based on customizer user options (@since 3.2.0)
-          add_action( 'template_redirect'                            , array( $this , 'czr_set_design_options' ) , 20 );
+          add_action( 'template_redirect'                            , array( $this , 'czr_fn_set_design_options' ) , 20 );
           //Show / hide metas based on customizer user options (@since 3.2.0)
-          add_action( '__after_content_title'         , array( $this , 'czr_set_post_metas_hooks' ), 20 );
+          add_action( '__after_content_title'         , array( $this , 'czr_fn_set_post_metas_hooks' ), 20 );
 
         }
 
@@ -37,51 +37,51 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @package Customizr
         * @since Customizr 3.2.0
         */
-        function czr_set_visibility_options() {
+        function czr_fn_set_visibility_options() {
           //if customizing context, always render. Will be hidden in the DOM with a body class filter is disabled.
-          if ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_post_metas' ) ) ) {
-            if ( CZR___::$instance -> czr_is_customizing() )
-              add_filter( 'body_class' , array( $this , 'czr_hide_all_post_metas') );
+          if ( 0 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_post_metas' ) ) ) {
+            if ( CZR___::$instance -> czr_fn_is_customizing() )
+              add_filter( 'body_class' , array( $this , 'czr_fn_hide_all_post_metas') );
             else{
               add_filter( 'tc_show_post_metas' , '__return_false' );
               return;
             }
           }
-          if ( is_singular() && ! is_page() && ! czr__f('__is_home') ) {
-              if ( 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_post_metas_single_post' ) ) ) {
+          if ( is_singular() && ! is_page() && ! czr_fn__f('__is_home') ) {
+              if ( 0 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_post_metas_single_post' ) ) ) {
                   add_filter( 'tc_show_post_metas' , '__return_true' );
                   return;
               }
 
-              if ( CZR___::$instance -> czr_is_customizing() ) {
-                  add_filter( 'body_class' , array( $this , 'czr_hide_post_metas') );
+              if ( CZR___::$instance -> czr_fn_is_customizing() ) {
+                  add_filter( 'body_class' , array( $this , 'czr_fn_hide_post_metas') );
                   add_filter( 'tc_show_post_metas' , '__return_true' );
               }
               else
                   add_filter( 'tc_show_post_metas' , '__return_false' );
               return;
           }
-          if ( ! is_singular() && ! czr__f('__is_home') && ! is_page() ) {
-              if ( 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_post_metas_post_lists' ) ) ) {
+          if ( ! is_singular() && ! czr_fn__f('__is_home') && ! is_page() ) {
+              if ( 0 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_post_metas_post_lists' ) ) ) {
                   add_filter( 'tc_show_post_metas' , '__return_true' );
                   return;
               }
 
-              if ( CZR___::$instance -> czr_is_customizing() ) {
-                  add_filter( 'body_class' , array( $this , 'czr_hide_post_metas') );
+              if ( CZR___::$instance -> czr_fn_is_customizing() ) {
+                  add_filter( 'body_class' , array( $this , 'czr_fn_hide_post_metas') );
                   add_filter( 'tc_show_post_metas' , '__return_true' );
               }
               else
                   add_filter( 'tc_show_post_metas' , '__return_false' );
               return;
           }
-          if ( czr__f('__is_home') ) {
-              if ( 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_post_metas_home' ) ) ) {
+          if ( czr_fn__f('__is_home') ) {
+              if ( 0 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_post_metas_home' ) ) ) {
                   add_filter( 'tc_show_post_metas' , '__return_true' );
                   return;
               }
-              if ( CZR___::$instance -> czr_is_customizing() ) {
-                  add_filter( 'body_class' , array( $this , 'czr_hide_post_metas') );
+              if ( CZR___::$instance -> czr_fn_is_customizing() ) {
+                  add_filter( 'body_class' , array( $this , 'czr_fn_hide_post_metas') );
                   add_filter( 'tc_show_post_metas' , '__return_true' );
               }
               else
@@ -93,19 +93,19 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
 
         /**
         * Default metas visibility controller
-        * tc_show_post_metas gets filtered by czr_set_visibility_options() called early in template_redirect
+        * tc_show_post_metas gets filtered by czr_fn_set_visibility_options() called early in template_redirect
         * @return  boolean
         * @package Customizr
         * @since Customizr 3.2.6
         */
-        private function czr_show_post_metas() {
+        private function czr_fn_show_post_metas() {
           global $post;
           //when do we display the metas ?
           //1) default is : not on home page, 404, search page
           //2) +filter conditions
           return apply_filters(
               'tc_show_post_metas',
-              ! czr__f('__is_home')
+              ! czr_fn__f('__is_home')
               && ! is_404()
               && ! 'page' == $post -> post_type
               && in_array( get_post_type(), apply_filters('tc_show_metas_for_post_types' , array( 'post') ) )
@@ -117,17 +117,17 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         /***********************
         * DESIGN HOOK SETUP
         ***********************/
-        function czr_set_design_options() {
-          if ( 'buttons' == esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_metas_design' ) ) )
+        function czr_fn_set_design_options() {
+          if ( 'buttons' == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_post_metas_design' ) ) )
             return;
 
-          add_filter( 'tc_meta_terms_glue'           , array( $this, 'czr_set_term_meta_glue' ) );
+          add_filter( 'tc_meta_terms_glue'           , array( $this, 'czr_fn_set_term_meta_glue' ) );
           add_filter( 'tc_meta_tax_class'            , '__return_empty_array' );
 
-          add_filter( 'tc_post_tax_metas_html'       , array( $this, 'czr_set_tax_metas' ), 10, 2 );
-          add_filter( 'tc_post_date_metas_html'      , array( $this, 'czr_set_date_metas' ), 10, 2 );
-          add_filter( 'tc_post_author_metas_html'    , array( $this, 'czr_set_author_metas' ), 10 , 2 );
-          add_filter( 'tc_set_metas_content'         , array( $this, 'czr_set_metas' ), 10, 2 );
+          add_filter( 'tc_post_tax_metas_html'       , array( $this, 'czr_fn_set_tax_metas' ), 10, 2 );
+          add_filter( 'tc_post_date_metas_html'      , array( $this, 'czr_fn_set_date_metas' ), 10, 2 );
+          add_filter( 'tc_post_author_metas_html'    , array( $this, 'czr_fn_set_author_metas' ), 10 , 2 );
+          add_filter( 'tc_set_metas_content'         , array( $this, 'czr_fn_set_metas' ), 10, 2 );
         }
 
 
@@ -142,25 +142,25 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @package Customizr
         * @since Customizr 3.2.2
         */
-        function czr_set_post_metas_hooks() {
-          if ( ! $this -> czr_show_post_metas() )
+        function czr_fn_set_post_metas_hooks() {
+          if ( ! $this -> czr_fn_show_post_metas() )
             return;
           global $post;
           $_model = array();
           //BUILD MODEL
           //Two cases : attachment and not attachment
           if ( 'attachment' == $post -> post_type ) {
-            $_model = $this -> czr_build_attachment_post_metas_model();
+            $_model = $this -> czr_fn_build_attachment_post_metas_model();
           } else {
-            $_model = $this -> czr_build_post_post_metas_model();
+            $_model = $this -> czr_fn_build_post_post_metas_model();
             //Set metas content based on customizer user options (@since 3.2.6)
-            add_filter( 'tc_meta_utility_text'      , array( $this , 'czr_set_post_metas_elements'), 10 , 2 );
+            add_filter( 'tc_meta_utility_text'      , array( $this , 'czr_fn_set_post_metas_elements'), 10 , 2 );
             //filter metas content with default theme settings
-            add_filter( 'tc_meta_utility_text'      , array( $this , 'czr_add_link_to_post_after_metas'), 20 );
+            add_filter( 'tc_meta_utility_text'      , array( $this , 'czr_fn_add_link_to_post_after_metas'), 20 );
           }
 
           //RENDER VIEW
-          $this -> czr_render_metas_view( $_model );
+          $this -> czr_fn_render_metas_view( $_model );
         }
 
 
@@ -171,12 +171,12 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @package Customizr
         * @since Customizr 3.2.6
         */
-        private function czr_build_post_post_metas_model() {
-          $cat_list   = $this -> czr_meta_generate_tax_list( true );
-          $tag_list   = $this -> czr_meta_generate_tax_list( false );
-          $pub_date   = $this -> czr_get_meta_date( 'publication' );
-          $auth       = $this -> czr_get_meta_author();
-          $upd_date   = $this -> czr_get_meta_date( 'update' );
+        private function czr_fn_build_post_post_metas_model() {
+          $cat_list   = $this -> czr_fn_meta_generate_tax_list( true );
+          $tag_list   = $this -> czr_fn_meta_generate_tax_list( false );
+          $pub_date   = $this -> czr_fn_get_meta_date( 'publication' );
+          $auth       = $this -> czr_fn_get_meta_author();
+          $upd_date   = $this -> czr_fn_get_meta_date( 'update' );
 
           $_args      = compact( 'cat_list' ,'tag_list', 'pub_date', 'auth', 'upd_date' );
           $_html      = sprintf( __( 'This entry was posted on %1$s<span class="by-author"> by %2$s</span>.' , 'customizr' ),
@@ -194,7 +194,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @package Customizr
         * @since Customizr 3.3.2
         */
-        private function czr_build_attachment_post_metas_model() {
+        private function czr_fn_build_attachment_post_metas_model() {
           global $post;
           $metadata       = wp_get_attachment_metadata();
           $_html = sprintf( '%1$s <span class="entry-date"><time class="entry-date updated" datetime="%2$s">%3$s</time></span> %4$s %5$s',
@@ -218,7 +218,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @package Customizr
         * @since Customizr 3.3.2
         */
-        private function czr_render_metas_view( $_model ) {
+        private function czr_fn_render_metas_view( $_model ) {
           if ( empty($_model) )
             return;
           //extract $_html , $_args
@@ -247,14 +247,14 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @package Customizr
         * @since Customizr 3.2.6
         */
-        function czr_set_post_metas_elements( $_default , $_args = array() ) {
-            $_show_cats         = 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_post_metas_categories' ) ) && false != $this -> czr_meta_generate_tax_list( true );
-            $_show_tags         = 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_post_metas_tags' ) ) && false != $this -> czr_meta_generate_tax_list( false );
-            $_show_pub_date     = 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_post_metas_publication_date' ) );
-            $_show_upd_date     = 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_post_metas_update_date' ) ) && false !== CZR_utils::$inst -> czr_post_has_update();
-            $_show_upd_in_days  = 'days' == esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_metas_update_date_format' ) );
+        function czr_fn_set_post_metas_elements( $_default , $_args = array() ) {
+            $_show_cats         = 0 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_post_metas_categories' ) ) && false != $this -> czr_fn_meta_generate_tax_list( true );
+            $_show_tags         = 0 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_post_metas_tags' ) ) && false != $this -> czr_fn_meta_generate_tax_list( false );
+            $_show_pub_date     = 0 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_post_metas_publication_date' ) );
+            $_show_upd_date     = 0 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_post_metas_update_date' ) ) && false !== CZR_utils::$inst -> czr_fn_post_has_update();
+            $_show_upd_in_days  = 'days' == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_post_metas_update_date_format' ) );
             $_show_date         = $_show_pub_date || $_show_upd_date;
-            $_show_author       = 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_post_metas_author' ) );
+            $_show_author       = 0 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_post_metas_author' ) );
 
             //extract cat_list, tag_list, pub_date, auth, upd_date from $args if not empty
             if ( empty($_args) )
@@ -308,7 +308,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
             $_update_text = '';
             if ( $_show_upd_date ) {
               if ( $_show_upd_in_days ) {
-                $_update_days = CZR_utils::$inst -> czr_post_has_update();
+                $_update_days = CZR_utils::$inst -> czr_fn_post_has_update();
                 $_update_text = ( 0 == $_update_days ) ? __( '(updated today)' , 'customizr' ) : sprintf( __( '(updated %s days ago)' , 'customizr' ), $_update_days );
                 $_update_text = ( 1 == $_update_days ) ? __( '(updated 1 day ago)' , 'customizr' ) : $_update_text;
               }
@@ -337,13 +337,13 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @package Customizr
         * @since Customizr 3.0
         */
-        public function czr_meta_generate_tax_list( $hierarchical ) {
-          $post_terms = $this -> czr_get_term_of_tax_type( $hierarchical );
+        public function czr_fn_meta_generate_tax_list( $hierarchical ) {
+          $post_terms = $this -> czr_fn_get_term_of_tax_type( $hierarchical );
           if ( ! $post_terms )
             return;
 
-          $_terms_html_array  = array_map( array( $this , 'czr_meta_term_view' ), $post_terms );
-          return apply_filters( 'czr_meta_generate_tax_list', implode( apply_filters( 'tc_meta_terms_glue' , '' ) , $_terms_html_array ) , $post_terms );
+          $_terms_html_array  = array_map( array( $this , 'czr_fn_meta_term_view' ), $post_terms );
+          return apply_filters( 'czr_fn_meta_generate_tax_list', implode( apply_filters( 'tc_meta_terms_glue' , '' ) , $_terms_html_array ) , $post_terms );
         }
 
 
@@ -355,7 +355,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @package Customizr
         * @since Customizr 3.3.2
         */
-        private function czr_meta_term_view( $term ) {
+        private function czr_fn_meta_term_view( $term ) {
           $_classes         =  array( 'btn' , 'btn-mini' );
           $_is_hierarchical  =  is_taxonomy_hierarchical( $term -> taxonomy );
           if ( $_is_hierarchical ) //<= check if hierarchical (category) or not (tag)
@@ -371,7 +371,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
 
           $_to_return    = $_term_link ? '<a class="%1$s" href="%2$s" title="%3$s"> %4$s </a>' :  '<span class="%1$s"> %4$s </a>';
 
-          return apply_filters( 'czr_meta_term_view' , sprintf($_to_return,
+          return apply_filters( 'czr_fn_meta_term_view' , sprintf($_to_return,
               $_classes,
               $_term_link,
               esc_attr( sprintf( __( "View all posts in %s", 'customizr' ), $term -> name ) ),
@@ -391,9 +391,9 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @since Customizr 3.1.20
         *
         */
-        public function czr_get_term_of_tax_type( $hierarchical = true ) {
+        public function czr_fn_get_term_of_tax_type( $hierarchical = true ) {
           //var declaration
-          $post_type              = get_post_type( CZR_utils::czr_id() );
+          $post_type              = get_post_type( CZR_utils::czr_fn_id() );
           $tax_list               = get_object_taxonomies( $post_type, 'object' );
           $_tax_type_list         = array();
           $_tax_type_terms_list   = array();
@@ -416,7 +416,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
             $_tax_name = $_tax_object['name'];
 
             //skip the post format taxinomy
-            if ( ! $this -> czr_is_tax_authorized( $_tax_object, $post_type ) ) {
+            if ( ! $this -> czr_fn_is_tax_authorized( $_tax_object, $post_type ) ) {
               next($tax_list);
               continue;
             }
@@ -431,7 +431,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
 
           //fill the post terms array
           foreach ($_tax_type_list as $tax_name => $data ) {
-              $_current_tax_terms = get_the_terms( CZR_utils::czr_id() , $tax_name );
+              $_current_tax_terms = get_the_terms( CZR_utils::czr_fn_id() , $tax_name );
 
               //If current post support this tax but no terms has been assigned yet = continue
               if ( ! $_current_tax_terms )
@@ -459,13 +459,13 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @since Customizr 3.3+
         *
         */
-        public function czr_is_tax_authorized( $_tax_object , $post_type ) {
+        public function czr_fn_is_tax_authorized( $_tax_object , $post_type ) {
           $_in_exclude_list = in_array(
             $_tax_object['name'],
-            apply_filters_ref_array ( 'tc_exclude_taxonomies_from_metas' , array( array('post_format') , $post_type , CZR_utils::czr_id() ) )
+            apply_filters_ref_array ( 'tc_exclude_taxonomies_from_metas' , array( array('post_format') , $post_type , CZR_utils::czr_fn_id() ) )
           );
 
-          $_is_private = false === (bool) $_tax_object['public'] && apply_filters_ref_array( 'tc_exclude_private_taxonomies', array( true, $_tax_object['public'], CZR_utils::czr_id() ) );
+          $_is_private = false === (bool) $_tax_object['public'] && apply_filters_ref_array( 'tc_exclude_private_taxonomies', array( true, $_tax_object['public'], CZR_utils::czr_fn_id() ) );
           return ! $_in_exclude_list && ! $_is_private;
         }
 
@@ -477,7 +477,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @package Customizr
         * @since Customizr 3.2.6
         */
-        public function czr_get_meta_date( $pub_or_update = 'publication', $_format = '' ) {
+        public function czr_fn_get_meta_date( $pub_or_update = 'publication', $_format = '' ) {
             if ( 'short' == $_format )
               $_format = 'j M, Y';
 
@@ -504,7 +504,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @package Customizr
         * @since Customizr 3.2.6
         */
-        private function czr_get_meta_author() {
+        private function czr_fn_get_meta_author() {
             return apply_filters(
                 'tc_author_meta',
                 sprintf( '<span class="author vcard"><a class="url fn n" href="%1$s" title="%2$s" rel="author">%3$s</a></span>' ,
@@ -523,12 +523,12 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @package Customizr
         * @since Customizr 3.2.9
         */
-        function czr_add_link_to_post_after_metas( $_metas_html ) {
+        function czr_fn_add_link_to_post_after_metas( $_metas_html ) {
 
           if ( apply_filters( 'tc_show_link_after_post_metas' , true )
             && in_array( get_post_format(), apply_filters( 'tc_post_formats_with_no_heading', CZR_init::$instance -> post_formats_with_no_heading ) )
             && ! is_singular() ) {
-            return apply_filters('czr_add_link_to_post_after_metas',
+            return apply_filters('czr_fn_add_link_to_post_after_metas',
               sprintf('%1$s | <a href="%2$s" title="%3$s">%3$s &raquo;</a>', $_metas_html, get_permalink(), __('Open' , 'customizr') )
             );
           }
@@ -544,7 +544,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @package Customizr
         * @since Customizr 3.2.0
         */
-        function czr_hide_all_post_metas( $_classes ) {
+        function czr_fn_hide_all_post_metas( $_classes ) {
           return array_merge($_classes , array('hide-all-post-metas') );
         }
 
@@ -555,7 +555,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @package Customizr
         * @since Customizr 3.2.0
         */
-        function czr_hide_post_metas( $_classes ) {
+        function czr_fn_hide_post_metas( $_classes ) {
           return array_merge($_classes , array('hide-post-metas') );
         }
 
@@ -564,7 +564,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * hook : tc_meta_terms_glue
         * @return  string
         */
-        public function czr_set_term_meta_glue() {
+        public function czr_fn_set_term_meta_glue() {
           return ' / ';
         }
 
@@ -573,7 +573,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * hook : tc_post_tax_metas_html
         * @return  string
         */
-        function czr_set_tax_metas( $_html , $_tax = array() ) {
+        function czr_fn_set_tax_metas( $_html , $_tax = array() ) {
           if ( empty($_tax) )
             return $_html;
           //extract "_show_cats" , "_show_tags" , "cat_list", "tag_list"
@@ -588,17 +588,17 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * hook : tc_post_date_metas_html
         * @return  string
         */
-        function czr_set_date_metas( $_html, $_pubdate = '' ) {
+        function czr_fn_set_date_metas( $_html, $_pubdate = '' ) {
           if ( empty($_pubdate))
             return $_html;
-          return CZR_post_metas::$instance -> czr_get_meta_date( 'publication' , 'short' );
+          return CZR_post_metas::$instance -> czr_fn_get_meta_date( 'publication' , 'short' );
         }
 
         /**
         * hook : tc_post_author_metas_html
         * @return  string
         */
-        function czr_set_author_metas( $_html , $_auth = '' ) {
+        function czr_fn_set_author_metas( $_html , $_auth = '' ) {
           if ( empty($_auth) )
             return $_html;
 
@@ -609,7 +609,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * hook : tc_set_metas_content
         * @return  string
         */
-        function czr_set_metas( $_html, $_parts = array() ) {
+        function czr_fn_set_metas( $_html, $_parts = array() ) {
           if ( empty($_parts) )
             return $_html;
           //extract $_tax_text , $_date_text, $_author_text, $_update_text
@@ -620,6 +620,6 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
 endif;
 
 //the only purpose of this function is to use the_tags() wp function in the theme...
-function czr_get_the_tags() {
+function czr_fn_get_the_tags() {
     return the_tags();
 }

--- a/inc/parts/class-content-post_metas.php
+++ b/inc/parts/class-content-post_metas.php
@@ -11,8 +11,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_post_metas' ) ) :
-    class TC_post_metas {
+if ( ! class_exists( 'CZR_post_metas' ) ) :
+    class CZR_post_metas {
         static $instance;
         function __construct () {
           self::$instance =& $this;
@@ -39,8 +39,8 @@ if ( ! class_exists( 'TC_post_metas' ) ) :
         */
         function tc_set_visibility_options() {
           //if customizing context, always render. Will be hidden in the DOM with a body class filter is disabled.
-          if ( 0 == esc_attr( TC_utils::$inst->tc_opt( 'tc_show_post_metas' ) ) ) {
-            if ( TC___::$instance -> tc_is_customizing() )
+          if ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_post_metas' ) ) ) {
+            if ( CZR___::$instance -> tc_is_customizing() )
               add_filter( 'body_class' , array( $this , 'tc_hide_all_post_metas') );
             else{
               add_filter( 'tc_show_post_metas' , '__return_false' );
@@ -48,12 +48,12 @@ if ( ! class_exists( 'TC_post_metas' ) ) :
             }
           }
           if ( is_singular() && ! is_page() && ! tc__f('__is_home') ) {
-              if ( 0 != esc_attr( TC_utils::$inst->tc_opt( 'tc_show_post_metas_single_post' ) ) ) {
+              if ( 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_post_metas_single_post' ) ) ) {
                   add_filter( 'tc_show_post_metas' , '__return_true' );
                   return;
               }
 
-              if ( TC___::$instance -> tc_is_customizing() ) {
+              if ( CZR___::$instance -> tc_is_customizing() ) {
                   add_filter( 'body_class' , array( $this , 'tc_hide_post_metas') );
                   add_filter( 'tc_show_post_metas' , '__return_true' );
               }
@@ -62,12 +62,12 @@ if ( ! class_exists( 'TC_post_metas' ) ) :
               return;
           }
           if ( ! is_singular() && ! tc__f('__is_home') && ! is_page() ) {
-              if ( 0 != esc_attr( TC_utils::$inst->tc_opt( 'tc_show_post_metas_post_lists' ) ) ) {
+              if ( 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_post_metas_post_lists' ) ) ) {
                   add_filter( 'tc_show_post_metas' , '__return_true' );
                   return;
               }
 
-              if ( TC___::$instance -> tc_is_customizing() ) {
+              if ( CZR___::$instance -> tc_is_customizing() ) {
                   add_filter( 'body_class' , array( $this , 'tc_hide_post_metas') );
                   add_filter( 'tc_show_post_metas' , '__return_true' );
               }
@@ -76,11 +76,11 @@ if ( ! class_exists( 'TC_post_metas' ) ) :
               return;
           }
           if ( tc__f('__is_home') ) {
-              if ( 0 != esc_attr( TC_utils::$inst->tc_opt( 'tc_show_post_metas_home' ) ) ) {
+              if ( 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_post_metas_home' ) ) ) {
                   add_filter( 'tc_show_post_metas' , '__return_true' );
                   return;
               }
-              if ( TC___::$instance -> tc_is_customizing() ) {
+              if ( CZR___::$instance -> tc_is_customizing() ) {
                   add_filter( 'body_class' , array( $this , 'tc_hide_post_metas') );
                   add_filter( 'tc_show_post_metas' , '__return_true' );
               }
@@ -118,7 +118,7 @@ if ( ! class_exists( 'TC_post_metas' ) ) :
         * DESIGN HOOK SETUP
         ***********************/
         function tc_set_design_options() {
-          if ( 'buttons' == esc_attr( TC_utils::$inst->tc_opt( 'tc_post_metas_design' ) ) )
+          if ( 'buttons' == esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_metas_design' ) ) )
             return;
 
           add_filter( 'tc_meta_terms_glue'           , array( $this, 'tc_set_term_meta_glue' ) );
@@ -248,13 +248,13 @@ if ( ! class_exists( 'TC_post_metas' ) ) :
         * @since Customizr 3.2.6
         */
         function tc_set_post_metas_elements( $_default , $_args = array() ) {
-            $_show_cats         = 0 != esc_attr( TC_utils::$inst->tc_opt( 'tc_show_post_metas_categories' ) ) && false != $this -> tc_meta_generate_tax_list( true );
-            $_show_tags         = 0 != esc_attr( TC_utils::$inst->tc_opt( 'tc_show_post_metas_tags' ) ) && false != $this -> tc_meta_generate_tax_list( false );
-            $_show_pub_date     = 0 != esc_attr( TC_utils::$inst->tc_opt( 'tc_show_post_metas_publication_date' ) );
-            $_show_upd_date     = 0 != esc_attr( TC_utils::$inst->tc_opt( 'tc_show_post_metas_update_date' ) ) && false !== TC_utils::$inst -> tc_post_has_update();
-            $_show_upd_in_days  = 'days' == esc_attr( TC_utils::$inst->tc_opt( 'tc_post_metas_update_date_format' ) );
+            $_show_cats         = 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_post_metas_categories' ) ) && false != $this -> tc_meta_generate_tax_list( true );
+            $_show_tags         = 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_post_metas_tags' ) ) && false != $this -> tc_meta_generate_tax_list( false );
+            $_show_pub_date     = 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_post_metas_publication_date' ) );
+            $_show_upd_date     = 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_post_metas_update_date' ) ) && false !== CZR_utils::$inst -> tc_post_has_update();
+            $_show_upd_in_days  = 'days' == esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_metas_update_date_format' ) );
             $_show_date         = $_show_pub_date || $_show_upd_date;
-            $_show_author       = 0 != esc_attr( TC_utils::$inst->tc_opt( 'tc_show_post_metas_author' ) );
+            $_show_author       = 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_post_metas_author' ) );
 
             //extract cat_list, tag_list, pub_date, auth, upd_date from $args if not empty
             if ( empty($_args) )
@@ -308,7 +308,7 @@ if ( ! class_exists( 'TC_post_metas' ) ) :
             $_update_text = '';
             if ( $_show_upd_date ) {
               if ( $_show_upd_in_days ) {
-                $_update_days = TC_utils::$inst -> tc_post_has_update();
+                $_update_days = CZR_utils::$inst -> tc_post_has_update();
                 $_update_text = ( 0 == $_update_days ) ? __( '(updated today)' , 'customizr' ) : sprintf( __( '(updated %s days ago)' , 'customizr' ), $_update_days );
                 $_update_text = ( 1 == $_update_days ) ? __( '(updated 1 day ago)' , 'customizr' ) : $_update_text;
               }
@@ -393,7 +393,7 @@ if ( ! class_exists( 'TC_post_metas' ) ) :
         */
         public function tc_get_term_of_tax_type( $hierarchical = true ) {
           //var declaration
-          $post_type              = get_post_type( TC_utils::tc_id() );
+          $post_type              = get_post_type( CZR_utils::tc_id() );
           $tax_list               = get_object_taxonomies( $post_type, 'object' );
           $_tax_type_list         = array();
           $_tax_type_terms_list   = array();
@@ -431,7 +431,7 @@ if ( ! class_exists( 'TC_post_metas' ) ) :
 
           //fill the post terms array
           foreach ($_tax_type_list as $tax_name => $data ) {
-              $_current_tax_terms = get_the_terms( TC_utils::tc_id() , $tax_name );
+              $_current_tax_terms = get_the_terms( CZR_utils::tc_id() , $tax_name );
 
               //If current post support this tax but no terms has been assigned yet = continue
               if ( ! $_current_tax_terms )
@@ -462,10 +462,10 @@ if ( ! class_exists( 'TC_post_metas' ) ) :
         public function tc_is_tax_authorized( $_tax_object , $post_type ) {
           $_in_exclude_list = in_array(
             $_tax_object['name'],
-            apply_filters_ref_array ( 'tc_exclude_taxonomies_from_metas' , array( array('post_format') , $post_type , TC_utils::tc_id() ) )
+            apply_filters_ref_array ( 'tc_exclude_taxonomies_from_metas' , array( array('post_format') , $post_type , CZR_utils::tc_id() ) )
           );
 
-          $_is_private = false === (bool) $_tax_object['public'] && apply_filters_ref_array( 'tc_exclude_private_taxonomies', array( true, $_tax_object['public'], TC_utils::tc_id() ) );
+          $_is_private = false === (bool) $_tax_object['public'] && apply_filters_ref_array( 'tc_exclude_private_taxonomies', array( true, $_tax_object['public'], CZR_utils::tc_id() ) );
           return ! $_in_exclude_list && ! $_is_private;
         }
 
@@ -526,7 +526,7 @@ if ( ! class_exists( 'TC_post_metas' ) ) :
         function tc_add_link_to_post_after_metas( $_metas_html ) {
 
           if ( apply_filters( 'tc_show_link_after_post_metas' , true )
-            && in_array( get_post_format(), apply_filters( 'tc_post_formats_with_no_heading', TC_init::$instance -> post_formats_with_no_heading ) )
+            && in_array( get_post_format(), apply_filters( 'tc_post_formats_with_no_heading', CZR_init::$instance -> post_formats_with_no_heading ) )
             && ! is_singular() ) {
             return apply_filters('tc_add_link_to_post_after_metas',
               sprintf('%1$s | <a href="%2$s" title="%3$s">%3$s &raquo;</a>', $_metas_html, get_permalink(), __('Open' , 'customizr') )
@@ -591,7 +591,7 @@ if ( ! class_exists( 'TC_post_metas' ) ) :
         function tc_set_date_metas( $_html, $_pubdate = '' ) {
           if ( empty($_pubdate))
             return $_html;
-          return TC_post_metas::$instance -> tc_get_meta_date( 'publication' , 'short' );
+          return CZR_post_metas::$instance -> tc_get_meta_date( 'publication' , 'short' );
         }
 
         /**

--- a/inc/parts/class-content-post_metas.php
+++ b/inc/parts/class-content-post_metas.php
@@ -17,11 +17,11 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         function __construct () {
           self::$instance =& $this;
           //Show / hide metas based on customizer user options (@since 3.2.0)
-          add_action( 'template_redirect'                            , array( $this , 'tc_set_visibility_options' ) , 10 );
+          add_action( 'template_redirect'                            , array( $this , 'czr_set_visibility_options' ) , 10 );
            //Show / hide metas based on customizer user options (@since 3.2.0)
-          add_action( 'template_redirect'                            , array( $this , 'tc_set_design_options' ) , 20 );
+          add_action( 'template_redirect'                            , array( $this , 'czr_set_design_options' ) , 20 );
           //Show / hide metas based on customizer user options (@since 3.2.0)
-          add_action( '__after_content_title'         , array( $this , 'tc_set_post_metas_hooks' ), 20 );
+          add_action( '__after_content_title'         , array( $this , 'czr_set_post_metas_hooks' ), 20 );
 
         }
 
@@ -41,7 +41,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
           //if customizing context, always render. Will be hidden in the DOM with a body class filter is disabled.
           if ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_post_metas' ) ) ) {
             if ( CZR___::$instance -> czr_is_customizing() )
-              add_filter( 'body_class' , array( $this , 'tc_hide_all_post_metas') );
+              add_filter( 'body_class' , array( $this , 'czr_hide_all_post_metas') );
             else{
               add_filter( 'tc_show_post_metas' , '__return_false' );
               return;
@@ -54,7 +54,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
               }
 
               if ( CZR___::$instance -> czr_is_customizing() ) {
-                  add_filter( 'body_class' , array( $this , 'tc_hide_post_metas') );
+                  add_filter( 'body_class' , array( $this , 'czr_hide_post_metas') );
                   add_filter( 'tc_show_post_metas' , '__return_true' );
               }
               else
@@ -68,7 +68,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
               }
 
               if ( CZR___::$instance -> czr_is_customizing() ) {
-                  add_filter( 'body_class' , array( $this , 'tc_hide_post_metas') );
+                  add_filter( 'body_class' , array( $this , 'czr_hide_post_metas') );
                   add_filter( 'tc_show_post_metas' , '__return_true' );
               }
               else
@@ -81,7 +81,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
                   return;
               }
               if ( CZR___::$instance -> czr_is_customizing() ) {
-                  add_filter( 'body_class' , array( $this , 'tc_hide_post_metas') );
+                  add_filter( 'body_class' , array( $this , 'czr_hide_post_metas') );
                   add_filter( 'tc_show_post_metas' , '__return_true' );
               }
               else
@@ -121,13 +121,13 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
           if ( 'buttons' == esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_metas_design' ) ) )
             return;
 
-          add_filter( 'tc_meta_terms_glue'           , array( $this, 'tc_set_term_meta_glue' ) );
+          add_filter( 'tc_meta_terms_glue'           , array( $this, 'czr_set_term_meta_glue' ) );
           add_filter( 'tc_meta_tax_class'            , '__return_empty_array' );
 
-          add_filter( 'tc_post_tax_metas_html'       , array( $this, 'tc_set_tax_metas' ), 10, 2 );
-          add_filter( 'tc_post_date_metas_html'      , array( $this, 'tc_set_date_metas' ), 10, 2 );
-          add_filter( 'tc_post_author_metas_html'    , array( $this, 'tc_set_author_metas' ), 10 , 2 );
-          add_filter( 'tc_set_metas_content'         , array( $this, 'tc_set_metas' ), 10, 2 );
+          add_filter( 'tc_post_tax_metas_html'       , array( $this, 'czr_set_tax_metas' ), 10, 2 );
+          add_filter( 'tc_post_date_metas_html'      , array( $this, 'czr_set_date_metas' ), 10, 2 );
+          add_filter( 'tc_post_author_metas_html'    , array( $this, 'czr_set_author_metas' ), 10 , 2 );
+          add_filter( 'tc_set_metas_content'         , array( $this, 'czr_set_metas' ), 10, 2 );
         }
 
 
@@ -154,9 +154,9 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
           } else {
             $_model = $this -> czr_build_post_post_metas_model();
             //Set metas content based on customizer user options (@since 3.2.6)
-            add_filter( 'tc_meta_utility_text'      , array( $this , 'tc_set_post_metas_elements'), 10 , 2 );
+            add_filter( 'tc_meta_utility_text'      , array( $this , 'czr_set_post_metas_elements'), 10 , 2 );
             //filter metas content with default theme settings
-            add_filter( 'tc_meta_utility_text'      , array( $this , 'tc_add_link_to_post_after_metas'), 20 );
+            add_filter( 'tc_meta_utility_text'      , array( $this , 'czr_add_link_to_post_after_metas'), 20 );
           }
 
           //RENDER VIEW
@@ -342,8 +342,8 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
           if ( ! $post_terms )
             return;
 
-          $_terms_html_array  = array_map( array( $this , 'tc_meta_term_view' ), $post_terms );
-          return apply_filters( 'tc_meta_generate_tax_list', implode( apply_filters( 'tc_meta_terms_glue' , '' ) , $_terms_html_array ) , $post_terms );
+          $_terms_html_array  = array_map( array( $this , 'czr_meta_term_view' ), $post_terms );
+          return apply_filters( 'czr_meta_generate_tax_list', implode( apply_filters( 'tc_meta_terms_glue' , '' ) , $_terms_html_array ) , $post_terms );
         }
 
 
@@ -371,7 +371,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
 
           $_to_return    = $_term_link ? '<a class="%1$s" href="%2$s" title="%3$s"> %4$s </a>' :  '<span class="%1$s"> %4$s </a>';
 
-          return apply_filters( 'tc_meta_term_view' , sprintf($_to_return,
+          return apply_filters( 'czr_meta_term_view' , sprintf($_to_return,
               $_classes,
               $_term_link,
               esc_attr( sprintf( __( "View all posts in %s", 'customizr' ), $term -> name ) ),
@@ -528,7 +528,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
           if ( apply_filters( 'tc_show_link_after_post_metas' , true )
             && in_array( get_post_format(), apply_filters( 'tc_post_formats_with_no_heading', CZR_init::$instance -> post_formats_with_no_heading ) )
             && ! is_singular() ) {
-            return apply_filters('tc_add_link_to_post_after_metas',
+            return apply_filters('czr_add_link_to_post_after_metas',
               sprintf('%1$s | <a href="%2$s" title="%3$s">%3$s &raquo;</a>', $_metas_html, get_permalink(), __('Open' , 'customizr') )
             );
           }

--- a/inc/parts/class-content-post_metas.php
+++ b/inc/parts/class-content-post_metas.php
@@ -343,7 +343,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
             return;
 
           $_terms_html_array  = array_map( array( $this , 'czr_fn_meta_term_view' ), $post_terms );
-          return apply_filters( 'czr_fn_meta_generate_tax_list', implode( apply_filters( 'tc_meta_terms_glue' , '' ) , $_terms_html_array ) , $post_terms );
+          return apply_filters( 'tc_meta_generate_tax_list', implode( apply_filters( 'tc_meta_terms_glue' , '' ) , $_terms_html_array ) , $post_terms );
         }
 
 
@@ -371,7 +371,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
 
           $_to_return    = $_term_link ? '<a class="%1$s" href="%2$s" title="%3$s"> %4$s </a>' :  '<span class="%1$s"> %4$s </a>';
 
-          return apply_filters( 'czr_fn_meta_term_view' , sprintf($_to_return,
+          return apply_filters( 'tc_meta_term_view' , sprintf($_to_return,
               $_classes,
               $_term_link,
               esc_attr( sprintf( __( "View all posts in %s", 'customizr' ), $term -> name ) ),
@@ -528,7 +528,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
           if ( apply_filters( 'tc_show_link_after_post_metas' , true )
             && in_array( get_post_format(), apply_filters( 'tc_post_formats_with_no_heading', CZR_init::$instance -> post_formats_with_no_heading ) )
             && ! is_singular() ) {
-            return apply_filters('czr_fn_add_link_to_post_after_metas',
+            return apply_filters('tc_add_link_to_post_after_metas',
               sprintf('%1$s | <a href="%2$s" title="%3$s">%3$s &raquo;</a>', $_metas_html, get_permalink(), __('Open' , 'customizr') )
             );
           }

--- a/inc/parts/class-content-post_metas.php
+++ b/inc/parts/class-content-post_metas.php
@@ -39,21 +39,21 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         */
         function czr_set_visibility_options() {
           //if customizing context, always render. Will be hidden in the DOM with a body class filter is disabled.
-          if ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_post_metas' ) ) ) {
-            if ( CZR___::$instance -> tc_is_customizing() )
+          if ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_post_metas' ) ) ) {
+            if ( CZR___::$instance -> czr_is_customizing() )
               add_filter( 'body_class' , array( $this , 'tc_hide_all_post_metas') );
             else{
               add_filter( 'tc_show_post_metas' , '__return_false' );
               return;
             }
           }
-          if ( is_singular() && ! is_page() && ! tc__f('__is_home') ) {
-              if ( 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_post_metas_single_post' ) ) ) {
+          if ( is_singular() && ! is_page() && ! czr__f('__is_home') ) {
+              if ( 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_post_metas_single_post' ) ) ) {
                   add_filter( 'tc_show_post_metas' , '__return_true' );
                   return;
               }
 
-              if ( CZR___::$instance -> tc_is_customizing() ) {
+              if ( CZR___::$instance -> czr_is_customizing() ) {
                   add_filter( 'body_class' , array( $this , 'tc_hide_post_metas') );
                   add_filter( 'tc_show_post_metas' , '__return_true' );
               }
@@ -61,13 +61,13 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
                   add_filter( 'tc_show_post_metas' , '__return_false' );
               return;
           }
-          if ( ! is_singular() && ! tc__f('__is_home') && ! is_page() ) {
-              if ( 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_post_metas_post_lists' ) ) ) {
+          if ( ! is_singular() && ! czr__f('__is_home') && ! is_page() ) {
+              if ( 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_post_metas_post_lists' ) ) ) {
                   add_filter( 'tc_show_post_metas' , '__return_true' );
                   return;
               }
 
-              if ( CZR___::$instance -> tc_is_customizing() ) {
+              if ( CZR___::$instance -> czr_is_customizing() ) {
                   add_filter( 'body_class' , array( $this , 'tc_hide_post_metas') );
                   add_filter( 'tc_show_post_metas' , '__return_true' );
               }
@@ -75,12 +75,12 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
                   add_filter( 'tc_show_post_metas' , '__return_false' );
               return;
           }
-          if ( tc__f('__is_home') ) {
-              if ( 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_post_metas_home' ) ) ) {
+          if ( czr__f('__is_home') ) {
+              if ( 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_post_metas_home' ) ) ) {
                   add_filter( 'tc_show_post_metas' , '__return_true' );
                   return;
               }
-              if ( CZR___::$instance -> tc_is_customizing() ) {
+              if ( CZR___::$instance -> czr_is_customizing() ) {
                   add_filter( 'body_class' , array( $this , 'tc_hide_post_metas') );
                   add_filter( 'tc_show_post_metas' , '__return_true' );
               }
@@ -93,7 +93,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
 
         /**
         * Default metas visibility controller
-        * tc_show_post_metas gets filtered by tc_set_visibility_options() called early in template_redirect
+        * tc_show_post_metas gets filtered by czr_set_visibility_options() called early in template_redirect
         * @return  boolean
         * @package Customizr
         * @since Customizr 3.2.6
@@ -105,7 +105,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
           //2) +filter conditions
           return apply_filters(
               'tc_show_post_metas',
-              ! tc__f('__is_home')
+              ! czr__f('__is_home')
               && ! is_404()
               && ! 'page' == $post -> post_type
               && in_array( get_post_type(), apply_filters('tc_show_metas_for_post_types' , array( 'post') ) )
@@ -118,7 +118,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * DESIGN HOOK SETUP
         ***********************/
         function czr_set_design_options() {
-          if ( 'buttons' == esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_metas_design' ) ) )
+          if ( 'buttons' == esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_metas_design' ) ) )
             return;
 
           add_filter( 'tc_meta_terms_glue'           , array( $this, 'tc_set_term_meta_glue' ) );
@@ -143,16 +143,16 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @since Customizr 3.2.2
         */
         function czr_set_post_metas_hooks() {
-          if ( ! $this -> tc_show_post_metas() )
+          if ( ! $this -> czr_show_post_metas() )
             return;
           global $post;
           $_model = array();
           //BUILD MODEL
           //Two cases : attachment and not attachment
           if ( 'attachment' == $post -> post_type ) {
-            $_model = $this -> tc_build_attachment_post_metas_model();
+            $_model = $this -> czr_build_attachment_post_metas_model();
           } else {
-            $_model = $this -> tc_build_post_post_metas_model();
+            $_model = $this -> czr_build_post_post_metas_model();
             //Set metas content based on customizer user options (@since 3.2.6)
             add_filter( 'tc_meta_utility_text'      , array( $this , 'tc_set_post_metas_elements'), 10 , 2 );
             //filter metas content with default theme settings
@@ -160,7 +160,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
           }
 
           //RENDER VIEW
-          $this -> tc_render_metas_view( $_model );
+          $this -> czr_render_metas_view( $_model );
         }
 
 
@@ -172,11 +172,11 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @since Customizr 3.2.6
         */
         private function czr_build_post_post_metas_model() {
-          $cat_list   = $this -> tc_meta_generate_tax_list( true );
-          $tag_list   = $this -> tc_meta_generate_tax_list( false );
-          $pub_date   = $this -> tc_get_meta_date( 'publication' );
-          $auth       = $this -> tc_get_meta_author();
-          $upd_date   = $this -> tc_get_meta_date( 'update' );
+          $cat_list   = $this -> czr_meta_generate_tax_list( true );
+          $tag_list   = $this -> czr_meta_generate_tax_list( false );
+          $pub_date   = $this -> czr_get_meta_date( 'publication' );
+          $auth       = $this -> czr_get_meta_author();
+          $upd_date   = $this -> czr_get_meta_date( 'update' );
 
           $_args      = compact( 'cat_list' ,'tag_list', 'pub_date', 'auth', 'upd_date' );
           $_html      = sprintf( __( 'This entry was posted on %1$s<span class="by-author"> by %2$s</span>.' , 'customizr' ),
@@ -248,13 +248,13 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @since Customizr 3.2.6
         */
         function czr_set_post_metas_elements( $_default , $_args = array() ) {
-            $_show_cats         = 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_post_metas_categories' ) ) && false != $this -> tc_meta_generate_tax_list( true );
-            $_show_tags         = 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_post_metas_tags' ) ) && false != $this -> tc_meta_generate_tax_list( false );
-            $_show_pub_date     = 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_post_metas_publication_date' ) );
-            $_show_upd_date     = 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_post_metas_update_date' ) ) && false !== CZR_utils::$inst -> tc_post_has_update();
-            $_show_upd_in_days  = 'days' == esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_metas_update_date_format' ) );
+            $_show_cats         = 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_post_metas_categories' ) ) && false != $this -> czr_meta_generate_tax_list( true );
+            $_show_tags         = 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_post_metas_tags' ) ) && false != $this -> czr_meta_generate_tax_list( false );
+            $_show_pub_date     = 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_post_metas_publication_date' ) );
+            $_show_upd_date     = 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_post_metas_update_date' ) ) && false !== CZR_utils::$inst -> czr_post_has_update();
+            $_show_upd_in_days  = 'days' == esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_metas_update_date_format' ) );
             $_show_date         = $_show_pub_date || $_show_upd_date;
-            $_show_author       = 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_post_metas_author' ) );
+            $_show_author       = 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_post_metas_author' ) );
 
             //extract cat_list, tag_list, pub_date, auth, upd_date from $args if not empty
             if ( empty($_args) )
@@ -308,7 +308,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
             $_update_text = '';
             if ( $_show_upd_date ) {
               if ( $_show_upd_in_days ) {
-                $_update_days = CZR_utils::$inst -> tc_post_has_update();
+                $_update_days = CZR_utils::$inst -> czr_post_has_update();
                 $_update_text = ( 0 == $_update_days ) ? __( '(updated today)' , 'customizr' ) : sprintf( __( '(updated %s days ago)' , 'customizr' ), $_update_days );
                 $_update_text = ( 1 == $_update_days ) ? __( '(updated 1 day ago)' , 'customizr' ) : $_update_text;
               }
@@ -338,7 +338,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @since Customizr 3.0
         */
         public function czr_meta_generate_tax_list( $hierarchical ) {
-          $post_terms = $this -> tc_get_term_of_tax_type( $hierarchical );
+          $post_terms = $this -> czr_get_term_of_tax_type( $hierarchical );
           if ( ! $post_terms )
             return;
 
@@ -393,7 +393,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         */
         public function czr_get_term_of_tax_type( $hierarchical = true ) {
           //var declaration
-          $post_type              = get_post_type( CZR_utils::tc_id() );
+          $post_type              = get_post_type( CZR_utils::czr_id() );
           $tax_list               = get_object_taxonomies( $post_type, 'object' );
           $_tax_type_list         = array();
           $_tax_type_terms_list   = array();
@@ -416,7 +416,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
             $_tax_name = $_tax_object['name'];
 
             //skip the post format taxinomy
-            if ( ! $this -> tc_is_tax_authorized( $_tax_object, $post_type ) ) {
+            if ( ! $this -> czr_is_tax_authorized( $_tax_object, $post_type ) ) {
               next($tax_list);
               continue;
             }
@@ -431,7 +431,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
 
           //fill the post terms array
           foreach ($_tax_type_list as $tax_name => $data ) {
-              $_current_tax_terms = get_the_terms( CZR_utils::tc_id() , $tax_name );
+              $_current_tax_terms = get_the_terms( CZR_utils::czr_id() , $tax_name );
 
               //If current post support this tax but no terms has been assigned yet = continue
               if ( ! $_current_tax_terms )
@@ -462,10 +462,10 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         public function czr_is_tax_authorized( $_tax_object , $post_type ) {
           $_in_exclude_list = in_array(
             $_tax_object['name'],
-            apply_filters_ref_array ( 'tc_exclude_taxonomies_from_metas' , array( array('post_format') , $post_type , CZR_utils::tc_id() ) )
+            apply_filters_ref_array ( 'tc_exclude_taxonomies_from_metas' , array( array('post_format') , $post_type , CZR_utils::czr_id() ) )
           );
 
-          $_is_private = false === (bool) $_tax_object['public'] && apply_filters_ref_array( 'tc_exclude_private_taxonomies', array( true, $_tax_object['public'], CZR_utils::tc_id() ) );
+          $_is_private = false === (bool) $_tax_object['public'] && apply_filters_ref_array( 'tc_exclude_private_taxonomies', array( true, $_tax_object['public'], CZR_utils::czr_id() ) );
           return ! $_in_exclude_list && ! $_is_private;
         }
 
@@ -591,7 +591,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         function czr_set_date_metas( $_html, $_pubdate = '' ) {
           if ( empty($_pubdate))
             return $_html;
-          return CZR_post_metas::$instance -> tc_get_meta_date( 'publication' , 'short' );
+          return CZR_post_metas::$instance -> czr_get_meta_date( 'publication' , 'short' );
         }
 
         /**

--- a/inc/parts/class-content-post_metas.php
+++ b/inc/parts/class-content-post_metas.php
@@ -37,7 +37,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @package Customizr
         * @since Customizr 3.2.0
         */
-        function tc_set_visibility_options() {
+        function czr_set_visibility_options() {
           //if customizing context, always render. Will be hidden in the DOM with a body class filter is disabled.
           if ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_post_metas' ) ) ) {
             if ( CZR___::$instance -> tc_is_customizing() )
@@ -98,7 +98,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @package Customizr
         * @since Customizr 3.2.6
         */
-        private function tc_show_post_metas() {
+        private function czr_show_post_metas() {
           global $post;
           //when do we display the metas ?
           //1) default is : not on home page, 404, search page
@@ -117,7 +117,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         /***********************
         * DESIGN HOOK SETUP
         ***********************/
-        function tc_set_design_options() {
+        function czr_set_design_options() {
           if ( 'buttons' == esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_metas_design' ) ) )
             return;
 
@@ -142,7 +142,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @package Customizr
         * @since Customizr 3.2.2
         */
-        function tc_set_post_metas_hooks() {
+        function czr_set_post_metas_hooks() {
           if ( ! $this -> tc_show_post_metas() )
             return;
           global $post;
@@ -171,7 +171,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @package Customizr
         * @since Customizr 3.2.6
         */
-        private function tc_build_post_post_metas_model() {
+        private function czr_build_post_post_metas_model() {
           $cat_list   = $this -> tc_meta_generate_tax_list( true );
           $tag_list   = $this -> tc_meta_generate_tax_list( false );
           $pub_date   = $this -> tc_get_meta_date( 'publication' );
@@ -194,7 +194,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @package Customizr
         * @since Customizr 3.3.2
         */
-        private function tc_build_attachment_post_metas_model() {
+        private function czr_build_attachment_post_metas_model() {
           global $post;
           $metadata       = wp_get_attachment_metadata();
           $_html = sprintf( '%1$s <span class="entry-date"><time class="entry-date updated" datetime="%2$s">%3$s</time></span> %4$s %5$s',
@@ -218,7 +218,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @package Customizr
         * @since Customizr 3.3.2
         */
-        private function tc_render_metas_view( $_model ) {
+        private function czr_render_metas_view( $_model ) {
           if ( empty($_model) )
             return;
           //extract $_html , $_args
@@ -247,7 +247,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @package Customizr
         * @since Customizr 3.2.6
         */
-        function tc_set_post_metas_elements( $_default , $_args = array() ) {
+        function czr_set_post_metas_elements( $_default , $_args = array() ) {
             $_show_cats         = 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_post_metas_categories' ) ) && false != $this -> tc_meta_generate_tax_list( true );
             $_show_tags         = 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_post_metas_tags' ) ) && false != $this -> tc_meta_generate_tax_list( false );
             $_show_pub_date     = 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_post_metas_publication_date' ) );
@@ -337,7 +337,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @package Customizr
         * @since Customizr 3.0
         */
-        public function tc_meta_generate_tax_list( $hierarchical ) {
+        public function czr_meta_generate_tax_list( $hierarchical ) {
           $post_terms = $this -> tc_get_term_of_tax_type( $hierarchical );
           if ( ! $post_terms )
             return;
@@ -355,7 +355,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @package Customizr
         * @since Customizr 3.3.2
         */
-        private function tc_meta_term_view( $term ) {
+        private function czr_meta_term_view( $term ) {
           $_classes         =  array( 'btn' , 'btn-mini' );
           $_is_hierarchical  =  is_taxonomy_hierarchical( $term -> taxonomy );
           if ( $_is_hierarchical ) //<= check if hierarchical (category) or not (tag)
@@ -391,7 +391,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @since Customizr 3.1.20
         *
         */
-        public function tc_get_term_of_tax_type( $hierarchical = true ) {
+        public function czr_get_term_of_tax_type( $hierarchical = true ) {
           //var declaration
           $post_type              = get_post_type( CZR_utils::tc_id() );
           $tax_list               = get_object_taxonomies( $post_type, 'object' );
@@ -459,7 +459,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @since Customizr 3.3+
         *
         */
-        public function tc_is_tax_authorized( $_tax_object , $post_type ) {
+        public function czr_is_tax_authorized( $_tax_object , $post_type ) {
           $_in_exclude_list = in_array(
             $_tax_object['name'],
             apply_filters_ref_array ( 'tc_exclude_taxonomies_from_metas' , array( array('post_format') , $post_type , CZR_utils::tc_id() ) )
@@ -477,7 +477,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @package Customizr
         * @since Customizr 3.2.6
         */
-        public function tc_get_meta_date( $pub_or_update = 'publication', $_format = '' ) {
+        public function czr_get_meta_date( $pub_or_update = 'publication', $_format = '' ) {
             if ( 'short' == $_format )
               $_format = 'j M, Y';
 
@@ -504,7 +504,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @package Customizr
         * @since Customizr 3.2.6
         */
-        private function tc_get_meta_author() {
+        private function czr_get_meta_author() {
             return apply_filters(
                 'tc_author_meta',
                 sprintf( '<span class="author vcard"><a class="url fn n" href="%1$s" title="%2$s" rel="author">%3$s</a></span>' ,
@@ -523,7 +523,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @package Customizr
         * @since Customizr 3.2.9
         */
-        function tc_add_link_to_post_after_metas( $_metas_html ) {
+        function czr_add_link_to_post_after_metas( $_metas_html ) {
 
           if ( apply_filters( 'tc_show_link_after_post_metas' , true )
             && in_array( get_post_format(), apply_filters( 'tc_post_formats_with_no_heading', CZR_init::$instance -> post_formats_with_no_heading ) )
@@ -544,7 +544,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @package Customizr
         * @since Customizr 3.2.0
         */
-        function tc_hide_all_post_metas( $_classes ) {
+        function czr_hide_all_post_metas( $_classes ) {
           return array_merge($_classes , array('hide-all-post-metas') );
         }
 
@@ -555,7 +555,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * @package Customizr
         * @since Customizr 3.2.0
         */
-        function tc_hide_post_metas( $_classes ) {
+        function czr_hide_post_metas( $_classes ) {
           return array_merge($_classes , array('hide-post-metas') );
         }
 
@@ -564,7 +564,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * hook : tc_meta_terms_glue
         * @return  string
         */
-        public function tc_set_term_meta_glue() {
+        public function czr_set_term_meta_glue() {
           return ' / ';
         }
 
@@ -573,7 +573,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * hook : tc_post_tax_metas_html
         * @return  string
         */
-        function tc_set_tax_metas( $_html , $_tax = array() ) {
+        function czr_set_tax_metas( $_html , $_tax = array() ) {
           if ( empty($_tax) )
             return $_html;
           //extract "_show_cats" , "_show_tags" , "cat_list", "tag_list"
@@ -588,7 +588,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * hook : tc_post_date_metas_html
         * @return  string
         */
-        function tc_set_date_metas( $_html, $_pubdate = '' ) {
+        function czr_set_date_metas( $_html, $_pubdate = '' ) {
           if ( empty($_pubdate))
             return $_html;
           return CZR_post_metas::$instance -> tc_get_meta_date( 'publication' , 'short' );
@@ -598,7 +598,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * hook : tc_post_author_metas_html
         * @return  string
         */
-        function tc_set_author_metas( $_html , $_auth = '' ) {
+        function czr_set_author_metas( $_html , $_auth = '' ) {
           if ( empty($_auth) )
             return $_html;
 
@@ -609,7 +609,7 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
         * hook : tc_set_metas_content
         * @return  string
         */
-        function tc_set_metas( $_html, $_parts = array() ) {
+        function czr_set_metas( $_html, $_parts = array() ) {
           if ( empty($_parts) )
             return $_html;
           //extract $_tax_text , $_date_text, $_author_text, $_update_text
@@ -620,6 +620,6 @@ if ( ! class_exists( 'CZR_post_metas' ) ) :
 endif;
 
 //the only purpose of this function is to use the_tags() wp function in the theme...
-function tc_get_the_tags() {
+function czr_get_the_tags() {
     return the_tags();
 }

--- a/inc/parts/class-content-post_navigation.php
+++ b/inc/parts/class-content-post_navigation.php
@@ -33,7 +33,7 @@ if ( ! class_exists( 'CZR_post_navigation' ) ) :
       * @package Customizr
       * @since Customizr 3.3.22
       */
-      function tc_set_visibility_options(){
+      function czr_set_visibility_options(){
 
         $_nav_classes              = array('navigation');
         $_context                  = $this -> tc_get_context();
@@ -64,7 +64,7 @@ if ( ! class_exists( 'CZR_post_navigation' ) ) :
        * @package Customizr
        * @since Customizr 3.0
        */
-      function tc_post_nav() {
+      function czr_post_nav() {
 
         list( $post_navigation_bool, $post_nav_class, $_context) = $this -> tc_set_visibility_options();
 
@@ -208,7 +208,7 @@ if ( ! class_exists( 'CZR_post_navigation' ) ) :
       * @return string or bool
       *
       */
-      function tc_get_context(){
+      function czr_get_context(){
         if ( is_page() )
           return 'page';
         if ( is_single() && ! is_attachment() )
@@ -226,14 +226,14 @@ if ( ! class_exists( 'CZR_post_navigation' ) ) :
       * @param (string or bool) the context
       * @return bool
       */
-      function tc_is_post_navigation_context_enabled( $_context ) {
+      function czr_is_post_navigation_context_enabled( $_context ) {
         return $_context && 1 == esc_attr( CZR_utils::$inst -> tc_opt( "tc_show_post_navigation_{$_context}" ) );
       }
 
       /*
       * @return bool
       */
-      function tc_is_post_navigation_enabled(){
+      function czr_is_post_navigation_enabled(){
         return 1 == esc_attr( CZR_utils::$inst -> tc_opt( 'tc_show_post_navigation' ) ) ;
       }
 

--- a/inc/parts/class-content-post_navigation.php
+++ b/inc/parts/class-content-post_navigation.php
@@ -18,7 +18,7 @@ if ( ! class_exists( 'CZR_post_navigation' ) ) :
       function __construct () {
         self::$instance =& $this;
 
-        add_action ( '__after_loop'             , array( $this , 'tc_post_nav' ), 20 );
+        add_action ( '__after_loop'             , array( $this , 'czr_post_nav' ), 20 );
 
       }
 
@@ -195,7 +195,7 @@ if ( ! class_exists( 'CZR_post_navigation' ) ) :
         <?php
         $html = ob_get_contents();
         if ($html) ob_end_clean();
-        echo apply_filters( 'tc_post_nav' , $html );
+        echo apply_filters( 'czr_post_nav' , $html );
       }
 
 

--- a/inc/parts/class-content-post_navigation.php
+++ b/inc/parts/class-content-post_navigation.php
@@ -36,11 +36,11 @@ if ( ! class_exists( 'CZR_post_navigation' ) ) :
       function czr_set_visibility_options(){
 
         $_nav_classes              = array('navigation');
-        $_context                  = $this -> tc_get_context();
-        $_post_nav_enabled         = $this -> tc_is_post_navigation_enabled();
-        $_post_nav_context_enabled = $this -> tc_is_post_navigation_context_enabled( $_context );
+        $_context                  = $this -> czr_get_context();
+        $_post_nav_enabled         = $this -> czr_is_post_navigation_enabled();
+        $_post_nav_context_enabled = $this -> czr_is_post_navigation_context_enabled( $_context );
 
-        $_is_customizing           = CZR___::$instance -> tc_is_customizing() ;
+        $_is_customizing           = CZR___::$instance -> czr_is_customizing() ;
 
         if ( $_is_customizing ){
           if ( ! $_post_nav_enabled )
@@ -66,7 +66,7 @@ if ( ! class_exists( 'CZR_post_navigation' ) ) :
        */
       function czr_post_nav() {
 
-        list( $post_navigation_bool, $post_nav_class, $_context) = $this -> tc_set_visibility_options();
+        list( $post_navigation_bool, $post_nav_class, $_context) = $this -> czr_set_visibility_options();
 
         if( ! $post_navigation_bool )
           return;
@@ -215,7 +215,7 @@ if ( ! class_exists( 'CZR_post_navigation' ) ) :
           return 'single'; // exclude attachments
         if ( is_home() && 'posts' == get_option('show_on_front') )
           return 'home';
-        if ( !is_404() && !tc__f( '__is_home_empty') )
+        if ( !is_404() && !czr__f( '__is_home_empty') )
           return 'archive';
 
         return false;
@@ -227,14 +227,14 @@ if ( ! class_exists( 'CZR_post_navigation' ) ) :
       * @return bool
       */
       function czr_is_post_navigation_context_enabled( $_context ) {
-        return $_context && 1 == esc_attr( CZR_utils::$inst -> tc_opt( "tc_show_post_navigation_{$_context}" ) );
+        return $_context && 1 == esc_attr( CZR_utils::$inst -> czr_opt( "tc_show_post_navigation_{$_context}" ) );
       }
 
       /*
       * @return bool
       */
       function czr_is_post_navigation_enabled(){
-        return 1 == esc_attr( CZR_utils::$inst -> tc_opt( 'tc_show_post_navigation' ) ) ;
+        return 1 == esc_attr( CZR_utils::$inst -> czr_opt( 'tc_show_post_navigation' ) ) ;
       }
 
   }//end of class

--- a/inc/parts/class-content-post_navigation.php
+++ b/inc/parts/class-content-post_navigation.php
@@ -18,7 +18,7 @@ if ( ! class_exists( 'CZR_post_navigation' ) ) :
       function __construct () {
         self::$instance =& $this;
 
-        add_action ( '__after_loop'             , array( $this , 'czr_post_nav' ), 20 );
+        add_action ( '__after_loop'             , array( $this , 'czr_fn_post_nav' ), 20 );
 
       }
 
@@ -33,14 +33,14 @@ if ( ! class_exists( 'CZR_post_navigation' ) ) :
       * @package Customizr
       * @since Customizr 3.3.22
       */
-      function czr_set_visibility_options(){
+      function czr_fn_set_visibility_options(){
 
         $_nav_classes              = array('navigation');
-        $_context                  = $this -> czr_get_context();
-        $_post_nav_enabled         = $this -> czr_is_post_navigation_enabled();
-        $_post_nav_context_enabled = $this -> czr_is_post_navigation_context_enabled( $_context );
+        $_context                  = $this -> czr_fn_get_context();
+        $_post_nav_enabled         = $this -> czr_fn_is_post_navigation_enabled();
+        $_post_nav_context_enabled = $this -> czr_fn_is_post_navigation_context_enabled( $_context );
 
-        $_is_customizing           = CZR___::$instance -> czr_is_customizing() ;
+        $_is_customizing           = CZR___::$instance -> czr_fn_is_customizing() ;
 
         if ( $_is_customizing ){
           if ( ! $_post_nav_enabled )
@@ -64,9 +64,9 @@ if ( ! class_exists( 'CZR_post_navigation' ) ) :
        * @package Customizr
        * @since Customizr 3.0
        */
-      function czr_post_nav() {
+      function czr_fn_post_nav() {
 
-        list( $post_navigation_bool, $post_nav_class, $_context) = $this -> czr_set_visibility_options();
+        list( $post_navigation_bool, $post_nav_class, $_context) = $this -> czr_fn_set_visibility_options();
 
         if( ! $post_navigation_bool )
           return;
@@ -195,7 +195,7 @@ if ( ! class_exists( 'CZR_post_navigation' ) ) :
         <?php
         $html = ob_get_contents();
         if ($html) ob_end_clean();
-        echo apply_filters( 'czr_post_nav' , $html );
+        echo apply_filters( 'czr_fn_post_nav' , $html );
       }
 
 
@@ -208,14 +208,14 @@ if ( ! class_exists( 'CZR_post_navigation' ) ) :
       * @return string or bool
       *
       */
-      function czr_get_context(){
+      function czr_fn_get_context(){
         if ( is_page() )
           return 'page';
         if ( is_single() && ! is_attachment() )
           return 'single'; // exclude attachments
         if ( is_home() && 'posts' == get_option('show_on_front') )
           return 'home';
-        if ( !is_404() && !czr__f( '__is_home_empty') )
+        if ( !is_404() && !czr_fn__f( '__is_home_empty') )
           return 'archive';
 
         return false;
@@ -226,15 +226,15 @@ if ( ! class_exists( 'CZR_post_navigation' ) ) :
       * @param (string or bool) the context
       * @return bool
       */
-      function czr_is_post_navigation_context_enabled( $_context ) {
-        return $_context && 1 == esc_attr( CZR_utils::$inst -> czr_opt( "tc_show_post_navigation_{$_context}" ) );
+      function czr_fn_is_post_navigation_context_enabled( $_context ) {
+        return $_context && 1 == esc_attr( CZR_utils::$inst -> czr_fn_opt( "tc_show_post_navigation_{$_context}" ) );
       }
 
       /*
       * @return bool
       */
-      function czr_is_post_navigation_enabled(){
-        return 1 == esc_attr( CZR_utils::$inst -> czr_opt( 'tc_show_post_navigation' ) ) ;
+      function czr_fn_is_post_navigation_enabled(){
+        return 1 == esc_attr( CZR_utils::$inst -> czr_fn_opt( 'tc_show_post_navigation' ) ) ;
       }
 
   }//end of class

--- a/inc/parts/class-content-post_navigation.php
+++ b/inc/parts/class-content-post_navigation.php
@@ -195,7 +195,7 @@ if ( ! class_exists( 'CZR_post_navigation' ) ) :
         <?php
         $html = ob_get_contents();
         if ($html) ob_end_clean();
-        echo apply_filters( 'czr_fn_post_nav' , $html );
+        echo apply_filters( 'tc_post_nav' , $html );
       }
 
 

--- a/inc/parts/class-content-post_navigation.php
+++ b/inc/parts/class-content-post_navigation.php
@@ -11,8 +11,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_post_navigation' ) ) :
-  class TC_post_navigation {
+if ( ! class_exists( 'CZR_post_navigation' ) ) :
+  class CZR_post_navigation {
       static  $instance;
 
       function __construct () {
@@ -40,7 +40,7 @@ if ( ! class_exists( 'TC_post_navigation' ) ) :
         $_post_nav_enabled         = $this -> tc_is_post_navigation_enabled();
         $_post_nav_context_enabled = $this -> tc_is_post_navigation_context_enabled( $_context );
 
-        $_is_customizing           = TC___::$instance -> tc_is_customizing() ;
+        $_is_customizing           = CZR___::$instance -> tc_is_customizing() ;
 
         if ( $_is_customizing ){
           if ( ! $_post_nav_enabled )
@@ -227,14 +227,14 @@ if ( ! class_exists( 'TC_post_navigation' ) ) :
       * @return bool
       */
       function tc_is_post_navigation_context_enabled( $_context ) {
-        return $_context && 1 == esc_attr( TC_utils::$inst -> tc_opt( "tc_show_post_navigation_{$_context}" ) );
+        return $_context && 1 == esc_attr( CZR_utils::$inst -> tc_opt( "tc_show_post_navigation_{$_context}" ) );
       }
 
       /*
       * @return bool
       */
       function tc_is_post_navigation_enabled(){
-        return 1 == esc_attr( TC_utils::$inst -> tc_opt( 'tc_show_post_navigation' ) ) ;
+        return 1 == esc_attr( CZR_utils::$inst -> tc_opt( 'tc_show_post_navigation' ) ) ;
       }
 
   }//end of class

--- a/inc/parts/class-content-post_thumbnails.php
+++ b/inc/parts/class-content-post_thumbnails.php
@@ -17,7 +17,7 @@ class CZR_post_thumbnails {
     function __construct () {
       self::$instance =& $this;
       //may be filter the thumbnail inline style
-      add_filter( 'tc_post_thumb_inline_style'  , array( $this , 'tc_change_thumb_inline_css' ), 10, 3 );
+      add_filter( 'tc_post_thumb_inline_style'  , array( $this , 'czr_change_thumb_inline_css' ), 10, 3 );
     }
 
 
@@ -86,7 +86,7 @@ class CZR_post_thumbnails {
         //to avoid this we filter the attributes getting rid of the srcset if any.
         //Basically this trick, even if ugly, will avoid the srcset attr computation
         $_img_attr['srcset']  = " ";
-        add_filter( 'wp_get_attachment_image_attributes', array( $this, 'tc_remove_srcset_attr' ) );
+        add_filter( 'wp_get_attachment_image_attributes', array( $this, 'czr_remove_srcset_attr' ) );
       }
       //get the thumb html
       if ( is_null($_custom_thumb_id) && has_post_thumbnail( $_post_id ) )
@@ -104,7 +104,7 @@ class CZR_post_thumbnails {
       //used for smart load when enabled
       $tc_thumb = apply_filters( 'tc_thumb_html', $tc_thumb, $requested_size, $_post_id, $_custom_thumb_id );
 
-      return apply_filters( 'tc_get_thumbnail_model',
+      return apply_filters( 'czr_get_thumbnail_model',
         isset($tc_thumb) && ! empty($tc_thumb) && false != $tc_thumb ? compact( "tc_thumb" , "tc_thumb_height" , "tc_thumb_width" ) : array(),
         $_post_id,
         $_thumb_id,
@@ -188,7 +188,7 @@ class CZR_post_thumbnails {
       //update_post_meta($post_id, $meta_key, $meta_value, $prev_value);
       update_post_meta( $post_id , 'tc-thumb-fld', compact( "_thumb_id" , "_thumb_type" ) );
       if ( $_return )
-        return apply_filters( 'tc_set_thumb_info' , compact( "_thumb_id" , "_thumb_type" ), $post_id );
+        return apply_filters( 'czr_set_thumb_info' , compact( "_thumb_id" , "_thumb_type" ), $post_id );
     }//end of fn
 
 
@@ -270,7 +270,7 @@ class CZR_post_thumbnails {
         apply_filters( 'tc_post_thumb_class', $layout ),
         $thumb_wrapper
       );
-      $html = apply_filters_ref_array( 'tc_render_thumb_view', array( $html, $_thumb_model, $layout ) );
+      $html = apply_filters_ref_array( 'czr_render_thumb_view', array( $html, $_thumb_model, $layout ) );
       if ( ! $_echo )
         return $html;
       echo $html;

--- a/inc/parts/class-content-post_thumbnails.php
+++ b/inc/parts/class-content-post_thumbnails.php
@@ -104,7 +104,7 @@ class CZR_post_thumbnails {
       //used for smart load when enabled
       $tc_thumb = apply_filters( 'tc_thumb_html', $tc_thumb, $requested_size, $_post_id, $_custom_thumb_id );
 
-      return apply_filters( 'czr_fn_get_thumbnail_model',
+      return apply_filters( 'tc_get_thumbnail_model',
         isset($tc_thumb) && ! empty($tc_thumb) && false != $tc_thumb ? compact( "tc_thumb" , "tc_thumb_height" , "tc_thumb_width" ) : array(),
         $_post_id,
         $_thumb_id,
@@ -188,7 +188,7 @@ class CZR_post_thumbnails {
       //update_post_meta($post_id, $meta_key, $meta_value, $prev_value);
       update_post_meta( $post_id , 'tc-thumb-fld', compact( "_thumb_id" , "_thumb_type" ) );
       if ( $_return )
-        return apply_filters( 'czr_fn_set_thumb_info' , compact( "_thumb_id" , "_thumb_type" ), $post_id );
+        return apply_filters( 'tc_set_thumb_info' , compact( "_thumb_id" , "_thumb_type" ), $post_id );
     }//end of fn
 
 
@@ -270,7 +270,7 @@ class CZR_post_thumbnails {
         apply_filters( 'tc_post_thumb_class', $layout ),
         $thumb_wrapper
       );
-      $html = apply_filters_ref_array( 'czr_fn_render_thumb_view', array( $html, $_thumb_model, $layout ) );
+      $html = apply_filters_ref_array( 'tc_render_thumb_view', array( $html, $_thumb_model, $layout ) );
       if ( ! $_echo )
         return $html;
       echo $html;

--- a/inc/parts/class-content-post_thumbnails.php
+++ b/inc/parts/class-content-post_thumbnails.php
@@ -33,7 +33,7 @@ class CZR_post_thumbnails {
     * @package Customizr
     * @since Customizr 1.0
     */
-    function tc_get_thumbnail_model( $requested_size = null, $_post_id = null , $_custom_thumb_id = null, $_enable_wp_responsive_imgs = null ) {
+    function czr_get_thumbnail_model( $requested_size = null, $_post_id = null , $_custom_thumb_id = null, $_enable_wp_responsive_imgs = null ) {
       if ( ! $this -> tc_has_thumb( $_post_id, $_custom_thumb_id ) )
         return array();
 
@@ -118,7 +118,7 @@ class CZR_post_thumbnails {
     * inside loop
     * @return array( "_thumb_id" , "_thumb_type" )
     */
-    private function tc_get_thumb_info( $_post_id = null, $_thumb_id = null ) {
+    private function czr_get_thumb_info( $_post_id = null, $_thumb_id = null ) {
       $_post_id     = is_null($_post_id) ? get_the_ID() : $_post_id;
       $_meta_thumb  = get_post_meta( $_post_id , 'tc-thumb-fld', true );
       //get_post_meta( $post_id, $key, $single );
@@ -144,7 +144,7 @@ class CZR_post_thumbnails {
     /*
     * @return bool
     */
-    public function tc_has_thumb( $_post_id = null , $_thumb_id = null ) {
+    public function czr_has_thumb( $_post_id = null , $_thumb_id = null ) {
       $_post_id  = is_null($_post_id) ? get_the_ID() : $_post_id;
       //try to extract (OVERWRITE) $_thumb_id and $_thumb_type
       extract( $this -> tc_get_thumb_info( $_post_id, $_thumb_id ) );
@@ -158,7 +158,7 @@ class CZR_post_thumbnails {
     * @param post_id and (bool) return
     * @return void or array( "_thumb_id" , "_thumb_type" )
     */
-    public function tc_set_thumb_info( $post_id = null , $_thumb_id = null, $_return = false ) {
+    public function czr_set_thumb_info( $post_id = null , $_thumb_id = null, $_return = false ) {
       $post_id      = is_null($post_id) ? get_the_ID() : $post_id;
       $_thumb_type  = 'none';
 
@@ -192,7 +192,7 @@ class CZR_post_thumbnails {
     }//end of fn
 
 
-    private function tc_get_id_from_attachment( $post_id ) {
+    private function czr_get_id_from_attachment( $post_id ) {
       //define a filtrable boolean to set if attached images can be used as thumbnails
       //1) must be a non single post context
       //2) user option should be checked in customizer
@@ -239,7 +239,7 @@ class CZR_post_thumbnails {
     * @package Customizr
     * @since Customizr 3.0.10
     */
-    function tc_render_thumb_view( $_thumb_model , $layout = 'span3', $_echo = true ) {
+    function czr_render_thumb_view( $_thumb_model , $layout = 'span3', $_echo = true ) {
       if ( empty( $_thumb_model ) )
         return;
       //extract "tc_thumb" , "tc_thumb_height" , "tc_thumb_width"
@@ -288,7 +288,7 @@ class CZR_post_thumbnails {
     * @package Customizr
     * @since Customizr 3.4.16
     */
-    function tc_remove_srcset_attr( $attr ) {
+    function czr_remove_srcset_attr( $attr ) {
       if ( isset( $attr[ 'srcset' ] ) ) {
         unset( $attr['srcset'] );
         //to ensure a "local" removal we have to remove this filter callback, so it won't hurt
@@ -310,7 +310,7 @@ class CZR_post_thumbnails {
     * @package Customizr
     * @since Customizr 3.2.6
     */
-    function tc_change_thumb_inline_css( $_style, $image, $_filtered_thumb_size) {
+    function czr_change_thumb_inline_css( $_style, $image, $_filtered_thumb_size) {
       //conditions :
       //note : handled with javascript if tc_center_img option enabled
       $_bool = array_product(

--- a/inc/parts/class-content-post_thumbnails.php
+++ b/inc/parts/class-content-post_thumbnails.php
@@ -34,7 +34,7 @@ class CZR_post_thumbnails {
     * @since Customizr 1.0
     */
     function czr_get_thumbnail_model( $requested_size = null, $_post_id = null , $_custom_thumb_id = null, $_enable_wp_responsive_imgs = null ) {
-      if ( ! $this -> tc_has_thumb( $_post_id, $_custom_thumb_id ) )
+      if ( ! $this -> czr_has_thumb( $_post_id, $_custom_thumb_id ) )
         return array();
 
       $tc_thumb_size              = is_null($requested_size) ? apply_filters( 'tc_thumb_size_name' , 'tc-thumb' ) : $requested_size;
@@ -49,10 +49,10 @@ class CZR_post_thumbnails {
       //because this method is also called from the slider of posts which refers to the slider responsive image setting
       //limit this just for wp version >= 4.4
       if ( version_compare( $GLOBALS['wp_version'], '4.4', '>=' ) )
-        $_enable_wp_responsive_imgs = is_null( $_enable_wp_responsive_imgs ) ? 1 == CZR_utils::$inst->tc_opt('tc_resp_thumbs_img') : $_enable_wp_responsive_imgs;
+        $_enable_wp_responsive_imgs = is_null( $_enable_wp_responsive_imgs ) ? 1 == CZR_utils::$inst->czr_opt('tc_resp_thumbs_img') : $_enable_wp_responsive_imgs;
 
       //try to extract $_thumb_id and $_thumb_type
-      extract( $this -> tc_get_thumb_info( $_post_id, $_custom_thumb_id ) );
+      extract( $this -> czr_get_thumb_info( $_post_id, $_custom_thumb_id ) );
       if ( ! isset($_thumb_id) || ! $_thumb_id || is_null($_thumb_id) )
         return array();
 
@@ -135,7 +135,7 @@ class CZR_post_thumbnails {
       if ( ! $_refresh_bool )
         return $_meta_thumb;
 
-      return $this -> tc_set_thumb_info( $_post_id , $_thumb_id, true );
+      return $this -> czr_set_thumb_info( $_post_id , $_thumb_id, true );
     }
 
     /**************************
@@ -147,7 +147,7 @@ class CZR_post_thumbnails {
     public function czr_has_thumb( $_post_id = null , $_thumb_id = null ) {
       $_post_id  = is_null($_post_id) ? get_the_ID() : $_post_id;
       //try to extract (OVERWRITE) $_thumb_id and $_thumb_type
-      extract( $this -> tc_get_thumb_info( $_post_id, $_thumb_id ) );
+      extract( $this -> czr_get_thumb_info( $_post_id, $_thumb_id ) );
       return wp_attachment_is_image($_thumb_id) && isset($_thumb_id) && false != $_thumb_id && ! empty($_thumb_id);
     }
 
@@ -175,11 +175,11 @@ class CZR_post_thumbnails {
           $_thumb_id    = get_post_thumbnail_id( $post_id );
           $_thumb_type  = false !== $_thumb_id ? 'thumb' : $_thumb_type;
         } else {
-          $_thumb_id    = $this -> tc_get_id_from_attachment( $post_id );
+          $_thumb_id    = $this -> czr_get_id_from_attachment( $post_id );
           $_thumb_type  = false !== $_thumb_id ? 'attachment' : $_thumb_type;
         }
         if ( ! $_thumb_id || empty( $_thumb_id ) ) {
-          $_thumb_id    = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_default_thumb' ) );
+          $_thumb_id    = esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_default_thumb' ) );
           $_thumb_type  = ( false !== $_thumb_id && ! empty($_thumb_id) ) ? 'default' : $_thumb_type;
         }
       }
@@ -196,9 +196,9 @@ class CZR_post_thumbnails {
       //define a filtrable boolean to set if attached images can be used as thumbnails
       //1) must be a non single post context
       //2) user option should be checked in customizer
-      $_bool = 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_use_attachment_as_thumb' ) );
+      $_bool = 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_post_list_use_attachment_as_thumb' ) );
       if ( ! is_admin() )
-        $_bool == ! CZR_post::$instance -> tc_single_post_display_controller() && $_bool;
+        $_bool == ! CZR_post::$instance -> czr_single_post_display_controller() && $_bool;
       if ( ! apply_filters( 'tc_use_attachement_as_thumb' , $_bool ) )
         return;
 
@@ -245,14 +245,14 @@ class CZR_post_thumbnails {
       //extract "tc_thumb" , "tc_thumb_height" , "tc_thumb_width"
       extract( $_thumb_model );
       $thumb_img        = ! isset( $_thumb_model) ? false : $tc_thumb;
-      $thumb_img        = apply_filters( 'tc_post_thumb_img', $thumb_img, CZR_utils::tc_id() );
+      $thumb_img        = apply_filters( 'tc_post_thumb_img', $thumb_img, CZR_utils::czr_id() );
       if ( ! $thumb_img )
         return;
 
       //handles the case when the image dimensions are too small
-      $thumb_size       = apply_filters( 'tc_thumb_size' , CZR_init::$instance -> tc_thumb_size, CZR_utils::tc_id()  );
+      $thumb_size       = apply_filters( 'tc_thumb_size' , CZR_init::$instance -> tc_thumb_size, CZR_utils::czr_id()  );
       $no_effect_class  = ( isset($tc_thumb) && isset($tc_thumb_height) && ( $tc_thumb_height < $thumb_size['height']) ) ? 'no-effect' : '';
-      $no_effect_class  = ( esc_attr( CZR_utils::$inst->tc_opt( 'tc_center_img') ) || ! isset($tc_thumb) || empty($tc_thumb_height) || empty($tc_thumb_width) ) ? '' : $no_effect_class;
+      $no_effect_class  = ( esc_attr( CZR_utils::$inst->czr_opt( 'tc_center_img') ) || ! isset($tc_thumb) || empty($tc_thumb_height) || empty($tc_thumb_width) ) ? '' : $no_effect_class;
 
       //default hover effect
       $thumb_wrapper    = sprintf('<div class="%5$s %1$s"><div class="round-div"></div><a class="round-div %1$s" href="%2$s" title="%3$s"></a>%4$s</div>',
@@ -263,7 +263,7 @@ class CZR_post_thumbnails {
                                     implode( " ", apply_filters( 'tc_thumb_wrapper_class', array('thumb-wrapper') ) )
       );
 
-      $thumb_wrapper    = apply_filters_ref_array( 'tc_post_thumb_wrapper', array( $thumb_wrapper, $thumb_img, CZR_utils::tc_id() ) );
+      $thumb_wrapper    = apply_filters_ref_array( 'tc_post_thumb_wrapper', array( $thumb_wrapper, $thumb_img, CZR_utils::czr_id() ) );
 
       //cache the thumbnail view
       $html             = sprintf('<section class="tc-thumbnail %1$s">%2$s</section>',
@@ -315,7 +315,7 @@ class CZR_post_thumbnails {
       //note : handled with javascript if tc_center_img option enabled
       $_bool = array_product(
         array(
-          ! esc_attr( CZR_utils::$inst->tc_opt( 'tc_center_img') ),
+          ! esc_attr( CZR_utils::$inst->czr_opt( 'tc_center_img') ),
           false != $image,
           ! empty($image),
           isset($_filtered_thumb_size['width']),

--- a/inc/parts/class-content-post_thumbnails.php
+++ b/inc/parts/class-content-post_thumbnails.php
@@ -11,8 +11,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_post_thumbnails' ) ) :
-class TC_post_thumbnails {
+if ( ! class_exists( 'CZR_post_thumbnails' ) ) :
+class CZR_post_thumbnails {
     static $instance;
     function __construct () {
       self::$instance =& $this;
@@ -39,18 +39,18 @@ class TC_post_thumbnails {
 
       $tc_thumb_size              = is_null($requested_size) ? apply_filters( 'tc_thumb_size_name' , 'tc-thumb' ) : $requested_size;
       $_post_id                   = is_null($_post_id) ? get_the_ID() : $_post_id;
-      $_filtered_thumb_size       = apply_filters( 'tc_thumb_size' , TC_init::$instance -> tc_thumb_size );
+      $_filtered_thumb_size       = apply_filters( 'tc_thumb_size' , CZR_init::$instance -> tc_thumb_size );
       $_model                     = array();
       $_img_attr                  = array();
       $tc_thumb_height            = '';
       $tc_thumb_width             = '';
-      
+
       //when null set it as the image setting for reponsive thumbnails (default)
       //because this method is also called from the slider of posts which refers to the slider responsive image setting
       //limit this just for wp version >= 4.4
       if ( version_compare( $GLOBALS['wp_version'], '4.4', '>=' ) )
-        $_enable_wp_responsive_imgs = is_null( $_enable_wp_responsive_imgs ) ? 1 == TC_utils::$inst->tc_opt('tc_resp_thumbs_img') : $_enable_wp_responsive_imgs;
-      
+        $_enable_wp_responsive_imgs = is_null( $_enable_wp_responsive_imgs ) ? 1 == CZR_utils::$inst->tc_opt('tc_resp_thumbs_img') : $_enable_wp_responsive_imgs;
+
       //try to extract $_thumb_id and $_thumb_type
       extract( $this -> tc_get_thumb_info( $_post_id, $_custom_thumb_id ) );
       if ( ! isset($_thumb_id) || ! $_thumb_id || is_null($_thumb_id) )
@@ -73,7 +73,7 @@ class TC_post_thumbnails {
       if ( $_style )
         $_img_attr['style']   = $_style;
       $_img_attr              = apply_filters( 'tc_post_thumbnail_img_attributes' , $_img_attr );
- 
+
       //we might not want responsive images
       if ( false === $_enable_wp_responsive_imgs ) {
         //trick, will produce an empty attr srcset as in wp-includes/media.php the srcset is calculated and added
@@ -82,12 +82,12 @@ class TC_post_thumbnails {
         // or
         //b) use preg_replace to get rid of srcset and sizes attributes from the generated html
         //Side effect:
-        //we'll see an empty ( or " " depending on the browser ) srcset attribute in the html 
+        //we'll see an empty ( or " " depending on the browser ) srcset attribute in the html
         //to avoid this we filter the attributes getting rid of the srcset if any.
         //Basically this trick, even if ugly, will avoid the srcset attr computation
         $_img_attr['srcset']  = " ";
         add_filter( 'wp_get_attachment_image_attributes', array( $this, 'tc_remove_srcset_attr' ) );
-      }  
+      }
       //get the thumb html
       if ( is_null($_custom_thumb_id) && has_post_thumbnail( $_post_id ) )
         //get_the_post_thumbnail( $post_id, $size, $attr )
@@ -179,7 +179,7 @@ class TC_post_thumbnails {
           $_thumb_type  = false !== $_thumb_id ? 'attachment' : $_thumb_type;
         }
         if ( ! $_thumb_id || empty( $_thumb_id ) ) {
-          $_thumb_id    = esc_attr( TC_utils::$inst->tc_opt( 'tc_post_list_default_thumb' ) );
+          $_thumb_id    = esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_default_thumb' ) );
           $_thumb_type  = ( false !== $_thumb_id && ! empty($_thumb_id) ) ? 'default' : $_thumb_type;
         }
       }
@@ -196,9 +196,9 @@ class TC_post_thumbnails {
       //define a filtrable boolean to set if attached images can be used as thumbnails
       //1) must be a non single post context
       //2) user option should be checked in customizer
-      $_bool = 0 != esc_attr( TC_utils::$inst->tc_opt( 'tc_post_list_use_attachment_as_thumb' ) );
+      $_bool = 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_post_list_use_attachment_as_thumb' ) );
       if ( ! is_admin() )
-        $_bool == ! TC_post::$instance -> tc_single_post_display_controller() && $_bool;
+        $_bool == ! CZR_post::$instance -> tc_single_post_display_controller() && $_bool;
       if ( ! apply_filters( 'tc_use_attachement_as_thumb' , $_bool ) )
         return;
 
@@ -245,14 +245,14 @@ class TC_post_thumbnails {
       //extract "tc_thumb" , "tc_thumb_height" , "tc_thumb_width"
       extract( $_thumb_model );
       $thumb_img        = ! isset( $_thumb_model) ? false : $tc_thumb;
-      $thumb_img        = apply_filters( 'tc_post_thumb_img', $thumb_img, TC_utils::tc_id() );
+      $thumb_img        = apply_filters( 'tc_post_thumb_img', $thumb_img, CZR_utils::tc_id() );
       if ( ! $thumb_img )
         return;
 
       //handles the case when the image dimensions are too small
-      $thumb_size       = apply_filters( 'tc_thumb_size' , TC_init::$instance -> tc_thumb_size, TC_utils::tc_id()  );
+      $thumb_size       = apply_filters( 'tc_thumb_size' , CZR_init::$instance -> tc_thumb_size, CZR_utils::tc_id()  );
       $no_effect_class  = ( isset($tc_thumb) && isset($tc_thumb_height) && ( $tc_thumb_height < $thumb_size['height']) ) ? 'no-effect' : '';
-      $no_effect_class  = ( esc_attr( TC_utils::$inst->tc_opt( 'tc_center_img') ) || ! isset($tc_thumb) || empty($tc_thumb_height) || empty($tc_thumb_width) ) ? '' : $no_effect_class;
+      $no_effect_class  = ( esc_attr( CZR_utils::$inst->tc_opt( 'tc_center_img') ) || ! isset($tc_thumb) || empty($tc_thumb_height) || empty($tc_thumb_width) ) ? '' : $no_effect_class;
 
       //default hover effect
       $thumb_wrapper    = sprintf('<div class="%5$s %1$s"><div class="round-div"></div><a class="round-div %1$s" href="%2$s" title="%3$s"></a>%4$s</div>',
@@ -263,7 +263,7 @@ class TC_post_thumbnails {
                                     implode( " ", apply_filters( 'tc_thumb_wrapper_class', array('thumb-wrapper') ) )
       );
 
-      $thumb_wrapper    = apply_filters_ref_array( 'tc_post_thumb_wrapper', array( $thumb_wrapper, $thumb_img, TC_utils::tc_id() ) );
+      $thumb_wrapper    = apply_filters_ref_array( 'tc_post_thumb_wrapper', array( $thumb_wrapper, $thumb_img, CZR_utils::tc_id() ) );
 
       //cache the thumbnail view
       $html             = sprintf('<section class="tc-thumbnail %1$s">%2$s</section>',
@@ -291,11 +291,11 @@ class TC_post_thumbnails {
     function tc_remove_srcset_attr( $attr ) {
       if ( isset( $attr[ 'srcset' ] ) ) {
         unset( $attr['srcset'] );
-        //to ensure a "local" removal we have to remove this filter callback, so it won't hurt 
+        //to ensure a "local" removal we have to remove this filter callback, so it won't hurt
         //responsive images sitewide
         remove_filter( current_filter(), array( $this, __FUNCTION__ ) );
       }
-      return $attr;    
+      return $attr;
     }
 
     /**********************
@@ -315,7 +315,7 @@ class TC_post_thumbnails {
       //note : handled with javascript if tc_center_img option enabled
       $_bool = array_product(
         array(
-          ! esc_attr( TC_utils::$inst->tc_opt( 'tc_center_img') ),
+          ! esc_attr( CZR_utils::$inst->tc_opt( 'tc_center_img') ),
           false != $image,
           ! empty($image),
           isset($_filtered_thumb_size['width']),

--- a/inc/parts/class-content-sidebar.php
+++ b/inc/parts/class-content-sidebar.php
@@ -20,7 +20,7 @@ if ( ! class_exists( 'CZR_sidebar' ) ) :
       static $instance;
       function __construct () {
         self::$instance =& $this;
-        add_action ( 'wp'       , array( $this , 'tc_set_sidebar_hooks' ) );
+        add_action ( 'wp'       , array( $this , 'czr_set_sidebar_hooks' ) );
       }
 
 
@@ -35,16 +35,16 @@ if ( ! class_exists( 'CZR_sidebar' ) ) :
       */
       function czr_set_sidebar_hooks() {
         //displays left sidebar
-    		add_action ( '__before_article_container'  , array( $this , 'tc_sidebar_display' ) );
-    		add_action ( '__before_left_sidebar'       , array( $this , 'tc_social_in_sidebar' ) );
+    		add_action ( '__before_article_container'  , array( $this , 'czr_sidebar_display' ) );
+    		add_action ( '__before_left_sidebar'       , array( $this , 'czr_social_in_sidebar' ) );
 
         //displays right sidebar
-    		add_action ( '__after_article_container'   , array( $this , 'tc_sidebar_display' ) );
-    		add_action ( '__before_right_sidebar'      , array( $this , 'tc_social_in_sidebar' ) );
+    		add_action ( '__after_article_container'   , array( $this , 'czr_sidebar_display' ) );
+    		add_action ( '__before_right_sidebar'      , array( $this , 'czr_social_in_sidebar' ) );
 
         //since 3.2.0 show/hide the WP built-in widget icons
-        add_filter ( 'tc_left_sidebar_class'       , array( $this , 'tc_set_sidebar_wrapper_widget_class' ) );
-        add_filter ( 'tc_right_sidebar_class'      , array( $this , 'tc_set_sidebar_wrapper_widget_class' ) );
+        add_filter ( 'tc_left_sidebar_class'       , array( $this , 'czr_set_sidebar_wrapper_widget_class' ) );
+        add_filter ( 'tc_right_sidebar_class'      , array( $this , 'czr_set_sidebar_wrapper_widget_class' ) );
       }
 
 
@@ -107,7 +107,7 @@ if ( ! class_exists( 'CZR_sidebar' ) ) :
         <?php
         $html = ob_get_contents();
         if ($html) ob_end_clean();
-        echo apply_filters( 'tc_sidebar_display', $html, $sidebar_layout, $position );
+        echo apply_filters( 'czr_sidebar_display', $html, $sidebar_layout, $position );
       }//end of function
 
 
@@ -185,7 +185,7 @@ if ( ! class_exists( 'CZR_sidebar' ) ) :
             ! $_title ? '' : apply_filters( 'tc_sidebar_socials_title' , sprintf( '<h3 class="widget-title">%1$s</h3>', $_title ) ),
             czr__f( '__get_socials' )
         );
-        echo apply_filters( 'tc_social_in_sidebar', $html, current_filter() );
+        echo apply_filters( 'czr_social_in_sidebar', $html, current_filter() );
       }
 
 

--- a/inc/parts/class-content-sidebar.php
+++ b/inc/parts/class-content-sidebar.php
@@ -1,9 +1,9 @@
 <?php
 /**
 * Sidebar actions
-* The default widgets areas are defined as properties of the TC_utils class in class-fire-utils.php
-* TC_utils::$inst -> sidebar_widgets for left and right sidebars
-* TC_utils::$inst -> footer_widgets for the footer
+* The default widgets areas are defined as properties of the CZR_utils class in class-fire-utils.php
+* CZR_utils::$inst -> sidebar_widgets for left and right sidebars
+* CZR_utils::$inst -> footer_widgets for the footer
 * The widget area are then fired in class-fire-widgets.php
 * You can modify those default widgets with 3 filters : tc_default_widgets, tc_footer_widgets, tc_sidebar_widgets
 *
@@ -15,8 +15,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_sidebar' ) ) :
-  class TC_sidebar {
+if ( ! class_exists( 'CZR_sidebar' ) ) :
+  class CZR_sidebar {
       static $instance;
       function __construct () {
         self::$instance =& $this;
@@ -65,7 +65,7 @@ if ( ! class_exists( 'TC_sidebar' ) ) :
         if ( tc__f( '__is_home_empty') )
           return;
         //gets current screen layout
-        $screen_layout        = TC_utils::tc_get_layout( TC_utils::tc_id() , 'sidebar'  );
+        $screen_layout        = CZR_utils::tc_get_layout( CZR_utils::tc_id() , 'sidebar'  );
 		    // GY: add relative right and left for LTR/RTL sites
         $rel_left             = is_rtl() ? 'right' : 'left';
         $rel_right            = is_rtl() ? 'left' : 'right';
@@ -81,7 +81,7 @@ if ( ! class_exists( 'TC_sidebar' ) ) :
           return;
 
         //gets the global layout settings
-        $global_layout        = apply_filters( 'tc_global_layout' , TC_init::$instance -> global_layout );
+        $global_layout        = apply_filters( 'tc_global_layout' , CZR_init::$instance -> global_layout );
         $sidebar_layout       = $global_layout[$screen_layout];
 
         //defines the sidebar wrapper class
@@ -122,7 +122,7 @@ if ( ! class_exists( 'TC_sidebar' ) ) :
       * @since Customizr 3.3
       */
       private function tc_display_sidebar_placeholder( $position ) {
-        if ( ! TC_placeholders::tc_is_widget_placeholder_enabled( 'sidebar' ) )
+        if ( ! CZR_placeholders::tc_is_widget_placeholder_enabled( 'sidebar' ) )
           return;
         ?>
         <aside class="tc-placeholder-wrap tc-widget-placeholder">
@@ -137,7 +137,7 @@ if ( ! class_exists( 'TC_sidebar' ) ) :
 
             printf('<p><strong>%1$s</strong></p>',
               sprintf( __("Add widgets to this sidebar %s or %s.", "customizr"),
-                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', TC_utils::tc_get_customizer_url( array( 'panel' => 'widgets') ), __( "Add widgets", "customizr"), __("now", "customizr") ),
+                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', CZR_utils::tc_get_customizer_url( array( 'panel' => 'widgets') ), __( "Add widgets", "customizr"), __("now", "customizr") ),
                 sprintf('<a class="tc-inline-dismiss-notice" data-position="sidebar" href="#" title="%1$s">%1$s</a>',
                   __( 'dismiss this notice', 'customizr')
                 )
@@ -175,10 +175,10 @@ if ( ! class_exists( 'TC_sidebar' ) ) :
         //when do we display these blocks ?
         //1) if customizing always. (is hidden if empty of disabled)
         //2) if not customizing : must be enabled and have social networks set.
-        $_nothing_to_render = ( 0 == esc_attr( TC_utils::$inst->tc_opt( $option) ) ) || ! tc__f( '__get_socials' );
-        if ( ! TC___::$instance -> tc_is_customizing() && $_nothing_to_render )
+        $_nothing_to_render = ( 0 == esc_attr( CZR_utils::$inst->tc_opt( $option) ) ) || ! tc__f( '__get_socials' );
+        if ( ! CZR___::$instance -> tc_is_customizing() && $_nothing_to_render )
             return;
-        $_title = esc_attr( TC_utils::$inst->tc_opt( 'tc_social_in_sidebar_title') );
+        $_title = esc_attr( CZR_utils::$inst->tc_opt( 'tc_social_in_sidebar_title') );
         $html = sprintf('<aside class="%1$s" %2$s>%3$s%4$s</aside>',
             implode( " " , apply_filters( 'tc_sidebar_block_social_class' , array('social-block', 'widget', 'widget_social') ) ),
             $_nothing_to_render ? 'style="display:none"' : '',
@@ -201,8 +201,8 @@ if ( ! class_exists( 'TC_sidebar' ) ) :
       function tc_set_sidebar_wrapper_widget_class($_original_classes) {
         $_no_icons_classes = array_merge($_original_classes, array('no-widget-icons'));
 
-        if ( 1 == esc_attr( TC_utils::$inst->tc_opt('tc_show_sidebar_widget_icon' ) ) )
-          return ( 0 == esc_attr( TC_utils::$inst->tc_opt('tc_show_title_icon' ) ) ) ? $_no_icons_classes : $_original_classes;
+        if ( 1 == esc_attr( CZR_utils::$inst->tc_opt('tc_show_sidebar_widget_icon' ) ) )
+          return ( 0 == esc_attr( CZR_utils::$inst->tc_opt('tc_show_title_icon' ) ) ) ? $_no_icons_classes : $_original_classes;
          //last condition
         return $_no_icons_classes;
       }

--- a/inc/parts/class-content-sidebar.php
+++ b/inc/parts/class-content-sidebar.php
@@ -107,7 +107,7 @@ if ( ! class_exists( 'CZR_sidebar' ) ) :
         <?php
         $html = ob_get_contents();
         if ($html) ob_end_clean();
-        echo apply_filters( 'czr_fn_sidebar_display', $html, $sidebar_layout, $position );
+        echo apply_filters( 'tc_sidebar_display', $html, $sidebar_layout, $position );
       }//end of function
 
 
@@ -185,7 +185,7 @@ if ( ! class_exists( 'CZR_sidebar' ) ) :
             ! $_title ? '' : apply_filters( 'tc_sidebar_socials_title' , sprintf( '<h3 class="widget-title">%1$s</h3>', $_title ) ),
             czr_fn__f( '__get_socials' )
         );
-        echo apply_filters( 'czr_fn_social_in_sidebar', $html, current_filter() );
+        echo apply_filters( 'tc_social_in_sidebar', $html, current_filter() );
       }
 
 

--- a/inc/parts/class-content-sidebar.php
+++ b/inc/parts/class-content-sidebar.php
@@ -62,10 +62,10 @@ if ( ! class_exists( 'CZR_sidebar' ) ) :
       */
       function czr_sidebar_display() {
         //first check if home and no content option is choosen
-        if ( tc__f( '__is_home_empty') )
+        if ( czr__f( '__is_home_empty') )
           return;
         //gets current screen layout
-        $screen_layout        = CZR_utils::tc_get_layout( CZR_utils::tc_id() , 'sidebar'  );
+        $screen_layout        = CZR_utils::czr_get_layout( CZR_utils::czr_id() , 'sidebar'  );
 		    // GY: add relative right and left for LTR/RTL sites
         $rel_left             = is_rtl() ? 'right' : 'left';
         $rel_right            = is_rtl() ? 'left' : 'right';
@@ -97,7 +97,7 @@ if ( ! class_exists( 'CZR_sidebar' ) ) :
                 if ( is_active_sidebar( $position ) )
                   get_sidebar( $position );
                 else
-                  $this -> tc_display_sidebar_placeholder($position);
+                  $this -> czr_display_sidebar_placeholder($position);
 
                 do_action( "__after_{$position}_sidebar" );
               ?>
@@ -122,7 +122,7 @@ if ( ! class_exists( 'CZR_sidebar' ) ) :
       * @since Customizr 3.3
       */
       private function czr_display_sidebar_placeholder( $position ) {
-        if ( ! CZR_placeholders::tc_is_widget_placeholder_enabled( 'sidebar' ) )
+        if ( ! CZR_placeholders::czr_is_widget_placeholder_enabled( 'sidebar' ) )
           return;
         ?>
         <aside class="tc-placeholder-wrap tc-widget-placeholder">
@@ -137,7 +137,7 @@ if ( ! class_exists( 'CZR_sidebar' ) ) :
 
             printf('<p><strong>%1$s</strong></p>',
               sprintf( __("Add widgets to this sidebar %s or %s.", "customizr"),
-                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', CZR_utils::tc_get_customizer_url( array( 'panel' => 'widgets') ), __( "Add widgets", "customizr"), __("now", "customizr") ),
+                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', CZR_utils::czr_get_customizer_url( array( 'panel' => 'widgets') ), __( "Add widgets", "customizr"), __("now", "customizr") ),
                 sprintf('<a class="tc-inline-dismiss-notice" data-position="sidebar" href="#" title="%1$s">%1$s</a>',
                   __( 'dismiss this notice', 'customizr')
                 )
@@ -175,15 +175,15 @@ if ( ! class_exists( 'CZR_sidebar' ) ) :
         //when do we display these blocks ?
         //1) if customizing always. (is hidden if empty of disabled)
         //2) if not customizing : must be enabled and have social networks set.
-        $_nothing_to_render = ( 0 == esc_attr( CZR_utils::$inst->tc_opt( $option) ) ) || ! tc__f( '__get_socials' );
-        if ( ! CZR___::$instance -> tc_is_customizing() && $_nothing_to_render )
+        $_nothing_to_render = ( 0 == esc_attr( CZR_utils::$inst->czr_opt( $option) ) ) || ! czr__f( '__get_socials' );
+        if ( ! CZR___::$instance -> czr_is_customizing() && $_nothing_to_render )
             return;
-        $_title = esc_attr( CZR_utils::$inst->tc_opt( 'tc_social_in_sidebar_title') );
+        $_title = esc_attr( CZR_utils::$inst->czr_opt( 'tc_social_in_sidebar_title') );
         $html = sprintf('<aside class="%1$s" %2$s>%3$s%4$s</aside>',
             implode( " " , apply_filters( 'tc_sidebar_block_social_class' , array('social-block', 'widget', 'widget_social') ) ),
             $_nothing_to_render ? 'style="display:none"' : '',
             ! $_title ? '' : apply_filters( 'tc_sidebar_socials_title' , sprintf( '<h3 class="widget-title">%1$s</h3>', $_title ) ),
-            tc__f( '__get_socials' )
+            czr__f( '__get_socials' )
         );
         echo apply_filters( 'tc_social_in_sidebar', $html, current_filter() );
       }
@@ -201,8 +201,8 @@ if ( ! class_exists( 'CZR_sidebar' ) ) :
       function czr_set_sidebar_wrapper_widget_class($_original_classes) {
         $_no_icons_classes = array_merge($_original_classes, array('no-widget-icons'));
 
-        if ( 1 == esc_attr( CZR_utils::$inst->tc_opt('tc_show_sidebar_widget_icon' ) ) )
-          return ( 0 == esc_attr( CZR_utils::$inst->tc_opt('tc_show_title_icon' ) ) ) ? $_no_icons_classes : $_original_classes;
+        if ( 1 == esc_attr( CZR_utils::$inst->czr_opt('tc_show_sidebar_widget_icon' ) ) )
+          return ( 0 == esc_attr( CZR_utils::$inst->czr_opt('tc_show_title_icon' ) ) ) ? $_no_icons_classes : $_original_classes;
          //last condition
         return $_no_icons_classes;
       }

--- a/inc/parts/class-content-sidebar.php
+++ b/inc/parts/class-content-sidebar.php
@@ -20,7 +20,7 @@ if ( ! class_exists( 'CZR_sidebar' ) ) :
       static $instance;
       function __construct () {
         self::$instance =& $this;
-        add_action ( 'wp'       , array( $this , 'czr_set_sidebar_hooks' ) );
+        add_action ( 'wp'       , array( $this , 'czr_fn_set_sidebar_hooks' ) );
       }
 
 
@@ -33,18 +33,18 @@ if ( ! class_exists( 'CZR_sidebar' ) ) :
       *
       * @since Customizr 3.3+
       */
-      function czr_set_sidebar_hooks() {
+      function czr_fn_set_sidebar_hooks() {
         //displays left sidebar
-    		add_action ( '__before_article_container'  , array( $this , 'czr_sidebar_display' ) );
-    		add_action ( '__before_left_sidebar'       , array( $this , 'czr_social_in_sidebar' ) );
+    		add_action ( '__before_article_container'  , array( $this , 'czr_fn_sidebar_display' ) );
+    		add_action ( '__before_left_sidebar'       , array( $this , 'czr_fn_social_in_sidebar' ) );
 
         //displays right sidebar
-    		add_action ( '__after_article_container'   , array( $this , 'czr_sidebar_display' ) );
-    		add_action ( '__before_right_sidebar'      , array( $this , 'czr_social_in_sidebar' ) );
+    		add_action ( '__after_article_container'   , array( $this , 'czr_fn_sidebar_display' ) );
+    		add_action ( '__before_right_sidebar'      , array( $this , 'czr_fn_social_in_sidebar' ) );
 
         //since 3.2.0 show/hide the WP built-in widget icons
-        add_filter ( 'tc_left_sidebar_class'       , array( $this , 'czr_set_sidebar_wrapper_widget_class' ) );
-        add_filter ( 'tc_right_sidebar_class'      , array( $this , 'czr_set_sidebar_wrapper_widget_class' ) );
+        add_filter ( 'tc_left_sidebar_class'       , array( $this , 'czr_fn_set_sidebar_wrapper_widget_class' ) );
+        add_filter ( 'tc_right_sidebar_class'      , array( $this , 'czr_fn_set_sidebar_wrapper_widget_class' ) );
       }
 
 
@@ -60,12 +60,12 @@ if ( ! class_exists( 'CZR_sidebar' ) ) :
       * @package Customizr
       * @since Customizr 1.0
       */
-      function czr_sidebar_display() {
+      function czr_fn_sidebar_display() {
         //first check if home and no content option is choosen
-        if ( czr__f( '__is_home_empty') )
+        if ( czr_fn__f( '__is_home_empty') )
           return;
         //gets current screen layout
-        $screen_layout        = CZR_utils::czr_get_layout( CZR_utils::czr_id() , 'sidebar'  );
+        $screen_layout        = CZR_utils::czr_fn_get_layout( CZR_utils::czr_fn_id() , 'sidebar'  );
 		    // GY: add relative right and left for LTR/RTL sites
         $rel_left             = is_rtl() ? 'right' : 'left';
         $rel_right            = is_rtl() ? 'left' : 'right';
@@ -97,7 +97,7 @@ if ( ! class_exists( 'CZR_sidebar' ) ) :
                 if ( is_active_sidebar( $position ) )
                   get_sidebar( $position );
                 else
-                  $this -> czr_display_sidebar_placeholder($position);
+                  $this -> czr_fn_display_sidebar_placeholder($position);
 
                 do_action( "__after_{$position}_sidebar" );
               ?>
@@ -107,7 +107,7 @@ if ( ! class_exists( 'CZR_sidebar' ) ) :
         <?php
         $html = ob_get_contents();
         if ($html) ob_end_clean();
-        echo apply_filters( 'czr_sidebar_display', $html, $sidebar_layout, $position );
+        echo apply_filters( 'czr_fn_sidebar_display', $html, $sidebar_layout, $position );
       }//end of function
 
 
@@ -121,8 +121,8 @@ if ( ! class_exists( 'CZR_sidebar' ) ) :
       * @param : string position left or right
       * @since Customizr 3.3
       */
-      private function czr_display_sidebar_placeholder( $position ) {
-        if ( ! CZR_placeholders::czr_is_widget_placeholder_enabled( 'sidebar' ) )
+      private function czr_fn_display_sidebar_placeholder( $position ) {
+        if ( ! CZR_placeholders::czr_fn_is_widget_placeholder_enabled( 'sidebar' ) )
           return;
         ?>
         <aside class="tc-placeholder-wrap tc-widget-placeholder">
@@ -137,7 +137,7 @@ if ( ! class_exists( 'CZR_sidebar' ) ) :
 
             printf('<p><strong>%1$s</strong></p>',
               sprintf( __("Add widgets to this sidebar %s or %s.", "customizr"),
-                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', CZR_utils::czr_get_customizer_url( array( 'panel' => 'widgets') ), __( "Add widgets", "customizr"), __("now", "customizr") ),
+                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', CZR_utils::czr_fn_get_customizer_url( array( 'panel' => 'widgets') ), __( "Add widgets", "customizr"), __("now", "customizr") ),
                 sprintf('<a class="tc-inline-dismiss-notice" data-position="sidebar" href="#" title="%1$s">%1$s</a>',
                   __( 'dismiss this notice', 'customizr')
                 )
@@ -168,24 +168,24 @@ if ( ! class_exists( 'CZR_sidebar' ) ) :
       * @package Customizr
       * @since Customizr 1.0
       */
-      function czr_social_in_sidebar() {
+      function czr_fn_social_in_sidebar() {
         //get option from current hook
         $option               = ( false != strpos(current_filter(), 'left') ) ? 'tc_social_in_left-sidebar' : 'tc_social_in_right-sidebar';
 
         //when do we display these blocks ?
         //1) if customizing always. (is hidden if empty of disabled)
         //2) if not customizing : must be enabled and have social networks set.
-        $_nothing_to_render = ( 0 == esc_attr( CZR_utils::$inst->czr_opt( $option) ) ) || ! czr__f( '__get_socials' );
-        if ( ! CZR___::$instance -> czr_is_customizing() && $_nothing_to_render )
+        $_nothing_to_render = ( 0 == esc_attr( CZR_utils::$inst->czr_fn_opt( $option) ) ) || ! czr_fn__f( '__get_socials' );
+        if ( ! CZR___::$instance -> czr_fn_is_customizing() && $_nothing_to_render )
             return;
-        $_title = esc_attr( CZR_utils::$inst->czr_opt( 'tc_social_in_sidebar_title') );
+        $_title = esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_social_in_sidebar_title') );
         $html = sprintf('<aside class="%1$s" %2$s>%3$s%4$s</aside>',
             implode( " " , apply_filters( 'tc_sidebar_block_social_class' , array('social-block', 'widget', 'widget_social') ) ),
             $_nothing_to_render ? 'style="display:none"' : '',
             ! $_title ? '' : apply_filters( 'tc_sidebar_socials_title' , sprintf( '<h3 class="widget-title">%1$s</h3>', $_title ) ),
-            czr__f( '__get_socials' )
+            czr_fn__f( '__get_socials' )
         );
-        echo apply_filters( 'czr_social_in_sidebar', $html, current_filter() );
+        echo apply_filters( 'czr_fn_social_in_sidebar', $html, current_filter() );
       }
 
 
@@ -198,11 +198,11 @@ if ( ! class_exists( 'CZR_sidebar' ) ) :
       * @package Customizr
       * @since Customizr 3.2.0
       */
-      function czr_set_sidebar_wrapper_widget_class($_original_classes) {
+      function czr_fn_set_sidebar_wrapper_widget_class($_original_classes) {
         $_no_icons_classes = array_merge($_original_classes, array('no-widget-icons'));
 
-        if ( 1 == esc_attr( CZR_utils::$inst->czr_opt('tc_show_sidebar_widget_icon' ) ) )
-          return ( 0 == esc_attr( CZR_utils::$inst->czr_opt('tc_show_title_icon' ) ) ) ? $_no_icons_classes : $_original_classes;
+        if ( 1 == esc_attr( CZR_utils::$inst->czr_fn_opt('tc_show_sidebar_widget_icon' ) ) )
+          return ( 0 == esc_attr( CZR_utils::$inst->czr_fn_opt('tc_show_title_icon' ) ) ) ? $_no_icons_classes : $_original_classes;
          //last condition
         return $_no_icons_classes;
       }

--- a/inc/parts/class-content-sidebar.php
+++ b/inc/parts/class-content-sidebar.php
@@ -33,7 +33,7 @@ if ( ! class_exists( 'CZR_sidebar' ) ) :
       *
       * @since Customizr 3.3+
       */
-      function tc_set_sidebar_hooks() {
+      function czr_set_sidebar_hooks() {
         //displays left sidebar
     		add_action ( '__before_article_container'  , array( $this , 'tc_sidebar_display' ) );
     		add_action ( '__before_left_sidebar'       , array( $this , 'tc_social_in_sidebar' ) );
@@ -60,7 +60,7 @@ if ( ! class_exists( 'CZR_sidebar' ) ) :
       * @package Customizr
       * @since Customizr 1.0
       */
-      function tc_sidebar_display() {
+      function czr_sidebar_display() {
         //first check if home and no content option is choosen
         if ( tc__f( '__is_home_empty') )
           return;
@@ -121,7 +121,7 @@ if ( ! class_exists( 'CZR_sidebar' ) ) :
       * @param : string position left or right
       * @since Customizr 3.3
       */
-      private function tc_display_sidebar_placeholder( $position ) {
+      private function czr_display_sidebar_placeholder( $position ) {
         if ( ! CZR_placeholders::tc_is_widget_placeholder_enabled( 'sidebar' ) )
           return;
         ?>
@@ -168,7 +168,7 @@ if ( ! class_exists( 'CZR_sidebar' ) ) :
       * @package Customizr
       * @since Customizr 1.0
       */
-      function tc_social_in_sidebar() {
+      function czr_social_in_sidebar() {
         //get option from current hook
         $option               = ( false != strpos(current_filter(), 'left') ) ? 'tc_social_in_left-sidebar' : 'tc_social_in_right-sidebar';
 
@@ -198,7 +198,7 @@ if ( ! class_exists( 'CZR_sidebar' ) ) :
       * @package Customizr
       * @since Customizr 3.2.0
       */
-      function tc_set_sidebar_wrapper_widget_class($_original_classes) {
+      function czr_set_sidebar_wrapper_widget_class($_original_classes) {
         $_no_icons_classes = array_merge($_original_classes, array('no-widget-icons'));
 
         if ( 1 == esc_attr( CZR_utils::$inst->tc_opt('tc_show_sidebar_widget_icon' ) ) )

--- a/inc/parts/class-content-slider.php
+++ b/inc/parts/class-content-slider.php
@@ -616,7 +616,7 @@ class CZR_slider {
     $sql = apply_filters( 'tc_query_posts_slider_sql', $sql, $args );
 
     $_posts = $wpdb->get_results( $sql );
-    return apply_filters( 'czr_fn_query_posts_slider', $_posts, $args );
+    return apply_filters( 'tc_query_posts_slider', $_posts, $args );
   }
 
 
@@ -630,7 +630,7 @@ class CZR_slider {
   *
   */
   private function czr_fn_get_posts_have_tc_thumb_sql( $_columns, $_pt_where = '', $_pa_where = '' ) {
-    return apply_filters( 'czr_fn_get_posts_have_tc_thumb_sql', sprintf( '%1$s UNION %2$s',
+    return apply_filters( 'tc_get_posts_have_tc_thumb_sql', sprintf( '%1$s UNION %2$s',
         $this -> czr_fn_get_posts_have_thumbnail_sql( $_columns, $_pt_where ),
         $this -> czr_fn_get_posts_have_attachment_sql( $_columns, $_pa_where )
     ));
@@ -646,7 +646,7 @@ class CZR_slider {
   */
   private function czr_fn_get_posts_have_thumbnail_sql( $_columns, $_where = '' ) {
     global $wpdb;
-    return apply_filters( 'czr_fn_get_posts_have_thumbnail_sql', "
+    return apply_filters( 'tc_get_posts_have_thumbnail_sql', "
         SELECT $_columns
         FROM $wpdb->posts AS posts INNER JOIN $wpdb->postmeta AS metas
         ON posts.ID=metas.post_id
@@ -664,7 +664,7 @@ class CZR_slider {
   */
   private function czr_fn_get_posts_have_attachment_sql( $_columns, $_where = '' ) {
     global $wpdb;
-    return apply_filters( 'czr_fn_get_posts_have_attachment_sql', "
+    return apply_filters( 'tc_get_posts_have_attachment_sql', "
         SELECT $_columns FROM $wpdb->posts attachments, $wpdb->posts posts
         WHERE $_where
     ");
@@ -722,7 +722,7 @@ class CZR_slider {
     <?php
     $html = ob_get_contents();
     if ($html) ob_end_clean();
-    echo apply_filters( 'czr_fn_slider_display', $html, $slider_name_id );
+    echo apply_filters( 'tc_slider_display', $html, $slider_name_id );
   }
 
 
@@ -998,7 +998,7 @@ class CZR_slider {
         self::$rendered_sliders
       )
     );
-    echo apply_filters( 'czr_fn_slider_control_view', $_html );
+    echo apply_filters( 'tc_slider_control_view', $_html );
   }
 
 
@@ -1225,7 +1225,7 @@ class CZR_slider {
       if ( false !== (bool) esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_slider_default_height', CZR___::$tc_option_group, $use_default = false ) ) )
         return $_h;
     }
-    return apply_filters( 'czr_fn_set_demo_slider_height' , 750 );
+    return apply_filters( 'tc_set_demo_slider_height' , 750 );
   }
 
 

--- a/inc/parts/class-content-slider.php
+++ b/inc/parts/class-content-slider.php
@@ -29,7 +29,7 @@ class CZR_slider {
     //Set thumbnail specific design based on user options
     //Set user defined height
     add_filter( 'tc_user_options_style'    , array( $this , 'tc_write_slider_inline_css' ) );
-    //tc_slider_height is fired in CZR_slider::tc_write_slider_inline_css()
+    //tc_slider_height is fired in CZR_slider::czr_write_slider_inline_css()
     add_filter( 'tc_slider_height'         , array( $this, 'tc_set_demo_slider_height') );
   }//end of construct
 
@@ -47,7 +47,7 @@ class CZR_slider {
   function czr_set_slider_hooks() {
     //get slides model
     //extract $slider_name_id, $slides, $layout_class, $img_size
-    extract( $this -> tc_get_slider_model() );
+    extract( $this -> czr_get_slider_model() );
     //returns nothing if no slides to display
     if ( ! isset($slides) || ! $slides )
       return;
@@ -94,17 +94,17 @@ class CZR_slider {
     //title
     $title                  = esc_attr(get_post_meta( $id, $key = 'slide_title_key' , $single = true ));
     $default_title_length   = apply_filters( 'tc_slide_title_length', 80 );
-    $title                  = $this -> tc_trim_text( $title, $default_title_length, '...' );
+    $title                  = $this -> czr_trim_text( $title, $default_title_length, '...' );
 
     //lead text
     $text                   = get_post_meta( $id, $key = 'slide_text_key' , $single = true );
     $default_text_length    = apply_filters( 'tc_slide_text_length', 250 );
-    $text                   = $this -> tc_trim_text( $text, $default_text_length, '...' );
+    $text                   = $this -> czr_trim_text( $text, $default_text_length, '...' );
 
     //button text
     $button_text            = esc_attr(get_post_meta( $id, $key = 'slide_button_key' , $single = true ));
     $default_button_length  = apply_filters( 'tc_slide_button_length', 80 );
-    $button_text            = $this -> tc_trim_text( $button_text, $default_button_length, '...' );
+    $button_text            = $this -> czr_trim_text( $button_text, $default_button_length, '...' );
 
     //link post id
     $link_id                = apply_filters( 'tc_slide_link_id', esc_attr(get_post_meta( $id, $key = 'slide_link_key' , $single = true )), $id, $slider_name_id );
@@ -134,7 +134,7 @@ class CZR_slider {
 
     //allow responsive images?
     if ( version_compare( $GLOBALS['wp_version'], '4.4', '>=' ) )
-      if ( 0 == esc_attr( CZR_utils::$inst->tc_opt('tc_resp_slider_img') ) ) {
+      if ( 0 == esc_attr( CZR_utils::$inst->czr_opt('tc_resp_slider_img') ) ) {
         $slide_background_attr['srcset'] = " ";
         //trick, => will produce an empty attr srcset as in wp-includes/media.php the srcset is calculated and added
         //only when the passed srcset attr is not empty. This will avoid us to:
@@ -184,17 +184,17 @@ class CZR_slider {
     $ID                     = $_post->ID;
 
     //attachment image
-    $thumb                  = CZR_post_thumbnails::$instance -> tc_get_thumbnail_model($img_size, $ID, null, isset($args['slider_responsive_images']) ? $args['slider_responsive_images'] : null );
+    $thumb                  = CZR_post_thumbnails::$instance -> czr_get_thumbnail_model($img_size, $ID, null, isset($args['slider_responsive_images']) ? $args['slider_responsive_images'] : null );
     $slide_background       = isset($thumb) && isset($thumb['tc_thumb']) ? $thumb['tc_thumb'] : null;
     // we don't want to show slides with no image
     if ( ! $slide_background )
       return false;
 
     //title
-    $title                  = ( isset( $args['show_title'] ) && $args['show_title'] ) ? $this -> tc_get_post_slide_title( $_post, $ID) : '';
+    $title                  = ( isset( $args['show_title'] ) && $args['show_title'] ) ? $this -> czr_get_post_slide_title( $_post, $ID) : '';
 
     //lead text
-    $text                   = ( isset( $args['show_excerpt'] ) && $args['show_excerpt'] ) ? $this -> tc_get_post_slide_excerpt( $_post, $ID) : '';
+    $text                   = ( isset( $args['show_excerpt'] ) && $args['show_excerpt'] ) ? $this -> czr_get_post_slide_excerpt( $_post, $ID) : '';
 
     return compact( 'ID', 'title', 'text', 'slide_background' );
   }
@@ -269,21 +269,21 @@ class CZR_slider {
     if ( 'demo' == $slider_name_id )
       return apply_filters( 'tc_default_slides', CZR_init::$instance -> default_slides );
     else if ( 'tc_posts_slider' == $slider_name_id ) {
-      $use_transient = apply_filters( 'tc_posts_slider_use_transient', ! CZR___::$instance -> tc_is_customizing() );
+      $use_transient = apply_filters( 'tc_posts_slider_use_transient', ! CZR___::$instance -> czr_is_customizing() );
       //Do not use transient when in the customizer preview (this class is not called in the customize left panel)
       $store_transient = $load_transient = $use_transient;
       // delete transient when in the customize preview
       if ( ! $use_transient )
         delete_transient( 'tc_posts_slides' );
 
-      return $this -> tc_get_the_posts_slides( $slider_name_id, $img_size, $load_transient , $store_transient );
+      return $this -> czr_get_the_posts_slides( $slider_name_id, $img_size, $load_transient , $store_transient );
     }
     //if not demo or tc_posts_slider, we get slides from options
-    $all_sliders    = CZR_utils::$inst -> tc_opt( 'tc_sliders');
+    $all_sliders    = CZR_utils::$inst -> czr_opt( 'tc_sliders');
     $saved_slides   = ( isset($all_sliders[$slider_name_id]) ) ? $all_sliders[$slider_name_id] : false;
 
     //if the slider not longer exists or exists but is empty, return false
-    if ( ! $this -> tc_slider_exists( $saved_slides) )
+    if ( ! $this -> czr_slider_exists( $saved_slides) )
       return;
 
     //inititalize the slides array
@@ -301,7 +301,7 @@ class CZR_slider {
 
       $id                     = $slide_object -> ID;
 
-      $slide_model = $this -> tc_get_single_slide_model( $slider_name_id, $_loop_index, $id, $img_size);
+      $slide_model = $this -> czr_get_single_slide_model( $slider_name_id, $_loop_index, $id, $img_size);
 
       if ( ! $slide_model )
         continue;
@@ -343,13 +343,13 @@ class CZR_slider {
     $load_transient  = apply_filters( 'tc_posts_slider_load_transient'  , $load_transient );
     $store_transient = apply_filters( 'tc_posts_slider_store_transient', $store_transient );
 
-    $pre_slides      = $this -> tc_get_pre_posts_slides( compact( 'img_size', 'load_transient', 'store_transient' ) );
+    $pre_slides      = $this -> czr_get_pre_posts_slides( compact( 'img_size', 'load_transient', 'store_transient' ) );
 
     //filter the pre_model
     $pre_slides      = apply_filters( 'tc_posts_slider_pre_model', $pre_slides );
 
     //if the slider not longer exists or exists but is empty, return false
-    if ( ! $this -> tc_slider_exists( $pre_slides ) )
+    if ( ! $this -> czr_slider_exists( $pre_slides ) )
       return false;
 
     //extract pre_slides model
@@ -362,7 +362,7 @@ class CZR_slider {
 
     //GENERATE SLIDES ARRAY
     foreach ( $posts as $_post_slide ) {
-      $slide_model = $this -> tc_get_single_post_slide_model( $slider_name_id, $_loop_index, $_post_slide, $common, $img_size);
+      $slide_model = $this -> czr_get_single_post_slide_model( $slider_name_id, $_loop_index, $_post_slide, $common, $img_size);
 
       if ( ! $slide_model )
         continue;
@@ -408,12 +408,12 @@ class CZR_slider {
       'store_transient'     => true,
       'transient_name'      => 'tc_posts_slides',
       //options
-      'stickies_only'       => esc_attr( CZR_utils::$inst->tc_opt( 'tc_posts_slider_stickies' ) ),
-      'show_title'          => esc_attr( CZR_utils::$inst->tc_opt( 'tc_posts_slider_title' ) ),
-      'show_excerpt'        => esc_attr( CZR_utils::$inst->tc_opt( 'tc_posts_slider_text' ) ),
-      'button_text'         => esc_attr( CZR_utils::$inst->tc_opt( 'tc_posts_slider_button_text' ) ),
-      'limit'               => esc_attr( CZR_utils::$inst->tc_opt( 'tc_posts_slider_number' ) ),
-      'link_type'           => esc_attr( CZR_utils::$inst->tc_opt( 'tc_posts_slider_link') ),
+      'stickies_only'       => esc_attr( CZR_utils::$inst->czr_opt( 'tc_posts_slider_stickies' ) ),
+      'show_title'          => esc_attr( CZR_utils::$inst->czr_opt( 'tc_posts_slider_title' ) ),
+      'show_excerpt'        => esc_attr( CZR_utils::$inst->czr_opt( 'tc_posts_slider_text' ) ),
+      'button_text'         => esc_attr( CZR_utils::$inst->czr_opt( 'tc_posts_slider_button_text' ) ),
+      'limit'               => esc_attr( CZR_utils::$inst->czr_opt( 'tc_posts_slider_number' ) ),
+      'link_type'           => esc_attr( CZR_utils::$inst->czr_opt( 'tc_posts_slider_link') ),
     );
 
     $args         = apply_filters( 'tc_get_pre_posts_slides_args', wp_parse_args( $args, $defaults ) );
@@ -432,14 +432,14 @@ class CZR_slider {
       return $pre_slides;
 
     //retrieve posts from the db
-    $queried_posts    = $this -> tc_query_posts_slider( $args );
+    $queried_posts    = $this -> czr_query_posts_slider( $args );
 
     if ( empty ( $queried_posts ) )
       return array();
 
     /*** tc_thumb setup filters ***/
     // remove smart load img parsing if any
-    $smart_load_enabled = 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_img_smart_load' ) );
+    $smart_load_enabled = 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_img_smart_load' ) );
     if ( $smart_load_enabled )
       remove_filter( 'tc_thumb_html', array( CZR_utils::$instance, 'tc_parse_imgs') );
 
@@ -449,13 +449,13 @@ class CZR_slider {
 
     //allow responsive images?
     if ( version_compare( $GLOBALS['wp_version'], '4.4', '>=' ) )
-      $args['slider_responsive_images'] = 0 == esc_attr( CZR_utils::$inst->tc_opt('tc_resp_slider_img') ) ? false : true ;
+      $args['slider_responsive_images'] = 0 == esc_attr( CZR_utils::$inst->czr_opt('tc_resp_slider_img') ) ? false : true ;
 
     /* Get the pre_model */
     $pre_slides = $pre_slides_posts = array();
 
     foreach ( $queried_posts as $_post ) {
-      $pre_slide_model = $this ->  tc_get_single_post_slide_pre_model( $_post , $img_size, $args );
+      $pre_slide_model = $this ->  czr_get_single_post_slide_pre_model( $_post , $img_size, $args );
 
       if ( ! $pre_slide_model )
         continue;
@@ -477,7 +477,7 @@ class CZR_slider {
       // button and link whole slide
       // has button to be displayed?
       if ( strstr($link_type, 'cta') )
-        $button_text            = $this -> tc_get_post_slide_button_text( $button_text );
+        $button_text            = $this -> czr_get_post_slide_button_text( $button_text );
       else
         $button_text            = '';
 
@@ -510,22 +510,22 @@ class CZR_slider {
   */
   private function czr_get_slider_model() {
     //Do we have a slider to display in this context ?
-    if ( ! $this -> tc_is_slider_possible() )
+    if ( ! $this -> czr_is_slider_possible() )
       return array();
 
     //gets the actual page id if we are displaying the posts page
-    $queried_id                   = $this -> tc_get_real_id();
+    $queried_id                   = $this -> czr_get_real_id();
 
-    $slider_name_id               = $this -> tc_get_current_slider( $queried_id );
+    $slider_name_id               = $this -> czr_get_current_slider( $queried_id );
 
-    if ( ! $this -> tc_is_slider_active( $queried_id) )
+    if ( ! $this -> czr_is_slider_active( $queried_id) )
       return array();
 
     if ( ! empty( self::$sliders_model ) && is_array( self::$sliders_model ) && array_key_exists( $slider_name_id, self::$sliders_model ) )
       return self::$sliders_model[ $slider_name_id ];
 
     //gets slider options if any
-    $layout_value                 = tc__f('__is_home') ? CZR_utils::$inst->tc_opt( 'tc_slider_width' ) : esc_attr(get_post_meta( $queried_id, $key = 'slider_layout_key' , $single = true ));
+    $layout_value                 = czr__f('__is_home') ? CZR_utils::$inst->czr_opt( 'tc_slider_width' ) : esc_attr(get_post_meta( $queried_id, $key = 'slider_layout_key' , $single = true ));
     $layout_value                 = apply_filters( 'tc_slider_layout', $layout_value, $queried_id );
 
     //declares the layout vars
@@ -533,7 +533,7 @@ class CZR_slider {
     $img_size                     = apply_filters( 'tc_slider_img_size' , ( 0 == $layout_value ) ? 'slider' : 'slider-full');
 
     //get slides
-    $slides                       = $this -> tc_get_the_slides( $slider_name_id , $img_size );
+    $slides                       = $this -> czr_get_the_slides( $slider_name_id , $img_size );
 
     //store the model per slider_name_id
     self::$sliders_model[ $slider_name_id ] = compact( "slider_name_id", "slides", "layout_class" , "img_size" );
@@ -601,7 +601,7 @@ class CZR_slider {
 
     $sql = sprintf( 'SELECT DISTINCT %1$s FROM ( %2$s ) as posts %3$s %4$s ORDER BY %5$s LIMIT %6$s OFFSET %7$s',
              apply_filters( 'tc_query_posts_slider_columns', $columns, $args ),
-             $this -> tc_get_posts_have_tc_thumb_sql(
+             $this -> czr_get_posts_have_tc_thumb_sql(
                apply_filters( 'tc_query_posts_slider_columns', $columns, $args ),
                apply_filters( 'tc_query_posts_slide_thumbnail_where', $pt_where, $args ),
                apply_filters( 'tc_query_posts_slider_attachment_where', $pa_where, $args )
@@ -631,8 +631,8 @@ class CZR_slider {
   */
   private function czr_get_posts_have_tc_thumb_sql( $_columns, $_pt_where = '', $_pa_where = '' ) {
     return apply_filters( 'tc_get_posts_have_tc_thumb_sql', sprintf( '%1$s UNION %2$s',
-        $this -> tc_get_posts_have_thumbnail_sql( $_columns, $_pt_where ),
-        $this -> tc_get_posts_have_attachment_sql( $_columns, $_pa_where )
+        $this -> czr_get_posts_have_thumbnail_sql( $_columns, $_pt_where ),
+        $this -> czr_get_posts_have_attachment_sql( $_columns, $_pa_where )
     ));
   }
 
@@ -688,7 +688,7 @@ class CZR_slider {
   function czr_slider_display() {
     //get slides model
     //extract $slider_name_id, $slides, $layout_class, $img_size
-    extract( $this -> tc_get_slider_model() );
+    extract( $this -> czr_get_slider_model() );
     //returns nothing if no slides to display
     if ( ! isset($slides) || ! $slides )
       return;
@@ -702,7 +702,7 @@ class CZR_slider {
     ?>
     <div id="customizr-slider-<?php echo self::$rendered_sliders ?>" class="<?php echo $layout_class ?> ">
 
-      <?php $this -> tc_render_slider_loader_view( $slider_name_id ); ?>
+      <?php $this -> czr_render_slider_loader_view( $slider_name_id ); ?>
 
       <?php do_action( '__before_carousel_inner' , $slides, $slider_name_id )  ?>
 
@@ -710,7 +710,7 @@ class CZR_slider {
         <?php
           foreach ($slides as $id => $data) {
             $_view_model = compact( "id", "data" , "slider_name_id", "img_size" );
-            $this -> tc_render_single_slide_view( $_view_model );
+            $this -> czr_render_single_slide_view( $_view_model );
           }
         ?>
       </div><!-- /.carousel-inner -->
@@ -744,9 +744,9 @@ class CZR_slider {
     ?>
     <div class="<?php echo $slide_classes; ?>">
       <?php
-        $this -> tc_render_slide_background_view( $_view_model );
-        $this -> tc_render_slide_caption_view( $_view_model );
-        $this -> tc_render_slide_edit_link_view( $_view_model );
+        $this -> czr_render_slide_background_view( $_view_model );
+        $this -> czr_render_slide_caption_view( $_view_model );
+        $this -> czr_render_slide_edit_link_view( $_view_model );
       ?>
     </div><!-- /.item -->
     <?php
@@ -763,7 +763,7 @@ class CZR_slider {
   *
   */
   function czr_render_slider_loader_view( $slider_name_id ) {
-    if ( ! $this -> tc_is_slider_loader_active( $slider_name_id ) )
+    if ( ! $this -> czr_is_slider_loader_active( $slider_name_id ) )
       return;
 
     if ( ! apply_filters( 'tc_slider_loader_gif_only', false ) )
@@ -900,7 +900,7 @@ class CZR_slider {
   */
   function czr_render_slide_edit_link_view( $_view_model ) {
     //never display when customizing
-    if ( CZR___::$instance -> tc_is_customizing() )
+    if ( CZR___::$instance -> czr_is_customizing() )
       return;
     //extract $_view_model = array( $id, $data , $slider_name_id, $img_size )
     extract( $_view_model );
@@ -935,7 +935,7 @@ class CZR_slider {
 
   function czr_render_slider_edit_link_view( $slides, $slider_name_id ) {
     //never display when customizing
-    if ( CZR___::$instance -> tc_is_customizing() )
+    if ( CZR___::$instance -> czr_is_customizing() )
       return;
     if ( 'demo' == $slider_name_id )
       return;
@@ -945,9 +945,9 @@ class CZR_slider {
     //We have to show the slider edit link to
     //a) users who can edit theme options for the slider in home -> deep link in the customizer
     //b) users who can edit the post/page where the slider is displayed for users who can edit the post/page -> deep link in the post/page slider section
-    if ( tc__f('__is_home') ){
+    if ( czr__f('__is_home') ){
       $show_slider_edit_link = ( is_user_logged_in() && current_user_can('edit_theme_options') ) ? true : false;
-      $_edit_link            = CZR_utils::tc_get_customizer_url( array( 'control' => 'tc_front_slider', 'section' => 'frontpage_sec') );
+      $_edit_link            = CZR_utils::czr_get_customizer_url( array( 'control' => 'tc_front_slider', 'section' => 'frontpage_sec') );
     }else if ( is_singular() ){ // we have a snippet to display sliders in categories, we don't want the slider edit link displayed there
       global $post;
       $show_slider_edit_link = ( is_user_logged_in() && ( current_user_can('edit_pages') || current_user_can( 'edit_posts', $post -> ID ) ) ) ? true : false;
@@ -1010,9 +1010,9 @@ class CZR_slider {
   * @since v3.4+
   */
   function czr_maybe_display_dismiss_notice() {
-    if ( ! CZR_placeholders::tc_is_slider_notice_on() )
+    if ( ! CZR_placeholders::czr_is_slider_notice_on() )
       return;
-    $_customizer_lnk = CZR_utils::tc_get_customizer_url( array( 'control' => 'tc_front_slider', 'section' => 'frontpage_sec') );
+    $_customizer_lnk = CZR_utils::czr_get_customizer_url( array( 'control' => 'tc_front_slider', 'section' => 'frontpage_sec') );
     ?>
     <div class="tc-placeholder-wrap tc-slider-notice">
       <?php
@@ -1040,7 +1040,7 @@ class CZR_slider {
   //hook : wp
   //introduced in v3.4.23
   function czr_maybe_setup_parallax() {
-    if ( 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_slider_parallax') ) )
+    if ( 1 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_slider_parallax') ) )
       return;
     add_filter('tc_slider_layout_class'     , array( $this, 'tc_add_parallax_wrapper_class' ) );
     add_filter('tc_carousel_inner_classes'  , array( $this, 'tc_add_parallax_item_class' ) );
@@ -1121,9 +1121,9 @@ class CZR_slider {
   */
   private function czr_is_slider_possible() {
     //gets the front slider if any
-    $tc_front_slider              = esc_attr(CZR_utils::$inst->tc_opt( 'tc_front_slider' ) );
+    $tc_front_slider              = esc_attr(CZR_utils::$inst->czr_opt( 'tc_front_slider' ) );
     //when do we display a slider? By default only for home (if a slider is defined), pages and posts (including custom post types)
-    $_show_slider = tc__f('__is_home') ? ! empty( $tc_front_slider ) : ! is_404() && ! is_archive() && ! is_search();
+    $_show_slider = czr__f('__is_home') ? ! empty( $tc_front_slider ) : ! is_404() && ! is_archive() && ! is_search();
 
     return apply_filters( 'tc_show_slider' , $_show_slider );
   }
@@ -1150,8 +1150,8 @@ class CZR_slider {
   */
   private function czr_get_current_slider($queried_id) {
     //gets the current slider id
-    $_home_slider     = CZR_utils::$inst->tc_opt( 'tc_front_slider' );
-    $slider_name_id   = ( tc__f('__is_home') && $_home_slider ) ? $_home_slider : esc_attr( get_post_meta( $queried_id, $key = 'post_slider_key' , $single = true ) );
+    $_home_slider     = CZR_utils::$inst->czr_opt( 'tc_front_slider' );
+    $slider_name_id   = ( czr__f('__is_home') && $_home_slider ) ? $_home_slider : esc_attr( get_post_meta( $queried_id, $key = 'post_slider_key' , $single = true ) );
     return apply_filters( 'tc_slider_name_id', $slider_name_id , $queried_id);
   }
 
@@ -1165,7 +1165,7 @@ class CZR_slider {
   private function czr_get_real_id() {
     global $wp_query;
     $queried_id                   = get_queried_object_id();
-    return apply_filters( 'tc_slider_get_real_id', ( ! tc__f('__is_home') && $wp_query -> is_posts_page && ! empty($queried_id) ) ?  $queried_id : get_the_ID() );
+    return apply_filters( 'tc_slider_get_real_id', ( ! czr__f('__is_home') && $wp_query -> is_posts_page && ! empty($queried_id) ) ?  $queried_id : get_the_ID() );
   }
 
 
@@ -1177,7 +1177,7 @@ class CZR_slider {
   */
   private function czr_is_slider_active( $queried_id ) {
     //is the slider set to on for the queried id?
-    if ( tc__f('__is_home') && CZR_utils::$inst->tc_opt( 'tc_front_slider' ) )
+    if ( czr__f('__is_home') && CZR_utils::$inst->czr_opt( 'tc_front_slider' ) )
       return apply_filters( 'tc_slider_active_status', true , $queried_id );
 
     $_slider_on = esc_attr( get_post_meta( $queried_id, $key = 'post_slider_check_key' , $single = true ) );
@@ -1198,7 +1198,7 @@ class CZR_slider {
     //a) we have to render the demo slider
     //b) display slider loading option is enabled (can be filtered)
     return ( 'demo' == $slider_name_id
-        || apply_filters( 'tc_display_slider_loader', 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_display_slide_loader') ), $slider_name_id )
+        || apply_filters( 'tc_display_slider_loader', 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_display_slide_loader') ), $slider_name_id )
     );
   }
 
@@ -1213,16 +1213,16 @@ class CZR_slider {
   function czr_set_demo_slider_height( $_h ) {
     //this custom demo height is applied when :
     //1) current slider is demo
-    if ( 'demo' != $this -> tc_get_current_slider( $this -> tc_get_real_id() ) )
+    if ( 'demo' != $this -> czr_get_current_slider( $this -> czr_get_real_id() ) )
       return $_h;
 
     //2) height option has not been changed by user yet
     //the possible customization context must be taken into account here
-    if ( CZR___::$instance -> tc_is_customizing() ) {
-      if ( 500 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_slider_default_height') ) )
+    if ( CZR___::$instance -> czr_is_customizing() ) {
+      if ( 500 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_slider_default_height') ) )
         return $_h;
     } else {
-      if ( false !== (bool) esc_attr( CZR_utils::$inst->tc_opt( 'tc_slider_default_height', CZR___::$tc_option_group, $use_default = false ) ) )
+      if ( false !== (bool) esc_attr( CZR_utils::$inst->czr_opt( 'tc_slider_default_height', CZR___::$tc_option_group, $use_default = false ) ) )
         return $_h;
     }
     return apply_filters( 'tc_set_demo_slider_height' , 750 );
@@ -1238,7 +1238,7 @@ class CZR_slider {
   */
   function czr_write_slider_inline_css( $_css ) {
     //custom css for the slider loader
-    if ( $this -> tc_is_slider_loader_active( $this -> tc_get_current_slider( $this -> tc_get_real_id() ) ) ) {
+    if ( $this -> czr_is_slider_loader_active( $this -> czr_get_current_slider( $this -> czr_get_real_id() ) ) ) {
 
       $_slider_loader_src = apply_filters( 'tc_slider_loader_src' , sprintf( '%1$s/%2$s' , TC_BASE_URL , 'inc/assets/img/slider-loader.gif') );
       //we can load only the gif, or use it as fallback for old browsers (.no-csstransforms3d)
@@ -1247,7 +1247,7 @@ class CZR_slider {
         // The pure css loader color depends on the skin. Why can we do this here without caring of the live preview?
         // Basically 'cause the loader is something we see when the page "loads" then it disappears so a live change of the skin
         // will still have no visive impact on it. This will avoid us to rebuild the custom skins.
-        $_current_skin_colors      = CZR_utils::$inst -> tc_get_skin_color( 'pair' );
+        $_current_skin_colors      = CZR_utils::$inst -> czr_get_skin_color( 'pair' );
         $_pure_css_loader_css      = apply_filters( 'tc_slider_loader_css', sprintf(
             '.tc-slider-loader-wrapper .tc-css-loader > div { border-color:%s; }',
             //we can use the primary or the secondary skin color
@@ -1273,12 +1273,12 @@ class CZR_slider {
 
     // 1) Do we have a custom height ?
     // 2) check if the setting must be applied to all context
-    $_custom_height     = apply_filters( 'tc_slider_height' , esc_attr( CZR_utils::$inst->tc_opt( 'tc_slider_default_height') ) );
+    $_custom_height     = apply_filters( 'tc_slider_height' , esc_attr( CZR_utils::$inst->czr_opt( 'tc_slider_default_height') ) );
     $_slider_inline_css = "";
 
     //When shall we append custom slider style to the global custom inline stylesheet?
     $_bool = 500 != $_custom_height;
-    $_bool = $_bool && ( tc__f('__is_home') || 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_slider_default_height_apply_all') ) );
+    $_bool = $_bool && ( czr__f('__is_home') || 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_slider_default_height_apply_all') ) );
 
     if ( ! apply_filters( 'tc_print_slider_inline_css' , $_bool ) )
       return $_css;
@@ -1339,7 +1339,7 @@ class CZR_slider {
   *
   */
   function czr_set_slider_wrapper_class($_classes) {
-    if ( ! is_array($_classes) || 500 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_slider_default_height') ) )
+    if ( ! is_array($_classes) || 500 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_slider_default_height') ) )
       return $_classes;
 
     return array_merge( $_classes , array('custom-slider-height') );
@@ -1354,7 +1354,7 @@ class CZR_slider {
   * @since Customizr 3.3+
   */
   function czr_set_inner_class( $_classes ) {
-    if( ! (bool) esc_attr( CZR_utils::$inst->tc_opt( 'tc_center_slider_img') ) || ! is_array($_classes) )
+    if( ! (bool) esc_attr( CZR_utils::$inst->czr_opt( 'tc_center_slider_img') ) || ! is_array($_classes) )
       return $_classes;
     array_push( $_classes, 'center-slides-enabled' );
     return $_classes;
@@ -1370,12 +1370,12 @@ class CZR_slider {
   function czr_cache_posts_slider( $args = array() ) {
     $defaults = array (
       //use the home slider_width
-      'img_size'        => 1 == CZR_utils::$inst->tc_opt( 'tc_slider_width' ) ? 'slider-full' : 'slider',
+      'img_size'        => 1 == CZR_utils::$inst->czr_opt( 'tc_slider_width' ) ? 'slider-full' : 'slider',
       'load_transient'  => false,
       'store_transient' => true,
       'transient_name'  => 'tc_posts_slides'
     );
-    $this -> tc_get_pre_posts_slides( wp_parse_args( $args, $defaults) );
+    $this -> czr_get_pre_posts_slides( wp_parse_args( $args, $defaults) );
   }
 
 
@@ -1393,7 +1393,7 @@ class CZR_slider {
   function czr_get_post_slide_title( $_post, $ID ) {
     $title_length   = apply_filters('tc_post_slide_title_length', 80, $ID );
     $more           = apply_filters('tc_post_slide_more', '...', $ID );
-    return $this -> tc_get_post_title( $_post, $title_length, $more );
+    return $this -> czr_get_post_title( $_post, $title_length, $more );
   }
 
 
@@ -1410,7 +1410,7 @@ class CZR_slider {
   function czr_get_post_slide_excerpt( $_post, $ID ) {
     $excerpt_length  = apply_filters( 'tc_post_slide_text_length', 80, $ID );
     $more            = apply_filters( 'tc_post_slide_more', '...', $ID );
-    return $this -> tc_get_post_excerpt( $_post, $excerpt_length, $more );
+    return $this -> czr_get_post_excerpt( $_post, $excerpt_length, $more );
   }
 
   /**
@@ -1427,7 +1427,7 @@ class CZR_slider {
     $button_text_length  = apply_filters( 'tc_posts_slider_button_text_length', 80 );
     $more                = apply_filters( 'tc_post_slide_more', '...');
     $button_text         = apply_filters( 'tc_posts_slider_button_text_pre_trim' , $button_text );
-    return $this -> tc_trim_text( $button_text, $button_text_length, $more );
+    return $this -> czr_trim_text( $button_text, $button_text_length, $more );
   }
 
   /**
@@ -1452,7 +1452,7 @@ class CZR_slider {
     }
 
     $title = apply_filters( 'tc_post_title_pre_trim' , $title );
-    return $this -> tc_trim_text( $title, $default_title_length, $more);
+    return $this -> czr_trim_text( $title, $default_title_length, $more);
   }
 
 
@@ -1488,7 +1488,7 @@ class CZR_slider {
     $excerpt = str_replace(']]>', ']]&gt;', $excerpt );
 
     $excerpt = apply_filters( 'tc_post_excerpt_pre_trim' , $excerpt );
-    return $this -> tc_trim_text( $excerpt, $default_text_length, $more);
+    return $this -> czr_trim_text( $excerpt, $default_text_length, $more);
   }
 
 

--- a/inc/parts/class-content-slider.php
+++ b/inc/parts/class-content-slider.php
@@ -44,7 +44,7 @@ class CZR_slider {
   * Set slider hooks
   * @return  void
   */
-  function tc_set_slider_hooks() {
+  function czr_set_slider_hooks() {
     //get slides model
     //extract $slider_name_id, $slides, $layout_class, $img_size
     extract( $this -> tc_get_slider_model() );
@@ -85,7 +85,7 @@ class CZR_slider {
   * @since Customizr 3.0.15
   *
   */
-  private function tc_get_single_slide_model( $slider_name_id, $_loop_index , $id , $img_size ) {
+  private function czr_get_single_slide_model( $slider_name_id, $_loop_index , $id , $img_size ) {
     //check if slider enabled for this attachment and go to next slide if not
     $slider_checked         = esc_attr(get_post_meta( $id, $key = 'slider_check_key' , $single = true ));
     if ( ! isset( $slider_checked) || $slider_checked != 1 )
@@ -180,7 +180,7 @@ class CZR_slider {
   * @since Customizr 3.4.9
   *
   */
-  function tc_get_single_post_slide_pre_model( $_post , $img_size, $args ){
+  function czr_get_single_post_slide_pre_model( $_post , $img_size, $args ){
     $ID                     = $_post->ID;
 
     //attachment image
@@ -208,7 +208,7 @@ class CZR_slider {
   * @since Customizr 3.4.9
   *
   */
-  function tc_get_single_post_slide_model( $slider_name_id, $_loop_index , $_post_slide , $common, $img_size ){
+  function czr_get_single_post_slide_model( $slider_name_id, $_loop_index , $_post_slide , $common, $img_size ){
     extract( $_post_slide );
     extract( $common );
 
@@ -264,7 +264,7 @@ class CZR_slider {
   * @since Customizr 3.0.15
   *
   */
-  private function tc_get_the_slides( $slider_name_id, $img_size ) {
+  private function czr_get_the_slides( $slider_name_id, $img_size ) {
     //returns the default slider if requested
     if ( 'demo' == $slider_name_id )
       return apply_filters( 'tc_default_slides', CZR_init::$instance -> default_slides );
@@ -338,7 +338,7 @@ class CZR_slider {
   * mostly with qtranslate (polylang will force us, most likely if I don't find any
   * other suitable solution, to not use the transient).
   */
-  private function tc_get_the_posts_slides( $slider_name_id, $img_size, $load_transient = true, $store_transient = true ) {
+  private function czr_get_the_posts_slides( $slider_name_id, $img_size, $load_transient = true, $store_transient = true ) {
 
     $load_transient  = apply_filters( 'tc_posts_slider_load_transient'  , $load_transient );
     $store_transient = apply_filters( 'tc_posts_slider_store_transient', $store_transient );
@@ -400,7 +400,7 @@ class CZR_slider {
   * @since Customizr 3.4.9
   *
   */
-  private function tc_get_pre_posts_slides( $args ){
+  private function czr_get_pre_posts_slides( $args ){
 
     $defaults       = array(
       'img_size'            => null,
@@ -508,7 +508,7 @@ class CZR_slider {
   * @since Customizr 3.3+
   *
   */
-  private function tc_get_slider_model() {
+  private function czr_get_slider_model() {
     //Do we have a slider to display in this context ?
     if ( ! $this -> tc_is_slider_possible() )
       return array();
@@ -552,7 +552,7 @@ class CZR_slider {
   * @since Customizr 3.4.9
   *
   */
-  private function tc_query_posts_slider( $args = array() ) {
+  private function czr_query_posts_slider( $args = array() ) {
     global $wpdb;
 
     $defaults       = array(
@@ -629,7 +629,7 @@ class CZR_slider {
   * @since Customizr 3.4.9
   *
   */
-  private function tc_get_posts_have_tc_thumb_sql( $_columns, $_pt_where = '', $_pa_where = '' ) {
+  private function czr_get_posts_have_tc_thumb_sql( $_columns, $_pt_where = '', $_pa_where = '' ) {
     return apply_filters( 'tc_get_posts_have_tc_thumb_sql', sprintf( '%1$s UNION %2$s',
         $this -> tc_get_posts_have_thumbnail_sql( $_columns, $_pt_where ),
         $this -> tc_get_posts_have_attachment_sql( $_columns, $_pa_where )
@@ -644,7 +644,7 @@ class CZR_slider {
   * @since Customizr 3.4.9
   *
   */
-  private function tc_get_posts_have_thumbnail_sql( $_columns, $_where = '' ) {
+  private function czr_get_posts_have_thumbnail_sql( $_columns, $_where = '' ) {
     global $wpdb;
     return apply_filters( 'tc_get_posts_have_thumbnail_sql', "
         SELECT $_columns
@@ -662,7 +662,7 @@ class CZR_slider {
   * @since Customizr 3.4.9
   *
   */
-  private function tc_get_posts_have_attachment_sql( $_columns, $_where = '' ) {
+  private function czr_get_posts_have_attachment_sql( $_columns, $_where = '' ) {
     global $wpdb;
     return apply_filters( 'tc_get_posts_have_attachment_sql', "
         SELECT $_columns FROM $wpdb->posts attachments, $wpdb->posts posts
@@ -685,7 +685,7 @@ class CZR_slider {
   * @since Customizr 1.0
   *
   */
-  function tc_slider_display() {
+  function czr_slider_display() {
     //get slides model
     //extract $slider_name_id, $slides, $layout_class, $img_size
     extract( $this -> tc_get_slider_model() );
@@ -736,7 +736,7 @@ class CZR_slider {
   * @since Customizr 3.3+
   *
   */
-  function tc_render_single_slide_view( $_view_model ) {
+  function czr_render_single_slide_view( $_view_model ) {
     //extract $_view_model = array( $id, $data , $slider_name_id, $img_size )
     extract( $_view_model );
 
@@ -762,7 +762,7 @@ class CZR_slider {
   * @since Customizr 3.3+
   *
   */
-  function tc_render_slider_loader_view( $slider_name_id ) {
+  function czr_render_slider_loader_view( $slider_name_id ) {
     if ( ! $this -> tc_is_slider_loader_active( $slider_name_id ) )
       return;
 
@@ -795,7 +795,7 @@ class CZR_slider {
   * @since Customizr 3.3+
   *
   */
-  function tc_render_slide_background_view( $_view_model ) {
+  function czr_render_slide_background_view( $_view_model ) {
     //extract $_view_model = array( $id, $data , $slider_name_id, $img_size )
     extract( $_view_model );
     ?>
@@ -822,7 +822,7 @@ class CZR_slider {
   * @since Customizr 3.3+
   *
   */
-  function tc_link_whole_slide( $slide_background, $link_url, $id, $slider_name_id, $data ) {
+  function czr_link_whole_slide( $slide_background, $link_url, $id, $slider_name_id, $data ) {
     if ( isset( $data['link_whole_slide'] )  && $data['link_whole_slide'] && $link_url )
       $slide_background = sprintf('<a href="%1$s" class="tc-slide-link" target="%2$s" title="%3$s">%4$s</a>',
                                 $link_url,
@@ -841,7 +841,7 @@ class CZR_slider {
   * @since Customizr 3.3+
   *
   */
-  function tc_render_slide_caption_view( $_view_model ) {
+  function czr_render_slide_caption_view( $_view_model ) {
     //extract $_view_model = array( $id, $data , $slider_name_id, $img_size )
     extract( $_view_model );
     //filters the data before (=> used for demo for example )
@@ -898,7 +898,7 @@ class CZR_slider {
   * @since Customizr 3.3+
   *
   */
-  function tc_render_slide_edit_link_view( $_view_model ) {
+  function czr_render_slide_edit_link_view( $_view_model ) {
     //never display when customizing
     if ( CZR___::$instance -> tc_is_customizing() )
       return;
@@ -933,7 +933,7 @@ class CZR_slider {
   * @since v3.4.9
   */
 
-  function tc_render_slider_edit_link_view( $slides, $slider_name_id ) {
+  function czr_render_slider_edit_link_view( $slides, $slider_name_id ) {
     //never display when customizing
     if ( CZR___::$instance -> tc_is_customizing() )
       return;
@@ -976,7 +976,7 @@ class CZR_slider {
   * @since v3.2.0
   *
   */
-  function tc_slider_control_view( $_slides ) {
+  function czr_slider_control_view( $_slides ) {
     if ( count( $_slides ) <= 1 )
       return;
 
@@ -1009,7 +1009,7 @@ class CZR_slider {
   * hook : __after_carousel_inner
   * @since v3.4+
   */
-  function tc_maybe_display_dismiss_notice() {
+  function czr_maybe_display_dismiss_notice() {
     if ( ! CZR_placeholders::tc_is_slider_notice_on() )
       return;
     $_customizer_lnk = CZR_utils::tc_get_customizer_url( array( 'control' => 'tc_front_slider', 'section' => 'frontpage_sec') );
@@ -1039,7 +1039,7 @@ class CZR_slider {
   *******************************/
   //hook : wp
   //introduced in v3.4.23
-  function tc_maybe_setup_parallax() {
+  function czr_maybe_setup_parallax() {
     if ( 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_slider_parallax') ) )
       return;
     add_filter('tc_slider_layout_class'     , array( $this, 'tc_add_parallax_wrapper_class' ) );
@@ -1049,7 +1049,7 @@ class CZR_slider {
 
 
   //hook : wp_head
-  function tc_add_parallax_slider_script() {
+  function czr_add_parallax_slider_script() {
     ?>
       <script type="text/javascript" id="do-parallax-sliders">
         jQuery( function($){
@@ -1060,13 +1060,13 @@ class CZR_slider {
   }
 
   //hook : tc_carousel_inner_classes
-  function tc_add_parallax_item_class ( $classes ) {
+  function czr_add_parallax_item_class ( $classes ) {
     array_push($classes, 'czr-parallax-slider' );
     return $classes;
   }
 
   //hook : tc_slider_layout_class
-  function tc_add_parallax_wrapper_class( $classes ) {
+  function czr_add_parallax_wrapper_class( $classes ) {
     array_push($classes, 'parallax-wrapper' );
     return $classes;
   }
@@ -1087,7 +1087,7 @@ class CZR_slider {
   * @since Customizr 3.3.+
   *
   */
-  function tc_set_demo_slide_data( $data, $slider_name_id, $id ) {
+  function czr_set_demo_slide_data( $data, $slider_name_id, $id ) {
     if ( 'demo' != $slider_name_id || ! is_user_logged_in() )
       return $data;
 
@@ -1119,7 +1119,7 @@ class CZR_slider {
   * @since Customizr 3.3+
   *
   */
-  private function tc_is_slider_possible() {
+  private function czr_is_slider_possible() {
     //gets the front slider if any
     $tc_front_slider              = esc_attr(CZR_utils::$inst->tc_opt( 'tc_front_slider' ) );
     //when do we display a slider? By default only for home (if a slider is defined), pages and posts (including custom post types)
@@ -1136,7 +1136,7 @@ class CZR_slider {
   * @package Customizr
   * @since Customizr 3.4.9
   */
-  function tc_slider_exists( $slider ){
+  function czr_slider_exists( $slider ){
     //if the slider not longer exists or exists but is empty, return false
     return ! ( !isset($slider) || !is_array($slider) || empty($slider) );
   }
@@ -1148,7 +1148,7 @@ class CZR_slider {
   * @return  string
   *
   */
-  private function tc_get_current_slider($queried_id) {
+  private function czr_get_current_slider($queried_id) {
     //gets the current slider id
     $_home_slider     = CZR_utils::$inst->tc_opt( 'tc_front_slider' );
     $slider_name_id   = ( tc__f('__is_home') && $_home_slider ) ? $_home_slider : esc_attr( get_post_meta( $queried_id, $key = 'post_slider_key' , $single = true ) );
@@ -1162,7 +1162,7 @@ class CZR_slider {
   * @return  number
   *
   */
-  private function tc_get_real_id() {
+  private function czr_get_real_id() {
     global $wp_query;
     $queried_id                   = get_queried_object_id();
     return apply_filters( 'tc_slider_get_real_id', ( ! tc__f('__is_home') && $wp_query -> is_posts_page && ! empty($queried_id) ) ?  $queried_id : get_the_ID() );
@@ -1175,7 +1175,7 @@ class CZR_slider {
   * @return  boolean
   *
   */
-  private function tc_is_slider_active( $queried_id ) {
+  private function czr_is_slider_active( $queried_id ) {
     //is the slider set to on for the queried id?
     if ( tc__f('__is_home') && CZR_utils::$inst->tc_opt( 'tc_front_slider' ) )
       return apply_filters( 'tc_slider_active_status', true , $queried_id );
@@ -1193,7 +1193,7 @@ class CZR_slider {
   * @return  boolean
   *
   */
-  private function tc_is_slider_loader_active( $slider_name_id ) {
+  private function czr_is_slider_loader_active( $slider_name_id ) {
     //The slider loader must be printed when
     //a) we have to render the demo slider
     //b) display slider loading option is enabled (can be filtered)
@@ -1210,7 +1210,7 @@ class CZR_slider {
   * @package Customizr
   * @since Customizr 3.3+
   */
-  function tc_set_demo_slider_height( $_h ) {
+  function czr_set_demo_slider_height( $_h ) {
     //this custom demo height is applied when :
     //1) current slider is demo
     if ( 'demo' != $this -> tc_get_current_slider( $this -> tc_get_real_id() ) )
@@ -1236,7 +1236,7 @@ class CZR_slider {
   * @package Customizr
   * @since Customizr 3.2.6
   */
-  function tc_write_slider_inline_css( $_css ) {
+  function czr_write_slider_inline_css( $_css ) {
     //custom css for the slider loader
     if ( $this -> tc_is_slider_loader_active( $this -> tc_get_current_slider( $this -> tc_get_real_id() ) ) ) {
 
@@ -1338,7 +1338,7 @@ class CZR_slider {
   * @since Customizr 3.2.0
   *
   */
-  function tc_set_slider_wrapper_class($_classes) {
+  function czr_set_slider_wrapper_class($_classes) {
     if ( ! is_array($_classes) || 500 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_slider_default_height') ) )
       return $_classes;
 
@@ -1353,7 +1353,7 @@ class CZR_slider {
   * @package Customizr
   * @since Customizr 3.3+
   */
-  function tc_set_inner_class( $_classes ) {
+  function czr_set_inner_class( $_classes ) {
     if( ! (bool) esc_attr( CZR_utils::$inst->tc_opt( 'tc_center_slider_img') ) || ! is_array($_classes) )
       return $_classes;
     array_push( $_classes, 'center-slides-enabled' );
@@ -1367,7 +1367,7 @@ class CZR_slider {
   * @package Customizr
   * @since Customizr 3.4.9
   */
-  function tc_cache_posts_slider( $args = array() ) {
+  function czr_cache_posts_slider( $args = array() ) {
     $defaults = array (
       //use the home slider_width
       'img_size'        => 1 == CZR_utils::$inst->tc_opt( 'tc_slider_width' ) ? 'slider-full' : 'slider',
@@ -1390,7 +1390,7 @@ class CZR_slider {
   * @since Customizr 3.4.9
   *
   */
-  function tc_get_post_slide_title( $_post, $ID ) {
+  function czr_get_post_slide_title( $_post, $ID ) {
     $title_length   = apply_filters('tc_post_slide_title_length', 80, $ID );
     $more           = apply_filters('tc_post_slide_more', '...', $ID );
     return $this -> tc_get_post_title( $_post, $title_length, $more );
@@ -1407,7 +1407,7 @@ class CZR_slider {
   * @since Customizr 3.4.9
   *
   */
-  function tc_get_post_slide_excerpt( $_post, $ID ) {
+  function czr_get_post_slide_excerpt( $_post, $ID ) {
     $excerpt_length  = apply_filters( 'tc_post_slide_text_length', 80, $ID );
     $more            = apply_filters( 'tc_post_slide_more', '...', $ID );
     return $this -> tc_get_post_excerpt( $_post, $excerpt_length, $more );
@@ -1423,7 +1423,7 @@ class CZR_slider {
   * @since Customizr 3.4.9
   *
   */
-  function tc_get_post_slide_button_text( $button_text ) {
+  function czr_get_post_slide_button_text( $button_text ) {
     $button_text_length  = apply_filters( 'tc_posts_slider_button_text_length', 80 );
     $more                = apply_filters( 'tc_post_slide_more', '...');
     $button_text         = apply_filters( 'tc_posts_slider_button_text_pre_trim' , $button_text );
@@ -1444,7 +1444,7 @@ class CZR_slider {
   *
   */
   // move this into CZR_utils?
-  function tc_get_post_title( $_post, $default_title_length, $more ) {
+  function czr_get_post_title( $_post, $default_title_length, $more ) {
     $title = $_post->post_title;
     if ( ! empty( $_post->post_password ) ) {
       $protected_title_format = apply_filters( 'protected_title_format', __( 'Protected: %s', 'customizr' ), $_post);
@@ -1470,7 +1470,7 @@ class CZR_slider {
   *
   */
   // move this into CZR_utils?
-  function tc_get_post_excerpt( $_post, $default_text_length, $more ) {
+  function czr_get_post_excerpt( $_post, $default_text_length, $more ) {
     if ( ! empty( $_post->post_password) )
       return __( 'There is no excerpt because this is a protected post.', 'customizr' );
 
@@ -1504,7 +1504,7 @@ class CZR_slider {
   *
   */
   // move this into CZR_utils?
-  function tc_trim_text( $text, $text_length, $more ) {
+  function czr_trim_text( $text, $text_length, $more ) {
     if ( ! $text )
       return '';
 

--- a/inc/parts/class-content-slider.php
+++ b/inc/parts/class-content-slider.php
@@ -20,17 +20,17 @@ class CZR_slider {
 
   function __construct () {
     self::$instance =& $this;
-    add_action( 'wp'                       , array( $this, 'czr_maybe_setup_parallax' ) );
-    add_action( 'template_redirect'        , array( $this, 'czr_set_slider_hooks' ) );
+    add_action( 'wp'                       , array( $this, 'czr_fn_maybe_setup_parallax' ) );
+    add_action( 'template_redirect'        , array( $this, 'czr_fn_set_slider_hooks' ) );
     //set user customizer options. @since v3.2.0
-    add_filter( 'tc_slider_layout_class'   , array( $this , 'czr_set_slider_wrapper_class' ) );
+    add_filter( 'tc_slider_layout_class'   , array( $this , 'czr_fn_set_slider_wrapper_class' ) );
     //! tc_user_options_style filter is shared by several classes => must always check the local context inside the callback before appending new css
     //fired on hook : wp_enqueue_scripts
     //Set thumbnail specific design based on user options
     //Set user defined height
-    add_filter( 'tc_user_options_style'    , array( $this , 'czr_write_slider_inline_css' ) );
-    //tc_slider_height is fired in CZR_slider::czr_write_slider_inline_css()
-    add_filter( 'tc_slider_height'         , array( $this, 'czr_set_demo_slider_height') );
+    add_filter( 'tc_user_options_style'    , array( $this , 'czr_fn_write_slider_inline_css' ) );
+    //tc_slider_height is fired in CZR_slider::czr_fn_write_slider_inline_css()
+    add_filter( 'tc_slider_height'         , array( $this, 'czr_fn_set_demo_slider_height') );
   }//end of construct
 
 
@@ -44,34 +44,34 @@ class CZR_slider {
   * Set slider hooks
   * @return  void
   */
-  function czr_set_slider_hooks() {
+  function czr_fn_set_slider_hooks() {
     //get slides model
     //extract $slider_name_id, $slides, $layout_class, $img_size
-    extract( $this -> czr_get_slider_model() );
+    extract( $this -> czr_fn_get_slider_model() );
     //returns nothing if no slides to display
     if ( ! isset($slides) || ! $slides )
       return;
 
-    add_action( '__after_header'            , array( $this , 'czr_slider_display' ) );
-    add_action( '__after_carousel_inner'    , array( $this , 'czr_slider_control_view' ) );
+    add_action( '__after_header'            , array( $this , 'czr_fn_slider_display' ) );
+    add_action( '__after_carousel_inner'    , array( $this , 'czr_fn_slider_control_view' ) );
 
     //adds the center-slides-enabled css class
-    add_filter( 'tc_carousel_inner_classes' , array( $this, 'czr_set_inner_class') );
+    add_filter( 'tc_carousel_inner_classes' , array( $this, 'czr_fn_set_inner_class') );
 
     //adds infos in the caption data of the demo slider
-    add_filter( 'tc_slide_caption_data'     , array( $this, 'czr_set_demo_slide_data'), 10, 3 );
+    add_filter( 'tc_slide_caption_data'     , array( $this, 'czr_fn_set_demo_slide_data'), 10, 3 );
 
     //wrap the slide into a link
-    add_filter( 'tc_slide_background'       , array( $this, 'czr_link_whole_slide'), 5, 5 );
+    add_filter( 'tc_slide_background'       , array( $this, 'czr_fn_link_whole_slide'), 5, 5 );
 
     //display a notice for first time users
     if ( 'demo' == $slider_name_id ) {
       //display a notice for first time users
-      add_action( '__after_carousel_inner'   , array( $this, 'czr_maybe_display_dismiss_notice') );
+      add_action( '__after_carousel_inner'   , array( $this, 'czr_fn_maybe_display_dismiss_notice') );
     }
 
     //display an edit deep link to the Slider section in the Customize or post/page
-    add_action( '__after_carousel_inner'    , array( $this, 'czr_render_slider_edit_link_view'), 10, 2 );
+    add_action( '__after_carousel_inner'    , array( $this, 'czr_fn_render_slider_edit_link_view'), 10, 2 );
   }
 
   /******************************
@@ -85,7 +85,7 @@ class CZR_slider {
   * @since Customizr 3.0.15
   *
   */
-  private function czr_get_single_slide_model( $slider_name_id, $_loop_index , $id , $img_size ) {
+  private function czr_fn_get_single_slide_model( $slider_name_id, $_loop_index , $id , $img_size ) {
     //check if slider enabled for this attachment and go to next slide if not
     $slider_checked         = esc_attr(get_post_meta( $id, $key = 'slider_check_key' , $single = true ));
     if ( ! isset( $slider_checked) || $slider_checked != 1 )
@@ -94,17 +94,17 @@ class CZR_slider {
     //title
     $title                  = esc_attr(get_post_meta( $id, $key = 'slide_title_key' , $single = true ));
     $default_title_length   = apply_filters( 'tc_slide_title_length', 80 );
-    $title                  = $this -> czr_trim_text( $title, $default_title_length, '...' );
+    $title                  = $this -> czr_fn_trim_text( $title, $default_title_length, '...' );
 
     //lead text
     $text                   = get_post_meta( $id, $key = 'slide_text_key' , $single = true );
     $default_text_length    = apply_filters( 'tc_slide_text_length', 250 );
-    $text                   = $this -> czr_trim_text( $text, $default_text_length, '...' );
+    $text                   = $this -> czr_fn_trim_text( $text, $default_text_length, '...' );
 
     //button text
     $button_text            = esc_attr(get_post_meta( $id, $key = 'slide_button_key' , $single = true ));
     $default_button_length  = apply_filters( 'tc_slide_button_length', 80 );
-    $button_text            = $this -> czr_trim_text( $button_text, $default_button_length, '...' );
+    $button_text            = $this -> czr_fn_trim_text( $button_text, $default_button_length, '...' );
 
     //link post id
     $link_id                = apply_filters( 'tc_slide_link_id', esc_attr(get_post_meta( $id, $key = 'slide_link_key' , $single = true )), $id, $slider_name_id );
@@ -134,7 +134,7 @@ class CZR_slider {
 
     //allow responsive images?
     if ( version_compare( $GLOBALS['wp_version'], '4.4', '>=' ) )
-      if ( 0 == esc_attr( CZR_utils::$inst->czr_opt('tc_resp_slider_img') ) ) {
+      if ( 0 == esc_attr( CZR_utils::$inst->czr_fn_opt('tc_resp_slider_img') ) ) {
         $slide_background_attr['srcset'] = " ";
         //trick, => will produce an empty attr srcset as in wp-includes/media.php the srcset is calculated and added
         //only when the passed srcset attr is not empty. This will avoid us to:
@@ -145,7 +145,7 @@ class CZR_slider {
         //we'll see an empty ( or " " depending on the browser ) srcset attribute in the html
         //to avoid this we filter the attributes getting rid of the srcset if any.
         //Basically this trick, even if ugly, will avoid the srcset attr computation
-        add_filter( 'wp_get_attachment_image_attributes', array( CZR_post_thumbnails::$instance, 'czr_remove_srcset_attr' ) );
+        add_filter( 'wp_get_attachment_image_attributes', array( CZR_post_thumbnails::$instance, 'czr_fn_remove_srcset_attr' ) );
       }
     $slide_background       = wp_get_attachment_image( $id, $img_size, false, $slide_background_attr );
 
@@ -180,21 +180,21 @@ class CZR_slider {
   * @since Customizr 3.4.9
   *
   */
-  function czr_get_single_post_slide_pre_model( $_post , $img_size, $args ){
+  function czr_fn_get_single_post_slide_pre_model( $_post , $img_size, $args ){
     $ID                     = $_post->ID;
 
     //attachment image
-    $thumb                  = CZR_post_thumbnails::$instance -> czr_get_thumbnail_model($img_size, $ID, null, isset($args['slider_responsive_images']) ? $args['slider_responsive_images'] : null );
+    $thumb                  = CZR_post_thumbnails::$instance -> czr_fn_get_thumbnail_model($img_size, $ID, null, isset($args['slider_responsive_images']) ? $args['slider_responsive_images'] : null );
     $slide_background       = isset($thumb) && isset($thumb['tc_thumb']) ? $thumb['tc_thumb'] : null;
     // we don't want to show slides with no image
     if ( ! $slide_background )
       return false;
 
     //title
-    $title                  = ( isset( $args['show_title'] ) && $args['show_title'] ) ? $this -> czr_get_post_slide_title( $_post, $ID) : '';
+    $title                  = ( isset( $args['show_title'] ) && $args['show_title'] ) ? $this -> czr_fn_get_post_slide_title( $_post, $ID) : '';
 
     //lead text
-    $text                   = ( isset( $args['show_excerpt'] ) && $args['show_excerpt'] ) ? $this -> czr_get_post_slide_excerpt( $_post, $ID) : '';
+    $text                   = ( isset( $args['show_excerpt'] ) && $args['show_excerpt'] ) ? $this -> czr_fn_get_post_slide_excerpt( $_post, $ID) : '';
 
     return compact( 'ID', 'title', 'text', 'slide_background' );
   }
@@ -208,7 +208,7 @@ class CZR_slider {
   * @since Customizr 3.4.9
   *
   */
-  function czr_get_single_post_slide_model( $slider_name_id, $_loop_index , $_post_slide , $common, $img_size ){
+  function czr_fn_get_single_post_slide_model( $slider_name_id, $_loop_index , $_post_slide , $common, $img_size ){
     extract( $_post_slide );
     extract( $common );
 
@@ -264,26 +264,26 @@ class CZR_slider {
   * @since Customizr 3.0.15
   *
   */
-  private function czr_get_the_slides( $slider_name_id, $img_size ) {
+  private function czr_fn_get_the_slides( $slider_name_id, $img_size ) {
     //returns the default slider if requested
     if ( 'demo' == $slider_name_id )
       return apply_filters( 'tc_default_slides', CZR_init::$instance -> default_slides );
     else if ( 'tc_posts_slider' == $slider_name_id ) {
-      $use_transient = apply_filters( 'tc_posts_slider_use_transient', ! CZR___::$instance -> czr_is_customizing() );
+      $use_transient = apply_filters( 'tc_posts_slider_use_transient', ! CZR___::$instance -> czr_fn_is_customizing() );
       //Do not use transient when in the customizer preview (this class is not called in the customize left panel)
       $store_transient = $load_transient = $use_transient;
       // delete transient when in the customize preview
       if ( ! $use_transient )
         delete_transient( 'tc_posts_slides' );
 
-      return $this -> czr_get_the_posts_slides( $slider_name_id, $img_size, $load_transient , $store_transient );
+      return $this -> czr_fn_get_the_posts_slides( $slider_name_id, $img_size, $load_transient , $store_transient );
     }
     //if not demo or tc_posts_slider, we get slides from options
-    $all_sliders    = CZR_utils::$inst -> czr_opt( 'tc_sliders');
+    $all_sliders    = CZR_utils::$inst -> czr_fn_opt( 'tc_sliders');
     $saved_slides   = ( isset($all_sliders[$slider_name_id]) ) ? $all_sliders[$slider_name_id] : false;
 
     //if the slider not longer exists or exists but is empty, return false
-    if ( ! $this -> czr_slider_exists( $saved_slides) )
+    if ( ! $this -> czr_fn_slider_exists( $saved_slides) )
       return;
 
     //inititalize the slides array
@@ -301,7 +301,7 @@ class CZR_slider {
 
       $id                     = $slide_object -> ID;
 
-      $slide_model = $this -> czr_get_single_slide_model( $slider_name_id, $_loop_index, $id, $img_size);
+      $slide_model = $this -> czr_fn_get_single_slide_model( $slider_name_id, $_loop_index, $id, $img_size);
 
       if ( ! $slide_model )
         continue;
@@ -338,18 +338,18 @@ class CZR_slider {
   * mostly with qtranslate (polylang will force us, most likely if I don't find any
   * other suitable solution, to not use the transient).
   */
-  private function czr_get_the_posts_slides( $slider_name_id, $img_size, $load_transient = true, $store_transient = true ) {
+  private function czr_fn_get_the_posts_slides( $slider_name_id, $img_size, $load_transient = true, $store_transient = true ) {
 
     $load_transient  = apply_filters( 'tc_posts_slider_load_transient'  , $load_transient );
     $store_transient = apply_filters( 'tc_posts_slider_store_transient', $store_transient );
 
-    $pre_slides      = $this -> czr_get_pre_posts_slides( compact( 'img_size', 'load_transient', 'store_transient' ) );
+    $pre_slides      = $this -> czr_fn_get_pre_posts_slides( compact( 'img_size', 'load_transient', 'store_transient' ) );
 
     //filter the pre_model
     $pre_slides      = apply_filters( 'tc_posts_slider_pre_model', $pre_slides );
 
     //if the slider not longer exists or exists but is empty, return false
-    if ( ! $this -> czr_slider_exists( $pre_slides ) )
+    if ( ! $this -> czr_fn_slider_exists( $pre_slides ) )
       return false;
 
     //extract pre_slides model
@@ -362,7 +362,7 @@ class CZR_slider {
 
     //GENERATE SLIDES ARRAY
     foreach ( $posts as $_post_slide ) {
-      $slide_model = $this -> czr_get_single_post_slide_model( $slider_name_id, $_loop_index, $_post_slide, $common, $img_size);
+      $slide_model = $this -> czr_fn_get_single_post_slide_model( $slider_name_id, $_loop_index, $_post_slide, $common, $img_size);
 
       if ( ! $slide_model )
         continue;
@@ -400,7 +400,7 @@ class CZR_slider {
   * @since Customizr 3.4.9
   *
   */
-  private function czr_get_pre_posts_slides( $args ){
+  private function czr_fn_get_pre_posts_slides( $args ){
 
     $defaults       = array(
       'img_size'            => null,
@@ -408,12 +408,12 @@ class CZR_slider {
       'store_transient'     => true,
       'transient_name'      => 'tc_posts_slides',
       //options
-      'stickies_only'       => esc_attr( CZR_utils::$inst->czr_opt( 'tc_posts_slider_stickies' ) ),
-      'show_title'          => esc_attr( CZR_utils::$inst->czr_opt( 'tc_posts_slider_title' ) ),
-      'show_excerpt'        => esc_attr( CZR_utils::$inst->czr_opt( 'tc_posts_slider_text' ) ),
-      'button_text'         => esc_attr( CZR_utils::$inst->czr_opt( 'tc_posts_slider_button_text' ) ),
-      'limit'               => esc_attr( CZR_utils::$inst->czr_opt( 'tc_posts_slider_number' ) ),
-      'link_type'           => esc_attr( CZR_utils::$inst->czr_opt( 'tc_posts_slider_link') ),
+      'stickies_only'       => esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_posts_slider_stickies' ) ),
+      'show_title'          => esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_posts_slider_title' ) ),
+      'show_excerpt'        => esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_posts_slider_text' ) ),
+      'button_text'         => esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_posts_slider_button_text' ) ),
+      'limit'               => esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_posts_slider_number' ) ),
+      'link_type'           => esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_posts_slider_link') ),
     );
 
     $args         = apply_filters( 'tc_get_pre_posts_slides_args', wp_parse_args( $args, $defaults ) );
@@ -432,16 +432,16 @@ class CZR_slider {
       return $pre_slides;
 
     //retrieve posts from the db
-    $queried_posts    = $this -> czr_query_posts_slider( $args );
+    $queried_posts    = $this -> czr_fn_query_posts_slider( $args );
 
     if ( empty ( $queried_posts ) )
       return array();
 
     /*** tc_thumb setup filters ***/
     // remove smart load img parsing if any
-    $smart_load_enabled = 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_img_smart_load' ) );
+    $smart_load_enabled = 1 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_img_smart_load' ) );
     if ( $smart_load_enabled )
-      remove_filter( 'tc_thumb_html', array( CZR_utils::$instance, 'czr_parse_imgs') );
+      remove_filter( 'tc_thumb_html', array( CZR_utils::$instance, 'czr_fn_parse_imgs') );
 
     // prevent adding thumb inline style when no center img is added
     add_filter( 'tc_post_thumb_inline_style', '__return_empty_string', 100 );
@@ -449,13 +449,13 @@ class CZR_slider {
 
     //allow responsive images?
     if ( version_compare( $GLOBALS['wp_version'], '4.4', '>=' ) )
-      $args['slider_responsive_images'] = 0 == esc_attr( CZR_utils::$inst->czr_opt('tc_resp_slider_img') ) ? false : true ;
+      $args['slider_responsive_images'] = 0 == esc_attr( CZR_utils::$inst->czr_fn_opt('tc_resp_slider_img') ) ? false : true ;
 
     /* Get the pre_model */
     $pre_slides = $pre_slides_posts = array();
 
     foreach ( $queried_posts as $_post ) {
-      $pre_slide_model = $this ->  czr_get_single_post_slide_pre_model( $_post , $img_size, $args );
+      $pre_slide_model = $this ->  czr_fn_get_single_post_slide_pre_model( $_post , $img_size, $args );
 
       if ( ! $pre_slide_model )
         continue;
@@ -466,7 +466,7 @@ class CZR_slider {
     /* tc_thumb reset filters */
     // re-add smart load parsing if removed
     if ( $smart_load_enabled )
-      add_filter('tc_thumb_html', array(CZR_utils::$instance, 'czr_parse_imgs') );
+      add_filter('tc_thumb_html', array(CZR_utils::$instance, 'czr_fn_parse_imgs') );
     // remove thumb style reset
     remove_filter( 'tc_post_thumb_inline_style', '__return_empty_string', 100 );
     /* end tc_thumb reset filters */
@@ -477,7 +477,7 @@ class CZR_slider {
       // button and link whole slide
       // has button to be displayed?
       if ( strstr($link_type, 'cta') )
-        $button_text            = $this -> czr_get_post_slide_button_text( $button_text );
+        $button_text            = $this -> czr_fn_get_post_slide_button_text( $button_text );
       else
         $button_text            = '';
 
@@ -508,24 +508,24 @@ class CZR_slider {
   * @since Customizr 3.3+
   *
   */
-  private function czr_get_slider_model() {
+  private function czr_fn_get_slider_model() {
     //Do we have a slider to display in this context ?
-    if ( ! $this -> czr_is_slider_possible() )
+    if ( ! $this -> czr_fn_is_slider_possible() )
       return array();
 
     //gets the actual page id if we are displaying the posts page
-    $queried_id                   = $this -> czr_get_real_id();
+    $queried_id                   = $this -> czr_fn_get_real_id();
 
-    $slider_name_id               = $this -> czr_get_current_slider( $queried_id );
+    $slider_name_id               = $this -> czr_fn_get_current_slider( $queried_id );
 
-    if ( ! $this -> czr_is_slider_active( $queried_id) )
+    if ( ! $this -> czr_fn_is_slider_active( $queried_id) )
       return array();
 
     if ( ! empty( self::$sliders_model ) && is_array( self::$sliders_model ) && array_key_exists( $slider_name_id, self::$sliders_model ) )
       return self::$sliders_model[ $slider_name_id ];
 
     //gets slider options if any
-    $layout_value                 = czr__f('__is_home') ? CZR_utils::$inst->czr_opt( 'tc_slider_width' ) : esc_attr(get_post_meta( $queried_id, $key = 'slider_layout_key' , $single = true ));
+    $layout_value                 = czr_fn__f('__is_home') ? CZR_utils::$inst->czr_fn_opt( 'tc_slider_width' ) : esc_attr(get_post_meta( $queried_id, $key = 'slider_layout_key' , $single = true ));
     $layout_value                 = apply_filters( 'tc_slider_layout', $layout_value, $queried_id );
 
     //declares the layout vars
@@ -533,7 +533,7 @@ class CZR_slider {
     $img_size                     = apply_filters( 'tc_slider_img_size' , ( 0 == $layout_value ) ? 'slider' : 'slider-full');
 
     //get slides
-    $slides                       = $this -> czr_get_the_slides( $slider_name_id , $img_size );
+    $slides                       = $this -> czr_fn_get_the_slides( $slider_name_id , $img_size );
 
     //store the model per slider_name_id
     self::$sliders_model[ $slider_name_id ] = compact( "slider_name_id", "slides", "layout_class" , "img_size" );
@@ -552,7 +552,7 @@ class CZR_slider {
   * @since Customizr 3.4.9
   *
   */
-  private function czr_query_posts_slider( $args = array() ) {
+  private function czr_fn_query_posts_slider( $args = array() ) {
     global $wpdb;
 
     $defaults       = array(
@@ -601,7 +601,7 @@ class CZR_slider {
 
     $sql = sprintf( 'SELECT DISTINCT %1$s FROM ( %2$s ) as posts %3$s %4$s ORDER BY %5$s LIMIT %6$s OFFSET %7$s',
              apply_filters( 'tc_query_posts_slider_columns', $columns, $args ),
-             $this -> czr_get_posts_have_tc_thumb_sql(
+             $this -> czr_fn_get_posts_have_tc_thumb_sql(
                apply_filters( 'tc_query_posts_slider_columns', $columns, $args ),
                apply_filters( 'tc_query_posts_slide_thumbnail_where', $pt_where, $args ),
                apply_filters( 'tc_query_posts_slider_attachment_where', $pa_where, $args )
@@ -616,7 +616,7 @@ class CZR_slider {
     $sql = apply_filters( 'tc_query_posts_slider_sql', $sql, $args );
 
     $_posts = $wpdb->get_results( $sql );
-    return apply_filters( 'czr_query_posts_slider', $_posts, $args );
+    return apply_filters( 'czr_fn_query_posts_slider', $_posts, $args );
   }
 
 
@@ -629,10 +629,10 @@ class CZR_slider {
   * @since Customizr 3.4.9
   *
   */
-  private function czr_get_posts_have_tc_thumb_sql( $_columns, $_pt_where = '', $_pa_where = '' ) {
-    return apply_filters( 'czr_get_posts_have_tc_thumb_sql', sprintf( '%1$s UNION %2$s',
-        $this -> czr_get_posts_have_thumbnail_sql( $_columns, $_pt_where ),
-        $this -> czr_get_posts_have_attachment_sql( $_columns, $_pa_where )
+  private function czr_fn_get_posts_have_tc_thumb_sql( $_columns, $_pt_where = '', $_pa_where = '' ) {
+    return apply_filters( 'czr_fn_get_posts_have_tc_thumb_sql', sprintf( '%1$s UNION %2$s',
+        $this -> czr_fn_get_posts_have_thumbnail_sql( $_columns, $_pt_where ),
+        $this -> czr_fn_get_posts_have_attachment_sql( $_columns, $_pa_where )
     ));
   }
 
@@ -644,9 +644,9 @@ class CZR_slider {
   * @since Customizr 3.4.9
   *
   */
-  private function czr_get_posts_have_thumbnail_sql( $_columns, $_where = '' ) {
+  private function czr_fn_get_posts_have_thumbnail_sql( $_columns, $_where = '' ) {
     global $wpdb;
-    return apply_filters( 'czr_get_posts_have_thumbnail_sql', "
+    return apply_filters( 'czr_fn_get_posts_have_thumbnail_sql', "
         SELECT $_columns
         FROM $wpdb->posts AS posts INNER JOIN $wpdb->postmeta AS metas
         ON posts.ID=metas.post_id
@@ -662,9 +662,9 @@ class CZR_slider {
   * @since Customizr 3.4.9
   *
   */
-  private function czr_get_posts_have_attachment_sql( $_columns, $_where = '' ) {
+  private function czr_fn_get_posts_have_attachment_sql( $_columns, $_where = '' ) {
     global $wpdb;
-    return apply_filters( 'czr_get_posts_have_attachment_sql', "
+    return apply_filters( 'czr_fn_get_posts_have_attachment_sql', "
         SELECT $_columns FROM $wpdb->posts attachments, $wpdb->posts posts
         WHERE $_where
     ");
@@ -685,10 +685,10 @@ class CZR_slider {
   * @since Customizr 1.0
   *
   */
-  function czr_slider_display() {
+  function czr_fn_slider_display() {
     //get slides model
     //extract $slider_name_id, $slides, $layout_class, $img_size
-    extract( $this -> czr_get_slider_model() );
+    extract( $this -> czr_fn_get_slider_model() );
     //returns nothing if no slides to display
     if ( ! isset($slides) || ! $slides )
       return;
@@ -702,7 +702,7 @@ class CZR_slider {
     ?>
     <div id="customizr-slider-<?php echo self::$rendered_sliders ?>" class="<?php echo $layout_class ?> ">
 
-      <?php $this -> czr_render_slider_loader_view( $slider_name_id ); ?>
+      <?php $this -> czr_fn_render_slider_loader_view( $slider_name_id ); ?>
 
       <?php do_action( '__before_carousel_inner' , $slides, $slider_name_id )  ?>
 
@@ -710,7 +710,7 @@ class CZR_slider {
         <?php
           foreach ($slides as $id => $data) {
             $_view_model = compact( "id", "data" , "slider_name_id", "img_size" );
-            $this -> czr_render_single_slide_view( $_view_model );
+            $this -> czr_fn_render_single_slide_view( $_view_model );
           }
         ?>
       </div><!-- /.carousel-inner -->
@@ -722,7 +722,7 @@ class CZR_slider {
     <?php
     $html = ob_get_contents();
     if ($html) ob_end_clean();
-    echo apply_filters( 'czr_slider_display', $html, $slider_name_id );
+    echo apply_filters( 'czr_fn_slider_display', $html, $slider_name_id );
   }
 
 
@@ -736,7 +736,7 @@ class CZR_slider {
   * @since Customizr 3.3+
   *
   */
-  function czr_render_single_slide_view( $_view_model ) {
+  function czr_fn_render_single_slide_view( $_view_model ) {
     //extract $_view_model = array( $id, $data , $slider_name_id, $img_size )
     extract( $_view_model );
 
@@ -744,9 +744,9 @@ class CZR_slider {
     ?>
     <div class="<?php echo $slide_classes; ?>">
       <?php
-        $this -> czr_render_slide_background_view( $_view_model );
-        $this -> czr_render_slide_caption_view( $_view_model );
-        $this -> czr_render_slide_edit_link_view( $_view_model );
+        $this -> czr_fn_render_slide_background_view( $_view_model );
+        $this -> czr_fn_render_slide_caption_view( $_view_model );
+        $this -> czr_fn_render_slide_edit_link_view( $_view_model );
       ?>
     </div><!-- /.item -->
     <?php
@@ -762,8 +762,8 @@ class CZR_slider {
   * @since Customizr 3.3+
   *
   */
-  function czr_render_slider_loader_view( $slider_name_id ) {
-    if ( ! $this -> czr_is_slider_loader_active( $slider_name_id ) )
+  function czr_fn_render_slider_loader_view( $slider_name_id ) {
+    if ( ! $this -> czr_fn_is_slider_loader_active( $slider_name_id ) )
       return;
 
     if ( ! apply_filters( 'tc_slider_loader_gif_only', false ) )
@@ -795,7 +795,7 @@ class CZR_slider {
   * @since Customizr 3.3+
   *
   */
-  function czr_render_slide_background_view( $_view_model ) {
+  function czr_fn_render_slide_background_view( $_view_model ) {
     //extract $_view_model = array( $id, $data , $slider_name_id, $img_size )
     extract( $_view_model );
     ?>
@@ -822,7 +822,7 @@ class CZR_slider {
   * @since Customizr 3.3+
   *
   */
-  function czr_link_whole_slide( $slide_background, $link_url, $id, $slider_name_id, $data ) {
+  function czr_fn_link_whole_slide( $slide_background, $link_url, $id, $slider_name_id, $data ) {
     if ( isset( $data['link_whole_slide'] )  && $data['link_whole_slide'] && $link_url )
       $slide_background = sprintf('<a href="%1$s" class="tc-slide-link" target="%2$s" title="%3$s">%4$s</a>',
                                 $link_url,
@@ -841,7 +841,7 @@ class CZR_slider {
   * @since Customizr 3.3+
   *
   */
-  function czr_render_slide_caption_view( $_view_model ) {
+  function czr_fn_render_slide_caption_view( $_view_model ) {
     //extract $_view_model = array( $id, $data , $slider_name_id, $img_size )
     extract( $_view_model );
     //filters the data before (=> used for demo for example )
@@ -898,9 +898,9 @@ class CZR_slider {
   * @since Customizr 3.3+
   *
   */
-  function czr_render_slide_edit_link_view( $_view_model ) {
+  function czr_fn_render_slide_edit_link_view( $_view_model ) {
     //never display when customizing
-    if ( CZR___::$instance -> czr_is_customizing() )
+    if ( CZR___::$instance -> czr_fn_is_customizing() )
       return;
     //extract $_view_model = array( $id, $data , $slider_name_id, $img_size )
     extract( $_view_model );
@@ -933,9 +933,9 @@ class CZR_slider {
   * @since v3.4.9
   */
 
-  function czr_render_slider_edit_link_view( $slides, $slider_name_id ) {
+  function czr_fn_render_slider_edit_link_view( $slides, $slider_name_id ) {
     //never display when customizing
-    if ( CZR___::$instance -> czr_is_customizing() )
+    if ( CZR___::$instance -> czr_fn_is_customizing() )
       return;
     if ( 'demo' == $slider_name_id )
       return;
@@ -945,9 +945,9 @@ class CZR_slider {
     //We have to show the slider edit link to
     //a) users who can edit theme options for the slider in home -> deep link in the customizer
     //b) users who can edit the post/page where the slider is displayed for users who can edit the post/page -> deep link in the post/page slider section
-    if ( czr__f('__is_home') ){
+    if ( czr_fn__f('__is_home') ){
       $show_slider_edit_link = ( is_user_logged_in() && current_user_can('edit_theme_options') ) ? true : false;
-      $_edit_link            = CZR_utils::czr_get_customizer_url( array( 'control' => 'tc_front_slider', 'section' => 'frontpage_sec') );
+      $_edit_link            = CZR_utils::czr_fn_get_customizer_url( array( 'control' => 'tc_front_slider', 'section' => 'frontpage_sec') );
     }else if ( is_singular() ){ // we have a snippet to display sliders in categories, we don't want the slider edit link displayed there
       global $post;
       $show_slider_edit_link = ( is_user_logged_in() && ( current_user_can('edit_pages') || current_user_can( 'edit_posts', $post -> ID ) ) ) ? true : false;
@@ -976,7 +976,7 @@ class CZR_slider {
   * @since v3.2.0
   *
   */
-  function czr_slider_control_view( $_slides ) {
+  function czr_fn_slider_control_view( $_slides ) {
     if ( count( $_slides ) <= 1 )
       return;
 
@@ -998,7 +998,7 @@ class CZR_slider {
         self::$rendered_sliders
       )
     );
-    echo apply_filters( 'czr_slider_control_view', $_html );
+    echo apply_filters( 'czr_fn_slider_control_view', $_html );
   }
 
 
@@ -1009,10 +1009,10 @@ class CZR_slider {
   * hook : __after_carousel_inner
   * @since v3.4+
   */
-  function czr_maybe_display_dismiss_notice() {
-    if ( ! CZR_placeholders::czr_is_slider_notice_on() )
+  function czr_fn_maybe_display_dismiss_notice() {
+    if ( ! CZR_placeholders::czr_fn_is_slider_notice_on() )
       return;
-    $_customizer_lnk = CZR_utils::czr_get_customizer_url( array( 'control' => 'tc_front_slider', 'section' => 'frontpage_sec') );
+    $_customizer_lnk = CZR_utils::czr_fn_get_customizer_url( array( 'control' => 'tc_front_slider', 'section' => 'frontpage_sec') );
     ?>
     <div class="tc-placeholder-wrap tc-slider-notice">
       <?php
@@ -1039,17 +1039,17 @@ class CZR_slider {
   *******************************/
   //hook : wp
   //introduced in v3.4.23
-  function czr_maybe_setup_parallax() {
-    if ( 1 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_slider_parallax') ) )
+  function czr_fn_maybe_setup_parallax() {
+    if ( 1 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_slider_parallax') ) )
       return;
-    add_filter('tc_slider_layout_class'     , array( $this, 'czr_add_parallax_wrapper_class' ) );
-    add_filter('tc_carousel_inner_classes'  , array( $this, 'czr_add_parallax_item_class' ) );
-    add_action('wp_head'                    , array( $this, 'czr_add_parallax_slider_script' ) );
+    add_filter('tc_slider_layout_class'     , array( $this, 'czr_fn_add_parallax_wrapper_class' ) );
+    add_filter('tc_carousel_inner_classes'  , array( $this, 'czr_fn_add_parallax_item_class' ) );
+    add_action('wp_head'                    , array( $this, 'czr_fn_add_parallax_slider_script' ) );
   }
 
 
   //hook : wp_head
-  function czr_add_parallax_slider_script() {
+  function czr_fn_add_parallax_slider_script() {
     ?>
       <script type="text/javascript" id="do-parallax-sliders">
         jQuery( function($){
@@ -1060,13 +1060,13 @@ class CZR_slider {
   }
 
   //hook : tc_carousel_inner_classes
-  function czr_add_parallax_item_class ( $classes ) {
+  function czr_fn_add_parallax_item_class ( $classes ) {
     array_push($classes, 'czr-parallax-slider' );
     return $classes;
   }
 
   //hook : tc_slider_layout_class
-  function czr_add_parallax_wrapper_class( $classes ) {
+  function czr_fn_add_parallax_wrapper_class( $classes ) {
     array_push($classes, 'parallax-wrapper' );
     return $classes;
   }
@@ -1087,7 +1087,7 @@ class CZR_slider {
   * @since Customizr 3.3.+
   *
   */
-  function czr_set_demo_slide_data( $data, $slider_name_id, $id ) {
+  function czr_fn_set_demo_slide_data( $data, $slider_name_id, $id ) {
     if ( 'demo' != $slider_name_id || ! is_user_logged_in() )
       return $data;
 
@@ -1119,11 +1119,11 @@ class CZR_slider {
   * @since Customizr 3.3+
   *
   */
-  private function czr_is_slider_possible() {
+  private function czr_fn_is_slider_possible() {
     //gets the front slider if any
-    $tc_front_slider              = esc_attr(CZR_utils::$inst->czr_opt( 'tc_front_slider' ) );
+    $tc_front_slider              = esc_attr(CZR_utils::$inst->czr_fn_opt( 'tc_front_slider' ) );
     //when do we display a slider? By default only for home (if a slider is defined), pages and posts (including custom post types)
-    $_show_slider = czr__f('__is_home') ? ! empty( $tc_front_slider ) : ! is_404() && ! is_archive() && ! is_search();
+    $_show_slider = czr_fn__f('__is_home') ? ! empty( $tc_front_slider ) : ! is_404() && ! is_archive() && ! is_search();
 
     return apply_filters( 'tc_show_slider' , $_show_slider );
   }
@@ -1136,7 +1136,7 @@ class CZR_slider {
   * @package Customizr
   * @since Customizr 3.4.9
   */
-  function czr_slider_exists( $slider ){
+  function czr_fn_slider_exists( $slider ){
     //if the slider not longer exists or exists but is empty, return false
     return ! ( !isset($slider) || !is_array($slider) || empty($slider) );
   }
@@ -1148,10 +1148,10 @@ class CZR_slider {
   * @return  string
   *
   */
-  private function czr_get_current_slider($queried_id) {
+  private function czr_fn_get_current_slider($queried_id) {
     //gets the current slider id
-    $_home_slider     = CZR_utils::$inst->czr_opt( 'tc_front_slider' );
-    $slider_name_id   = ( czr__f('__is_home') && $_home_slider ) ? $_home_slider : esc_attr( get_post_meta( $queried_id, $key = 'post_slider_key' , $single = true ) );
+    $_home_slider     = CZR_utils::$inst->czr_fn_opt( 'tc_front_slider' );
+    $slider_name_id   = ( czr_fn__f('__is_home') && $_home_slider ) ? $_home_slider : esc_attr( get_post_meta( $queried_id, $key = 'post_slider_key' , $single = true ) );
     return apply_filters( 'tc_slider_name_id', $slider_name_id , $queried_id);
   }
 
@@ -1162,10 +1162,10 @@ class CZR_slider {
   * @return  number
   *
   */
-  private function czr_get_real_id() {
+  private function czr_fn_get_real_id() {
     global $wp_query;
     $queried_id                   = get_queried_object_id();
-    return apply_filters( 'tc_slider_get_real_id', ( ! czr__f('__is_home') && $wp_query -> is_posts_page && ! empty($queried_id) ) ?  $queried_id : get_the_ID() );
+    return apply_filters( 'tc_slider_get_real_id', ( ! czr_fn__f('__is_home') && $wp_query -> is_posts_page && ! empty($queried_id) ) ?  $queried_id : get_the_ID() );
   }
 
 
@@ -1175,9 +1175,9 @@ class CZR_slider {
   * @return  boolean
   *
   */
-  private function czr_is_slider_active( $queried_id ) {
+  private function czr_fn_is_slider_active( $queried_id ) {
     //is the slider set to on for the queried id?
-    if ( czr__f('__is_home') && CZR_utils::$inst->czr_opt( 'tc_front_slider' ) )
+    if ( czr_fn__f('__is_home') && CZR_utils::$inst->czr_fn_opt( 'tc_front_slider' ) )
       return apply_filters( 'tc_slider_active_status', true , $queried_id );
 
     $_slider_on = esc_attr( get_post_meta( $queried_id, $key = 'post_slider_check_key' , $single = true ) );
@@ -1193,12 +1193,12 @@ class CZR_slider {
   * @return  boolean
   *
   */
-  private function czr_is_slider_loader_active( $slider_name_id ) {
+  private function czr_fn_is_slider_loader_active( $slider_name_id ) {
     //The slider loader must be printed when
     //a) we have to render the demo slider
     //b) display slider loading option is enabled (can be filtered)
     return ( 'demo' == $slider_name_id
-        || apply_filters( 'tc_display_slider_loader', 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_display_slide_loader') ), $slider_name_id )
+        || apply_filters( 'tc_display_slider_loader', 1 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_display_slide_loader') ), $slider_name_id )
     );
   }
 
@@ -1210,22 +1210,22 @@ class CZR_slider {
   * @package Customizr
   * @since Customizr 3.3+
   */
-  function czr_set_demo_slider_height( $_h ) {
+  function czr_fn_set_demo_slider_height( $_h ) {
     //this custom demo height is applied when :
     //1) current slider is demo
-    if ( 'demo' != $this -> czr_get_current_slider( $this -> czr_get_real_id() ) )
+    if ( 'demo' != $this -> czr_fn_get_current_slider( $this -> czr_fn_get_real_id() ) )
       return $_h;
 
     //2) height option has not been changed by user yet
     //the possible customization context must be taken into account here
-    if ( CZR___::$instance -> czr_is_customizing() ) {
-      if ( 500 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_slider_default_height') ) )
+    if ( CZR___::$instance -> czr_fn_is_customizing() ) {
+      if ( 500 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_slider_default_height') ) )
         return $_h;
     } else {
-      if ( false !== (bool) esc_attr( CZR_utils::$inst->czr_opt( 'tc_slider_default_height', CZR___::$tc_option_group, $use_default = false ) ) )
+      if ( false !== (bool) esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_slider_default_height', CZR___::$tc_option_group, $use_default = false ) ) )
         return $_h;
     }
-    return apply_filters( 'czr_set_demo_slider_height' , 750 );
+    return apply_filters( 'czr_fn_set_demo_slider_height' , 750 );
   }
 
 
@@ -1236,9 +1236,9 @@ class CZR_slider {
   * @package Customizr
   * @since Customizr 3.2.6
   */
-  function czr_write_slider_inline_css( $_css ) {
+  function czr_fn_write_slider_inline_css( $_css ) {
     //custom css for the slider loader
-    if ( $this -> czr_is_slider_loader_active( $this -> czr_get_current_slider( $this -> czr_get_real_id() ) ) ) {
+    if ( $this -> czr_fn_is_slider_loader_active( $this -> czr_fn_get_current_slider( $this -> czr_fn_get_real_id() ) ) ) {
 
       $_slider_loader_src = apply_filters( 'tc_slider_loader_src' , sprintf( '%1$s/%2$s' , TC_BASE_URL , 'inc/assets/img/slider-loader.gif') );
       //we can load only the gif, or use it as fallback for old browsers (.no-csstransforms3d)
@@ -1247,7 +1247,7 @@ class CZR_slider {
         // The pure css loader color depends on the skin. Why can we do this here without caring of the live preview?
         // Basically 'cause the loader is something we see when the page "loads" then it disappears so a live change of the skin
         // will still have no visive impact on it. This will avoid us to rebuild the custom skins.
-        $_current_skin_colors      = CZR_utils::$inst -> czr_get_skin_color( 'pair' );
+        $_current_skin_colors      = CZR_utils::$inst -> czr_fn_get_skin_color( 'pair' );
         $_pure_css_loader_css      = apply_filters( 'tc_slider_loader_css', sprintf(
             '.tc-slider-loader-wrapper .tc-css-loader > div { border-color:%s; }',
             //we can use the primary or the secondary skin color
@@ -1273,12 +1273,12 @@ class CZR_slider {
 
     // 1) Do we have a custom height ?
     // 2) check if the setting must be applied to all context
-    $_custom_height     = apply_filters( 'tc_slider_height' , esc_attr( CZR_utils::$inst->czr_opt( 'tc_slider_default_height') ) );
+    $_custom_height     = apply_filters( 'tc_slider_height' , esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_slider_default_height') ) );
     $_slider_inline_css = "";
 
     //When shall we append custom slider style to the global custom inline stylesheet?
     $_bool = 500 != $_custom_height;
-    $_bool = $_bool && ( czr__f('__is_home') || 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_slider_default_height_apply_all') ) );
+    $_bool = $_bool && ( czr_fn__f('__is_home') || 0 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_slider_default_height_apply_all') ) );
 
     if ( ! apply_filters( 'tc_print_slider_inline_css' , $_bool ) )
       return $_css;
@@ -1338,8 +1338,8 @@ class CZR_slider {
   * @since Customizr 3.2.0
   *
   */
-  function czr_set_slider_wrapper_class($_classes) {
-    if ( ! is_array($_classes) || 500 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_slider_default_height') ) )
+  function czr_fn_set_slider_wrapper_class($_classes) {
+    if ( ! is_array($_classes) || 500 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_slider_default_height') ) )
       return $_classes;
 
     return array_merge( $_classes , array('custom-slider-height') );
@@ -1353,8 +1353,8 @@ class CZR_slider {
   * @package Customizr
   * @since Customizr 3.3+
   */
-  function czr_set_inner_class( $_classes ) {
-    if( ! (bool) esc_attr( CZR_utils::$inst->czr_opt( 'tc_center_slider_img') ) || ! is_array($_classes) )
+  function czr_fn_set_inner_class( $_classes ) {
+    if( ! (bool) esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_center_slider_img') ) || ! is_array($_classes) )
       return $_classes;
     array_push( $_classes, 'center-slides-enabled' );
     return $_classes;
@@ -1367,15 +1367,15 @@ class CZR_slider {
   * @package Customizr
   * @since Customizr 3.4.9
   */
-  function czr_cache_posts_slider( $args = array() ) {
+  function czr_fn_cache_posts_slider( $args = array() ) {
     $defaults = array (
       //use the home slider_width
-      'img_size'        => 1 == CZR_utils::$inst->czr_opt( 'tc_slider_width' ) ? 'slider-full' : 'slider',
+      'img_size'        => 1 == CZR_utils::$inst->czr_fn_opt( 'tc_slider_width' ) ? 'slider-full' : 'slider',
       'load_transient'  => false,
       'store_transient' => true,
       'transient_name'  => 'tc_posts_slides'
     );
-    $this -> czr_get_pre_posts_slides( wp_parse_args( $args, $defaults) );
+    $this -> czr_fn_get_pre_posts_slides( wp_parse_args( $args, $defaults) );
   }
 
 
@@ -1390,10 +1390,10 @@ class CZR_slider {
   * @since Customizr 3.4.9
   *
   */
-  function czr_get_post_slide_title( $_post, $ID ) {
+  function czr_fn_get_post_slide_title( $_post, $ID ) {
     $title_length   = apply_filters('tc_post_slide_title_length', 80, $ID );
     $more           = apply_filters('tc_post_slide_more', '...', $ID );
-    return $this -> czr_get_post_title( $_post, $title_length, $more );
+    return $this -> czr_fn_get_post_title( $_post, $title_length, $more );
   }
 
 
@@ -1407,10 +1407,10 @@ class CZR_slider {
   * @since Customizr 3.4.9
   *
   */
-  function czr_get_post_slide_excerpt( $_post, $ID ) {
+  function czr_fn_get_post_slide_excerpt( $_post, $ID ) {
     $excerpt_length  = apply_filters( 'tc_post_slide_text_length', 80, $ID );
     $more            = apply_filters( 'tc_post_slide_more', '...', $ID );
-    return $this -> czr_get_post_excerpt( $_post, $excerpt_length, $more );
+    return $this -> czr_fn_get_post_excerpt( $_post, $excerpt_length, $more );
   }
 
   /**
@@ -1423,11 +1423,11 @@ class CZR_slider {
   * @since Customizr 3.4.9
   *
   */
-  function czr_get_post_slide_button_text( $button_text ) {
+  function czr_fn_get_post_slide_button_text( $button_text ) {
     $button_text_length  = apply_filters( 'tc_posts_slider_button_text_length', 80 );
     $more                = apply_filters( 'tc_post_slide_more', '...');
     $button_text         = apply_filters( 'tc_posts_slider_button_text_pre_trim' , $button_text );
-    return $this -> czr_trim_text( $button_text, $button_text_length, $more );
+    return $this -> czr_fn_trim_text( $button_text, $button_text_length, $more );
   }
 
   /**
@@ -1444,7 +1444,7 @@ class CZR_slider {
   *
   */
   // move this into CZR_utils?
-  function czr_get_post_title( $_post, $default_title_length, $more ) {
+  function czr_fn_get_post_title( $_post, $default_title_length, $more ) {
     $title = $_post->post_title;
     if ( ! empty( $_post->post_password ) ) {
       $protected_title_format = apply_filters( 'protected_title_format', __( 'Protected: %s', 'customizr' ), $_post);
@@ -1452,7 +1452,7 @@ class CZR_slider {
     }
 
     $title = apply_filters( 'tc_post_title_pre_trim' , $title );
-    return $this -> czr_trim_text( $title, $default_title_length, $more);
+    return $this -> czr_fn_trim_text( $title, $default_title_length, $more);
   }
 
 
@@ -1470,7 +1470,7 @@ class CZR_slider {
   *
   */
   // move this into CZR_utils?
-  function czr_get_post_excerpt( $_post, $default_text_length, $more ) {
+  function czr_fn_get_post_excerpt( $_post, $default_text_length, $more ) {
     if ( ! empty( $_post->post_password) )
       return __( 'There is no excerpt because this is a protected post.', 'customizr' );
 
@@ -1488,7 +1488,7 @@ class CZR_slider {
     $excerpt = str_replace(']]>', ']]&gt;', $excerpt );
 
     $excerpt = apply_filters( 'tc_post_excerpt_pre_trim' , $excerpt );
-    return $this -> czr_trim_text( $excerpt, $default_text_length, $more);
+    return $this -> czr_fn_trim_text( $excerpt, $default_text_length, $more);
   }
 
 
@@ -1504,7 +1504,7 @@ class CZR_slider {
   *
   */
   // move this into CZR_utils?
-  function czr_trim_text( $text, $text_length, $more ) {
+  function czr_fn_trim_text( $text, $text_length, $more ) {
     if ( ! $text )
       return '';
 

--- a/inc/parts/class-content-slider.php
+++ b/inc/parts/class-content-slider.php
@@ -20,17 +20,17 @@ class CZR_slider {
 
   function __construct () {
     self::$instance =& $this;
-    add_action( 'wp'                       , array( $this, 'tc_maybe_setup_parallax' ) );
-    add_action( 'template_redirect'        , array( $this, 'tc_set_slider_hooks' ) );
+    add_action( 'wp'                       , array( $this, 'czr_maybe_setup_parallax' ) );
+    add_action( 'template_redirect'        , array( $this, 'czr_set_slider_hooks' ) );
     //set user customizer options. @since v3.2.0
-    add_filter( 'tc_slider_layout_class'   , array( $this , 'tc_set_slider_wrapper_class' ) );
+    add_filter( 'tc_slider_layout_class'   , array( $this , 'czr_set_slider_wrapper_class' ) );
     //! tc_user_options_style filter is shared by several classes => must always check the local context inside the callback before appending new css
     //fired on hook : wp_enqueue_scripts
     //Set thumbnail specific design based on user options
     //Set user defined height
-    add_filter( 'tc_user_options_style'    , array( $this , 'tc_write_slider_inline_css' ) );
+    add_filter( 'tc_user_options_style'    , array( $this , 'czr_write_slider_inline_css' ) );
     //tc_slider_height is fired in CZR_slider::czr_write_slider_inline_css()
-    add_filter( 'tc_slider_height'         , array( $this, 'tc_set_demo_slider_height') );
+    add_filter( 'tc_slider_height'         , array( $this, 'czr_set_demo_slider_height') );
   }//end of construct
 
 
@@ -52,26 +52,26 @@ class CZR_slider {
     if ( ! isset($slides) || ! $slides )
       return;
 
-    add_action( '__after_header'            , array( $this , 'tc_slider_display' ) );
-    add_action( '__after_carousel_inner'    , array( $this , 'tc_slider_control_view' ) );
+    add_action( '__after_header'            , array( $this , 'czr_slider_display' ) );
+    add_action( '__after_carousel_inner'    , array( $this , 'czr_slider_control_view' ) );
 
     //adds the center-slides-enabled css class
-    add_filter( 'tc_carousel_inner_classes' , array( $this, 'tc_set_inner_class') );
+    add_filter( 'tc_carousel_inner_classes' , array( $this, 'czr_set_inner_class') );
 
     //adds infos in the caption data of the demo slider
-    add_filter( 'tc_slide_caption_data'     , array( $this, 'tc_set_demo_slide_data'), 10, 3 );
+    add_filter( 'tc_slide_caption_data'     , array( $this, 'czr_set_demo_slide_data'), 10, 3 );
 
     //wrap the slide into a link
-    add_filter( 'tc_slide_background'       , array( $this, 'tc_link_whole_slide'), 5, 5 );
+    add_filter( 'tc_slide_background'       , array( $this, 'czr_link_whole_slide'), 5, 5 );
 
     //display a notice for first time users
     if ( 'demo' == $slider_name_id ) {
       //display a notice for first time users
-      add_action( '__after_carousel_inner'   , array( $this, 'tc_maybe_display_dismiss_notice') );
+      add_action( '__after_carousel_inner'   , array( $this, 'czr_maybe_display_dismiss_notice') );
     }
 
     //display an edit deep link to the Slider section in the Customize or post/page
-    add_action( '__after_carousel_inner'    , array( $this, 'tc_render_slider_edit_link_view'), 10, 2 );
+    add_action( '__after_carousel_inner'    , array( $this, 'czr_render_slider_edit_link_view'), 10, 2 );
   }
 
   /******************************
@@ -145,7 +145,7 @@ class CZR_slider {
         //we'll see an empty ( or " " depending on the browser ) srcset attribute in the html
         //to avoid this we filter the attributes getting rid of the srcset if any.
         //Basically this trick, even if ugly, will avoid the srcset attr computation
-        add_filter( 'wp_get_attachment_image_attributes', array( CZR_post_thumbnails::$instance, 'tc_remove_srcset_attr' ) );
+        add_filter( 'wp_get_attachment_image_attributes', array( CZR_post_thumbnails::$instance, 'czr_remove_srcset_attr' ) );
       }
     $slide_background       = wp_get_attachment_image( $id, $img_size, false, $slide_background_attr );
 
@@ -441,7 +441,7 @@ class CZR_slider {
     // remove smart load img parsing if any
     $smart_load_enabled = 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_img_smart_load' ) );
     if ( $smart_load_enabled )
-      remove_filter( 'tc_thumb_html', array( CZR_utils::$instance, 'tc_parse_imgs') );
+      remove_filter( 'tc_thumb_html', array( CZR_utils::$instance, 'czr_parse_imgs') );
 
     // prevent adding thumb inline style when no center img is added
     add_filter( 'tc_post_thumb_inline_style', '__return_empty_string', 100 );
@@ -466,7 +466,7 @@ class CZR_slider {
     /* tc_thumb reset filters */
     // re-add smart load parsing if removed
     if ( $smart_load_enabled )
-      add_filter('tc_thumb_html', array(CZR_utils::$instance, 'tc_parse_imgs') );
+      add_filter('tc_thumb_html', array(CZR_utils::$instance, 'czr_parse_imgs') );
     // remove thumb style reset
     remove_filter( 'tc_post_thumb_inline_style', '__return_empty_string', 100 );
     /* end tc_thumb reset filters */
@@ -616,7 +616,7 @@ class CZR_slider {
     $sql = apply_filters( 'tc_query_posts_slider_sql', $sql, $args );
 
     $_posts = $wpdb->get_results( $sql );
-    return apply_filters( 'tc_query_posts_slider', $_posts, $args );
+    return apply_filters( 'czr_query_posts_slider', $_posts, $args );
   }
 
 
@@ -630,7 +630,7 @@ class CZR_slider {
   *
   */
   private function czr_get_posts_have_tc_thumb_sql( $_columns, $_pt_where = '', $_pa_where = '' ) {
-    return apply_filters( 'tc_get_posts_have_tc_thumb_sql', sprintf( '%1$s UNION %2$s',
+    return apply_filters( 'czr_get_posts_have_tc_thumb_sql', sprintf( '%1$s UNION %2$s',
         $this -> czr_get_posts_have_thumbnail_sql( $_columns, $_pt_where ),
         $this -> czr_get_posts_have_attachment_sql( $_columns, $_pa_where )
     ));
@@ -646,7 +646,7 @@ class CZR_slider {
   */
   private function czr_get_posts_have_thumbnail_sql( $_columns, $_where = '' ) {
     global $wpdb;
-    return apply_filters( 'tc_get_posts_have_thumbnail_sql', "
+    return apply_filters( 'czr_get_posts_have_thumbnail_sql', "
         SELECT $_columns
         FROM $wpdb->posts AS posts INNER JOIN $wpdb->postmeta AS metas
         ON posts.ID=metas.post_id
@@ -664,7 +664,7 @@ class CZR_slider {
   */
   private function czr_get_posts_have_attachment_sql( $_columns, $_where = '' ) {
     global $wpdb;
-    return apply_filters( 'tc_get_posts_have_attachment_sql', "
+    return apply_filters( 'czr_get_posts_have_attachment_sql', "
         SELECT $_columns FROM $wpdb->posts attachments, $wpdb->posts posts
         WHERE $_where
     ");
@@ -722,7 +722,7 @@ class CZR_slider {
     <?php
     $html = ob_get_contents();
     if ($html) ob_end_clean();
-    echo apply_filters( 'tc_slider_display', $html, $slider_name_id );
+    echo apply_filters( 'czr_slider_display', $html, $slider_name_id );
   }
 
 
@@ -998,7 +998,7 @@ class CZR_slider {
         self::$rendered_sliders
       )
     );
-    echo apply_filters( 'tc_slider_control_view', $_html );
+    echo apply_filters( 'czr_slider_control_view', $_html );
   }
 
 
@@ -1042,9 +1042,9 @@ class CZR_slider {
   function czr_maybe_setup_parallax() {
     if ( 1 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_slider_parallax') ) )
       return;
-    add_filter('tc_slider_layout_class'     , array( $this, 'tc_add_parallax_wrapper_class' ) );
-    add_filter('tc_carousel_inner_classes'  , array( $this, 'tc_add_parallax_item_class' ) );
-    add_action('wp_head'                    , array( $this, 'tc_add_parallax_slider_script' ) );
+    add_filter('tc_slider_layout_class'     , array( $this, 'czr_add_parallax_wrapper_class' ) );
+    add_filter('tc_carousel_inner_classes'  , array( $this, 'czr_add_parallax_item_class' ) );
+    add_action('wp_head'                    , array( $this, 'czr_add_parallax_slider_script' ) );
   }
 
 
@@ -1225,7 +1225,7 @@ class CZR_slider {
       if ( false !== (bool) esc_attr( CZR_utils::$inst->czr_opt( 'tc_slider_default_height', CZR___::$tc_option_group, $use_default = false ) ) )
         return $_h;
     }
-    return apply_filters( 'tc_set_demo_slider_height' , 750 );
+    return apply_filters( 'czr_set_demo_slider_height' , 750 );
   }
 
 

--- a/inc/parts/class-content-slider.php
+++ b/inc/parts/class-content-slider.php
@@ -11,8 +11,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_slider' ) ) :
-class TC_slider {
+if ( ! class_exists( 'CZR_slider' ) ) :
+class CZR_slider {
 
   static $instance;
   private static $sliders_model;
@@ -29,7 +29,7 @@ class TC_slider {
     //Set thumbnail specific design based on user options
     //Set user defined height
     add_filter( 'tc_user_options_style'    , array( $this , 'tc_write_slider_inline_css' ) );
-    //tc_slider_height is fired in TC_slider::tc_write_slider_inline_css()
+    //tc_slider_height is fired in CZR_slider::tc_write_slider_inline_css()
     add_filter( 'tc_slider_height'         , array( $this, 'tc_set_demo_slider_height') );
   }//end of construct
 
@@ -134,7 +134,7 @@ class TC_slider {
 
     //allow responsive images?
     if ( version_compare( $GLOBALS['wp_version'], '4.4', '>=' ) )
-      if ( 0 == esc_attr( TC_utils::$inst->tc_opt('tc_resp_slider_img') ) ) {
+      if ( 0 == esc_attr( CZR_utils::$inst->tc_opt('tc_resp_slider_img') ) ) {
         $slide_background_attr['srcset'] = " ";
         //trick, => will produce an empty attr srcset as in wp-includes/media.php the srcset is calculated and added
         //only when the passed srcset attr is not empty. This will avoid us to:
@@ -145,7 +145,7 @@ class TC_slider {
         //we'll see an empty ( or " " depending on the browser ) srcset attribute in the html
         //to avoid this we filter the attributes getting rid of the srcset if any.
         //Basically this trick, even if ugly, will avoid the srcset attr computation
-        add_filter( 'wp_get_attachment_image_attributes', array( TC_post_thumbnails::$instance, 'tc_remove_srcset_attr' ) );
+        add_filter( 'wp_get_attachment_image_attributes', array( CZR_post_thumbnails::$instance, 'tc_remove_srcset_attr' ) );
       }
     $slide_background       = wp_get_attachment_image( $id, $img_size, false, $slide_background_attr );
 
@@ -184,7 +184,7 @@ class TC_slider {
     $ID                     = $_post->ID;
 
     //attachment image
-    $thumb                  = TC_post_thumbnails::$instance -> tc_get_thumbnail_model($img_size, $ID, null, isset($args['slider_responsive_images']) ? $args['slider_responsive_images'] : null );
+    $thumb                  = CZR_post_thumbnails::$instance -> tc_get_thumbnail_model($img_size, $ID, null, isset($args['slider_responsive_images']) ? $args['slider_responsive_images'] : null );
     $slide_background       = isset($thumb) && isset($thumb['tc_thumb']) ? $thumb['tc_thumb'] : null;
     // we don't want to show slides with no image
     if ( ! $slide_background )
@@ -267,9 +267,9 @@ class TC_slider {
   private function tc_get_the_slides( $slider_name_id, $img_size ) {
     //returns the default slider if requested
     if ( 'demo' == $slider_name_id )
-      return apply_filters( 'tc_default_slides', TC_init::$instance -> default_slides );
+      return apply_filters( 'tc_default_slides', CZR_init::$instance -> default_slides );
     else if ( 'tc_posts_slider' == $slider_name_id ) {
-      $use_transient = apply_filters( 'tc_posts_slider_use_transient', ! TC___::$instance -> tc_is_customizing() );
+      $use_transient = apply_filters( 'tc_posts_slider_use_transient', ! CZR___::$instance -> tc_is_customizing() );
       //Do not use transient when in the customizer preview (this class is not called in the customize left panel)
       $store_transient = $load_transient = $use_transient;
       // delete transient when in the customize preview
@@ -279,7 +279,7 @@ class TC_slider {
       return $this -> tc_get_the_posts_slides( $slider_name_id, $img_size, $load_transient , $store_transient );
     }
     //if not demo or tc_posts_slider, we get slides from options
-    $all_sliders    = TC_utils::$inst -> tc_opt( 'tc_sliders');
+    $all_sliders    = CZR_utils::$inst -> tc_opt( 'tc_sliders');
     $saved_slides   = ( isset($all_sliders[$slider_name_id]) ) ? $all_sliders[$slider_name_id] : false;
 
     //if the slider not longer exists or exists but is empty, return false
@@ -408,12 +408,12 @@ class TC_slider {
       'store_transient'     => true,
       'transient_name'      => 'tc_posts_slides',
       //options
-      'stickies_only'       => esc_attr( TC_utils::$inst->tc_opt( 'tc_posts_slider_stickies' ) ),
-      'show_title'          => esc_attr( TC_utils::$inst->tc_opt( 'tc_posts_slider_title' ) ),
-      'show_excerpt'        => esc_attr( TC_utils::$inst->tc_opt( 'tc_posts_slider_text' ) ),
-      'button_text'         => esc_attr( TC_utils::$inst->tc_opt( 'tc_posts_slider_button_text' ) ),
-      'limit'               => esc_attr( TC_utils::$inst->tc_opt( 'tc_posts_slider_number' ) ),
-      'link_type'           => esc_attr( TC_utils::$inst->tc_opt( 'tc_posts_slider_link') ),
+      'stickies_only'       => esc_attr( CZR_utils::$inst->tc_opt( 'tc_posts_slider_stickies' ) ),
+      'show_title'          => esc_attr( CZR_utils::$inst->tc_opt( 'tc_posts_slider_title' ) ),
+      'show_excerpt'        => esc_attr( CZR_utils::$inst->tc_opt( 'tc_posts_slider_text' ) ),
+      'button_text'         => esc_attr( CZR_utils::$inst->tc_opt( 'tc_posts_slider_button_text' ) ),
+      'limit'               => esc_attr( CZR_utils::$inst->tc_opt( 'tc_posts_slider_number' ) ),
+      'link_type'           => esc_attr( CZR_utils::$inst->tc_opt( 'tc_posts_slider_link') ),
     );
 
     $args         = apply_filters( 'tc_get_pre_posts_slides_args', wp_parse_args( $args, $defaults ) );
@@ -439,9 +439,9 @@ class TC_slider {
 
     /*** tc_thumb setup filters ***/
     // remove smart load img parsing if any
-    $smart_load_enabled = 1 == esc_attr( TC_utils::$inst->tc_opt( 'tc_img_smart_load' ) );
+    $smart_load_enabled = 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_img_smart_load' ) );
     if ( $smart_load_enabled )
-      remove_filter( 'tc_thumb_html', array( TC_utils::$instance, 'tc_parse_imgs') );
+      remove_filter( 'tc_thumb_html', array( CZR_utils::$instance, 'tc_parse_imgs') );
 
     // prevent adding thumb inline style when no center img is added
     add_filter( 'tc_post_thumb_inline_style', '__return_empty_string', 100 );
@@ -449,7 +449,7 @@ class TC_slider {
 
     //allow responsive images?
     if ( version_compare( $GLOBALS['wp_version'], '4.4', '>=' ) )
-      $args['slider_responsive_images'] = 0 == esc_attr( TC_utils::$inst->tc_opt('tc_resp_slider_img') ) ? false : true ;
+      $args['slider_responsive_images'] = 0 == esc_attr( CZR_utils::$inst->tc_opt('tc_resp_slider_img') ) ? false : true ;
 
     /* Get the pre_model */
     $pre_slides = $pre_slides_posts = array();
@@ -466,7 +466,7 @@ class TC_slider {
     /* tc_thumb reset filters */
     // re-add smart load parsing if removed
     if ( $smart_load_enabled )
-      add_filter('tc_thumb_html', array(TC_utils::$instance, 'tc_parse_imgs') );
+      add_filter('tc_thumb_html', array(CZR_utils::$instance, 'tc_parse_imgs') );
     // remove thumb style reset
     remove_filter( 'tc_post_thumb_inline_style', '__return_empty_string', 100 );
     /* end tc_thumb reset filters */
@@ -525,7 +525,7 @@ class TC_slider {
       return self::$sliders_model[ $slider_name_id ];
 
     //gets slider options if any
-    $layout_value                 = tc__f('__is_home') ? TC_utils::$inst->tc_opt( 'tc_slider_width' ) : esc_attr(get_post_meta( $queried_id, $key = 'slider_layout_key' , $single = true ));
+    $layout_value                 = tc__f('__is_home') ? CZR_utils::$inst->tc_opt( 'tc_slider_width' ) : esc_attr(get_post_meta( $queried_id, $key = 'slider_layout_key' , $single = true ));
     $layout_value                 = apply_filters( 'tc_slider_layout', $layout_value, $queried_id );
 
     //declares the layout vars
@@ -900,7 +900,7 @@ class TC_slider {
   */
   function tc_render_slide_edit_link_view( $_view_model ) {
     //never display when customizing
-    if ( TC___::$instance -> tc_is_customizing() )
+    if ( CZR___::$instance -> tc_is_customizing() )
       return;
     //extract $_view_model = array( $id, $data , $slider_name_id, $img_size )
     extract( $_view_model );
@@ -935,7 +935,7 @@ class TC_slider {
 
   function tc_render_slider_edit_link_view( $slides, $slider_name_id ) {
     //never display when customizing
-    if ( TC___::$instance -> tc_is_customizing() )
+    if ( CZR___::$instance -> tc_is_customizing() )
       return;
     if ( 'demo' == $slider_name_id )
       return;
@@ -947,7 +947,7 @@ class TC_slider {
     //b) users who can edit the post/page where the slider is displayed for users who can edit the post/page -> deep link in the post/page slider section
     if ( tc__f('__is_home') ){
       $show_slider_edit_link = ( is_user_logged_in() && current_user_can('edit_theme_options') ) ? true : false;
-      $_edit_link            = TC_utils::tc_get_customizer_url( array( 'control' => 'tc_front_slider', 'section' => 'frontpage_sec') );
+      $_edit_link            = CZR_utils::tc_get_customizer_url( array( 'control' => 'tc_front_slider', 'section' => 'frontpage_sec') );
     }else if ( is_singular() ){ // we have a snippet to display sliders in categories, we don't want the slider edit link displayed there
       global $post;
       $show_slider_edit_link = ( is_user_logged_in() && ( current_user_can('edit_pages') || current_user_can( 'edit_posts', $post -> ID ) ) ) ? true : false;
@@ -1010,9 +1010,9 @@ class TC_slider {
   * @since v3.4+
   */
   function tc_maybe_display_dismiss_notice() {
-    if ( ! TC_placeholders::tc_is_slider_notice_on() )
+    if ( ! CZR_placeholders::tc_is_slider_notice_on() )
       return;
-    $_customizer_lnk = TC_utils::tc_get_customizer_url( array( 'control' => 'tc_front_slider', 'section' => 'frontpage_sec') );
+    $_customizer_lnk = CZR_utils::tc_get_customizer_url( array( 'control' => 'tc_front_slider', 'section' => 'frontpage_sec') );
     ?>
     <div class="tc-placeholder-wrap tc-slider-notice">
       <?php
@@ -1040,7 +1040,7 @@ class TC_slider {
   //hook : wp
   //introduced in v3.4.23
   function tc_maybe_setup_parallax() {
-    if ( 1 != esc_attr( TC_utils::$inst->tc_opt( 'tc_slider_parallax') ) )
+    if ( 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_slider_parallax') ) )
       return;
     add_filter('tc_slider_layout_class'     , array( $this, 'tc_add_parallax_wrapper_class' ) );
     add_filter('tc_carousel_inner_classes'  , array( $this, 'tc_add_parallax_item_class' ) );
@@ -1121,7 +1121,7 @@ class TC_slider {
   */
   private function tc_is_slider_possible() {
     //gets the front slider if any
-    $tc_front_slider              = esc_attr(TC_utils::$inst->tc_opt( 'tc_front_slider' ) );
+    $tc_front_slider              = esc_attr(CZR_utils::$inst->tc_opt( 'tc_front_slider' ) );
     //when do we display a slider? By default only for home (if a slider is defined), pages and posts (including custom post types)
     $_show_slider = tc__f('__is_home') ? ! empty( $tc_front_slider ) : ! is_404() && ! is_archive() && ! is_search();
 
@@ -1150,7 +1150,7 @@ class TC_slider {
   */
   private function tc_get_current_slider($queried_id) {
     //gets the current slider id
-    $_home_slider     = TC_utils::$inst->tc_opt( 'tc_front_slider' );
+    $_home_slider     = CZR_utils::$inst->tc_opt( 'tc_front_slider' );
     $slider_name_id   = ( tc__f('__is_home') && $_home_slider ) ? $_home_slider : esc_attr( get_post_meta( $queried_id, $key = 'post_slider_key' , $single = true ) );
     return apply_filters( 'tc_slider_name_id', $slider_name_id , $queried_id);
   }
@@ -1177,7 +1177,7 @@ class TC_slider {
   */
   private function tc_is_slider_active( $queried_id ) {
     //is the slider set to on for the queried id?
-    if ( tc__f('__is_home') && TC_utils::$inst->tc_opt( 'tc_front_slider' ) )
+    if ( tc__f('__is_home') && CZR_utils::$inst->tc_opt( 'tc_front_slider' ) )
       return apply_filters( 'tc_slider_active_status', true , $queried_id );
 
     $_slider_on = esc_attr( get_post_meta( $queried_id, $key = 'post_slider_check_key' , $single = true ) );
@@ -1198,7 +1198,7 @@ class TC_slider {
     //a) we have to render the demo slider
     //b) display slider loading option is enabled (can be filtered)
     return ( 'demo' == $slider_name_id
-        || apply_filters( 'tc_display_slider_loader', 1 == esc_attr( TC_utils::$inst->tc_opt( 'tc_display_slide_loader') ), $slider_name_id )
+        || apply_filters( 'tc_display_slider_loader', 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_display_slide_loader') ), $slider_name_id )
     );
   }
 
@@ -1218,11 +1218,11 @@ class TC_slider {
 
     //2) height option has not been changed by user yet
     //the possible customization context must be taken into account here
-    if ( TC___::$instance -> tc_is_customizing() ) {
-      if ( 500 != esc_attr( TC_utils::$inst->tc_opt( 'tc_slider_default_height') ) )
+    if ( CZR___::$instance -> tc_is_customizing() ) {
+      if ( 500 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_slider_default_height') ) )
         return $_h;
     } else {
-      if ( false !== (bool) esc_attr( TC_utils::$inst->tc_opt( 'tc_slider_default_height', TC___::$tc_option_group, $use_default = false ) ) )
+      if ( false !== (bool) esc_attr( CZR_utils::$inst->tc_opt( 'tc_slider_default_height', CZR___::$tc_option_group, $use_default = false ) ) )
         return $_h;
     }
     return apply_filters( 'tc_set_demo_slider_height' , 750 );
@@ -1247,7 +1247,7 @@ class TC_slider {
         // The pure css loader color depends on the skin. Why can we do this here without caring of the live preview?
         // Basically 'cause the loader is something we see when the page "loads" then it disappears so a live change of the skin
         // will still have no visive impact on it. This will avoid us to rebuild the custom skins.
-        $_current_skin_colors      = TC_utils::$inst -> tc_get_skin_color( 'pair' );
+        $_current_skin_colors      = CZR_utils::$inst -> tc_get_skin_color( 'pair' );
         $_pure_css_loader_css      = apply_filters( 'tc_slider_loader_css', sprintf(
             '.tc-slider-loader-wrapper .tc-css-loader > div { border-color:%s; }',
             //we can use the primary or the secondary skin color
@@ -1273,12 +1273,12 @@ class TC_slider {
 
     // 1) Do we have a custom height ?
     // 2) check if the setting must be applied to all context
-    $_custom_height     = apply_filters( 'tc_slider_height' , esc_attr( TC_utils::$inst->tc_opt( 'tc_slider_default_height') ) );
+    $_custom_height     = apply_filters( 'tc_slider_height' , esc_attr( CZR_utils::$inst->tc_opt( 'tc_slider_default_height') ) );
     $_slider_inline_css = "";
 
     //When shall we append custom slider style to the global custom inline stylesheet?
     $_bool = 500 != $_custom_height;
-    $_bool = $_bool && ( tc__f('__is_home') || 0 != esc_attr( TC_utils::$inst->tc_opt( 'tc_slider_default_height_apply_all') ) );
+    $_bool = $_bool && ( tc__f('__is_home') || 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_slider_default_height_apply_all') ) );
 
     if ( ! apply_filters( 'tc_print_slider_inline_css' , $_bool ) )
       return $_css;
@@ -1339,7 +1339,7 @@ class TC_slider {
   *
   */
   function tc_set_slider_wrapper_class($_classes) {
-    if ( ! is_array($_classes) || 500 == esc_attr( TC_utils::$inst->tc_opt( 'tc_slider_default_height') ) )
+    if ( ! is_array($_classes) || 500 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_slider_default_height') ) )
       return $_classes;
 
     return array_merge( $_classes , array('custom-slider-height') );
@@ -1354,7 +1354,7 @@ class TC_slider {
   * @since Customizr 3.3+
   */
   function tc_set_inner_class( $_classes ) {
-    if( ! (bool) esc_attr( TC_utils::$inst->tc_opt( 'tc_center_slider_img') ) || ! is_array($_classes) )
+    if( ! (bool) esc_attr( CZR_utils::$inst->tc_opt( 'tc_center_slider_img') ) || ! is_array($_classes) )
       return $_classes;
     array_push( $_classes, 'center-slides-enabled' );
     return $_classes;
@@ -1370,7 +1370,7 @@ class TC_slider {
   function tc_cache_posts_slider( $args = array() ) {
     $defaults = array (
       //use the home slider_width
-      'img_size'        => 1 == TC_utils::$inst->tc_opt( 'tc_slider_width' ) ? 'slider-full' : 'slider',
+      'img_size'        => 1 == CZR_utils::$inst->tc_opt( 'tc_slider_width' ) ? 'slider-full' : 'slider',
       'load_transient'  => false,
       'store_transient' => true,
       'transient_name'  => 'tc_posts_slides'
@@ -1443,7 +1443,7 @@ class TC_slider {
   * @since Customizr 3.4.9
   *
   */
-  // move this into TC_utils?
+  // move this into CZR_utils?
   function tc_get_post_title( $_post, $default_title_length, $more ) {
     $title = $_post->post_title;
     if ( ! empty( $_post->post_password ) ) {
@@ -1469,7 +1469,7 @@ class TC_slider {
   * @since Customizr 3.4.9
   *
   */
-  // move this into TC_utils?
+  // move this into CZR_utils?
   function tc_get_post_excerpt( $_post, $default_text_length, $more ) {
     if ( ! empty( $_post->post_password) )
       return __( 'There is no excerpt because this is a protected post.', 'customizr' );
@@ -1503,7 +1503,7 @@ class TC_slider {
   * @since Customizr 3.4.9
   *
   */
-  // move this into TC_utils?
+  // move this into CZR_utils?
   function tc_trim_text( $text, $text_length, $more ) {
     if ( ! $text )
       return '';

--- a/inc/parts/class-footer-footer_main.php
+++ b/inc/parts/class-footer-footer_main.php
@@ -17,10 +17,10 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
     function __construct () {
       self::$instance =& $this;
       //All footer hooks setup
-      add_action( 'wp_head'                   , array( $this , 'czr_footer_hook_setup') );
+      add_action( 'wp_head'                   , array( $this , 'czr_fn_footer_hook_setup') );
 
       // Sticky footer style
-      add_filter( 'tc_user_options_style' , array( $this , 'czr_write_sticky_footer_inline_css' ) );
+      add_filter( 'tc_user_options_style' , array( $this , 'czr_fn_write_sticky_footer_inline_css' ) );
     }
 
 
@@ -36,12 +36,12 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    function czr_footer_hook_setup() {
+    function czr_fn_footer_hook_setup() {
       //add sticky_footer body class
-      add_filter ( 'body_class' , array( $this, 'czr_add_sticky_footer_body_class' ) );
+      add_filter ( 'body_class' , array( $this, 'czr_fn_add_sticky_footer_body_class' ) );
 
       //print the sticky_footer push div
-      add_action ( '__after_main_container' , array( $this, 'czr_sticky_footer_push'), 100 );
+      add_action ( '__after_main_container' , array( $this, 'czr_fn_sticky_footer_push'), 100 );
 
       //html > footer actions
       add_action ( '__after_main_wrapper'   , 'get_footer');
@@ -51,18 +51,18 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
         return;
 
       //footer actions
-      add_action ( '__footer'         , array( $this , 'czr_widgets_footer' ), 10 );
-      add_action ( '__footer'         , array( $this , 'czr_colophon_display' ), 20 );
+      add_action ( '__footer'         , array( $this , 'czr_fn_widgets_footer' ), 10 );
+      add_action ( '__footer'         , array( $this , 'czr_fn_colophon_display' ), 20 );
 
       //colophon actions => some priorities are rtl dependants
-      add_action ( '__colophon'       , array( $this , 'czr_colophon_left_block' ), 10 );
-      add_action ( '__colophon'       , array( $this , 'czr_colophon_center_block' ), 20 );
-      add_action ( '__colophon'       , array( $this , 'czr_colophon_right_block' ), 30 );
+      add_action ( '__colophon'       , array( $this , 'czr_fn_colophon_left_block' ), 10 );
+      add_action ( '__colophon'       , array( $this , 'czr_fn_colophon_center_block' ), 20 );
+      add_action ( '__colophon'       , array( $this , 'czr_fn_colophon_right_block' ), 30 );
 
       //since v3.2.0, Show back to top from the Customizer option panel
-      add_action ( '__after_footer'       , array( $this , 'czr_render_back_to_top') );
+      add_action ( '__after_footer'       , array( $this , 'czr_fn_render_back_to_top') );
       //since v3.2.0, set no widget icons from the Customizer option panel
-      add_filter ( 'tc_footer_widget_wrapper_class' , array( $this , 'czr_set_widget_wrapper_class') );
+      add_filter ( 'tc_footer_widget_wrapper_class' , array( $this , 'czr_fn_set_widget_wrapper_class') );
     }
 
 
@@ -77,7 +77,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 		* @package Customizr
 		* @since Customizr 3.0.10
 		*/
-	  function czr_widgets_footer() {
+	  function czr_fn_widgets_footer() {
     	//checks if there's at least one active widget area in footer.php.php
     	$status 					= false;
     	$footer_widgets 			= apply_filters( 'tc_footer_widgets', CZR_init::$instance -> footer_widgets );
@@ -87,12 +87,12 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 
       //if no active widget area yet, display the footer widget placeholder
 			if ( ! $status ) {
-        $this -> czr_display_footer_placeholder();
+        $this -> czr_fn_display_footer_placeholder();
         return;
       }
 
 			//hack to render white color icons if skin is grey or black
-			$skin_class 					= ( in_array( CZR_utils::$inst->czr_opt( 'tc_skin') , array('grey.css' , 'black.css')) ) ? 'white-icons' : '';
+			$skin_class 					= ( in_array( CZR_utils::$inst->czr_fn_opt( 'tc_skin') , array('grey.css' , 'black.css')) ) ? 'white-icons' : '';
 			$footer_widgets_wrapper_classes = implode(" ", apply_filters( 'tc_footer_widget_wrapper_class' , array('container' , 'footer-widgets', $skin_class) ) );
 			ob_start();
 			?>
@@ -118,7 +118,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 			<?php
 			$html = ob_get_contents();
 	        if ($html) ob_end_clean();
-	        echo apply_filters( 'czr_widgets_footer', $html , $footer_widgets );
+	        echo apply_filters( 'czr_fn_widgets_footer', $html , $footer_widgets );
 		}//end of function
 
 
@@ -131,8 +131,8 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
     * @param : string position left or right
     * @since Customizr 3.3
     */
-    private function czr_display_footer_placeholder() {
-      if ( ! CZR_placeholders::czr_is_widget_placeholder_enabled( 'footer' ) )
+    private function czr_fn_display_footer_placeholder() {
+      if ( ! CZR_placeholders::czr_fn_is_widget_placeholder_enabled( 'footer' ) )
         return;
 
       ?>
@@ -148,7 +148,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 
           printf('<p><strong>%1$s</strong></p>',
               sprintf( __("Add widgets to the footer %s or %s.", "customizr"),
-                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', CZR_utils::czr_get_customizer_url( array( 'panel' => 'widgets') ), __( "Add widgets", "customizr"), __("now", "customizr") ),
+                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', CZR_utils::czr_fn_get_customizer_url( array( 'panel' => 'widgets') ), __( "Add widgets", "customizr"), __("now", "customizr") ),
                 sprintf('<a class="tc-inline-dismiss-notice" data-position="footer" href="#" title="%1$s">%1$s</a>',
                   __( 'dismiss this notice', 'customizr')
                 )
@@ -172,7 +172,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 		 * @package Customizr
 		 * @since Customizr 3.0.10
 		 */
-	    function czr_colophon_display() {
+	    function czr_fn_colophon_display() {
 
 	    	?>
 	    	<?php ob_start() ?>
@@ -190,7 +190,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 	    	<?php
 	    	$html = ob_get_contents();
 	        if ($html) ob_end_clean();
-	        echo apply_filters( 'czr_colophon_display', $html );
+	        echo apply_filters( 'czr_fn_colophon_display', $html );
 	    }
 
 
@@ -203,21 +203,21 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 		 * @package Customizr
 		 * @since Customizr 3.0.10
 		 */
-	    function czr_colophon_left_block() {
+	    function czr_fn_colophon_left_block() {
 	    	//when do we display this block ?
 	        //1) if customizing always. (is hidden if empty of disabled)
 	        //2) if not customizing : must be enabled and have social networks.
-	    	$_nothing_to_render = ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_social_in_footer') ) ) || ! czr__f( '__get_socials' );
-	    	$_hide_socials = $_nothing_to_render && CZR___::$instance -> czr_is_customizing();
-	    	$_nothing_to_render = $_nothing_to_render && ! CZR___::$instance -> czr_is_customizing();
+	    	$_nothing_to_render = ( 0 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_social_in_footer') ) ) || ! czr_fn__f( '__get_socials' );
+	    	$_hide_socials = $_nothing_to_render && CZR___::$instance -> czr_fn_is_customizing();
+	    	$_nothing_to_render = $_nothing_to_render && ! CZR___::$instance -> czr_fn_is_customizing();
 
 	      	echo apply_filters(
-	      		'czr_colophon_left_block',
+	      		'czr_fn_colophon_left_block',
 	      		sprintf('<div class="%1$s">%2$s</div>',
 	      			implode( ' ', apply_filters( 'tc_colophon_left_block_class', array( 'span3', 'social-block', is_rtl() ? 'pull-right' : 'pull-left' ) ) ),
 	      			( ! $_nothing_to_render ) ? sprintf('<span class="tc-footer-social-links-wrapper" %1$s>%2$s</span>',
 	      				( $_hide_socials ) ? 'style="display:none"' : '',
-	      				czr__f( '__get_socials' )
+	      				czr_fn__f( '__get_socials' )
 	      			) : ''
 	      		)
 	      	);
@@ -234,7 +234,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 		 * @package Customizr
 		 * @since Customizr 3.0.6
 		 */
-	    function czr_colophon_center_block() {
+	    function czr_fn_colophon_center_block() {
 	    	echo apply_filters(
 	    		'tc_credits_display',
 	    		sprintf('<div class="%1$s">%2$s</div>',
@@ -259,13 +259,13 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 		* @package Customizr
 		* @since Customizr 3.0.10
 		*/
-        function czr_colophon_right_block() {
+        function czr_fn_colophon_right_block() {
           //since 3.4.16 BTT button excludes BTT text
-      if ( ! apply_filters('tc_show_text_btt', 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_back_to_top' ) ) ) )
+      if ( ! apply_filters('tc_show_text_btt', 0 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_back_to_top' ) ) ) )
         return;
 
     	echo apply_filters(
-    		'czr_colophon_right_block',
+    		'czr_fn_colophon_right_block',
     		sprintf('<div class="%1$s"><p class="%3$s"><a class="back-to-top" href="#">%2$s</a></p></div>',
     			implode( ' ', apply_filters( 'tc_colophon_right_block_class', array( 'span3', 'backtop' ) ) ),
                 __( 'Back to top' , 'customizr' ),
@@ -286,7 +286,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    function czr_set_rtl_colophon_priority( $_priority, $_location ) {
+    function czr_fn_set_rtl_colophon_priority( $_priority, $_location ) {
       if ( ! is_rtl() )
         return $_priority;
       //tc_colophon_right_priority OR tc_colophon_left_priority
@@ -301,8 +301,8 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
     * @package Customizr
     * @since Customizr 3.3.27
     */
-    function czr_write_sticky_footer_inline_css( $_css ){
-      if ( ! ( $this -> is_sticky_footer_enabled() || CZR___::$instance -> czr_is_customizing() ) )
+    function czr_fn_write_sticky_footer_inline_css( $_css ){
+      if ( ! ( $this -> is_sticky_footer_enabled() || CZR___::$instance -> czr_fn_is_customizing() ) )
         return $_css;
 
       $_css = sprintf("%s\n%s",
@@ -319,7 +319,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
     * @package Customizr
     * @since Customizr 3.3.27
     */
-    function czr_add_sticky_footer_body_class($_classes) {
+    function czr_fn_add_sticky_footer_body_class($_classes) {
       if ( $this -> is_sticky_footer_enabled() )
         $_classes = array_merge( $_classes, array( 'tc-sticky-footer') );
 
@@ -337,8 +337,8 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
     * @hook __after_main_container
     *
     */
-    function czr_sticky_footer_push() {
-      if ( ! ( $this -> is_sticky_footer_enabled() || CZR___::$instance -> czr_is_customizing() ) )
+    function czr_fn_sticky_footer_push() {
+      if ( ! ( $this -> is_sticky_footer_enabled() || CZR___::$instance -> czr_fn_is_customizing() ) )
         return;
 
       echo '<div id="tc-push-footer"></div>';
@@ -352,11 +352,11 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 		* @package Customizr
 		* @since Customizr 3.2.0
 		*/
-		function czr_render_back_to_top() {
-			if ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_back_to_top' ) ) )
+		function czr_fn_render_back_to_top() {
+			if ( 0 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_back_to_top' ) ) )
                 return;
             printf('<div id="tc-footer-btt-wrapper" class="tc-btt-wrapper %1$s"><i class="btt-arrow"></i></div>',
-                esc_attr( CZR_utils::$inst -> czr_opt( 'tc_back_to_top_position' ) )
+                esc_attr( CZR_utils::$inst -> czr_fn_opt( 'tc_back_to_top_position' ) )
             );
 		}
 
@@ -368,11 +368,11 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 		* @package Customizr
 		* @since Customizr 3.2.0
 		*/
-		function czr_set_widget_wrapper_class( $_original_classes ) {
+		function czr_fn_set_widget_wrapper_class( $_original_classes ) {
 			$_no_icons_classes = array_merge($_original_classes, array('no-widget-icons'));
 
-			if ( 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_footer_widget_icon' ) ) )
-				return ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_title_icon' ) ) ) ? $_no_icons_classes : $_original_classes;
+			if ( 1 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_footer_widget_icon' ) ) )
+				return ( 0 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_title_icon' ) ) ) ? $_no_icons_classes : $_original_classes;
 			 //last condition
           	return $_no_icons_classes;
         }
@@ -386,7 +386,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
     * @return bool
     */
     function is_sticky_footer_enabled() {
-      return 1 == esc_attr( CZR_utils::$inst -> czr_opt( 'tc_sticky_footer') );
+      return 1 == esc_attr( CZR_utils::$inst -> czr_fn_opt( 'tc_sticky_footer') );
     }
   }//end of class
 endif;

--- a/inc/parts/class-footer-footer_main.php
+++ b/inc/parts/class-footer-footer_main.php
@@ -17,10 +17,10 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
     function __construct () {
       self::$instance =& $this;
       //All footer hooks setup
-      add_action( 'wp_head'                   , array( $this , 'tc_footer_hook_setup') );
+      add_action( 'wp_head'                   , array( $this , 'czr_footer_hook_setup') );
 
       // Sticky footer style
-      add_filter( 'tc_user_options_style' , array( $this , 'tc_write_sticky_footer_inline_css' ) );
+      add_filter( 'tc_user_options_style' , array( $this , 'czr_write_sticky_footer_inline_css' ) );
     }
 
 
@@ -38,10 +38,10 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
     */
     function czr_footer_hook_setup() {
       //add sticky_footer body class
-      add_filter ( 'body_class' , array( $this, 'tc_add_sticky_footer_body_class' ) );
+      add_filter ( 'body_class' , array( $this, 'czr_add_sticky_footer_body_class' ) );
 
       //print the sticky_footer push div
-      add_action ( '__after_main_container' , array( $this, 'tc_sticky_footer_push'), 100 );
+      add_action ( '__after_main_container' , array( $this, 'czr_sticky_footer_push'), 100 );
 
       //html > footer actions
       add_action ( '__after_main_wrapper'   , 'get_footer');
@@ -51,18 +51,18 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
         return;
 
       //footer actions
-      add_action ( '__footer'         , array( $this , 'tc_widgets_footer' ), 10 );
-      add_action ( '__footer'         , array( $this , 'tc_colophon_display' ), 20 );
+      add_action ( '__footer'         , array( $this , 'czr_widgets_footer' ), 10 );
+      add_action ( '__footer'         , array( $this , 'czr_colophon_display' ), 20 );
 
       //colophon actions => some priorities are rtl dependants
-      add_action ( '__colophon'       , array( $this , 'tc_colophon_left_block' ), 10 );
-      add_action ( '__colophon'       , array( $this , 'tc_colophon_center_block' ), 20 );
-      add_action ( '__colophon'       , array( $this , 'tc_colophon_right_block' ), 30 );
+      add_action ( '__colophon'       , array( $this , 'czr_colophon_left_block' ), 10 );
+      add_action ( '__colophon'       , array( $this , 'czr_colophon_center_block' ), 20 );
+      add_action ( '__colophon'       , array( $this , 'czr_colophon_right_block' ), 30 );
 
       //since v3.2.0, Show back to top from the Customizer option panel
-      add_action ( '__after_footer'       , array( $this , 'tc_render_back_to_top') );
+      add_action ( '__after_footer'       , array( $this , 'czr_render_back_to_top') );
       //since v3.2.0, set no widget icons from the Customizer option panel
-      add_filter ( 'tc_footer_widget_wrapper_class' , array( $this , 'tc_set_widget_wrapper_class') );
+      add_filter ( 'tc_footer_widget_wrapper_class' , array( $this , 'czr_set_widget_wrapper_class') );
     }
 
 
@@ -118,7 +118,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 			<?php
 			$html = ob_get_contents();
 	        if ($html) ob_end_clean();
-	        echo apply_filters( 'tc_widgets_footer', $html , $footer_widgets );
+	        echo apply_filters( 'czr_widgets_footer', $html , $footer_widgets );
 		}//end of function
 
 
@@ -190,7 +190,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 	    	<?php
 	    	$html = ob_get_contents();
 	        if ($html) ob_end_clean();
-	        echo apply_filters( 'tc_colophon_display', $html );
+	        echo apply_filters( 'czr_colophon_display', $html );
 	    }
 
 
@@ -212,7 +212,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 	    	$_nothing_to_render = $_nothing_to_render && ! CZR___::$instance -> czr_is_customizing();
 
 	      	echo apply_filters(
-	      		'tc_colophon_left_block',
+	      		'czr_colophon_left_block',
 	      		sprintf('<div class="%1$s">%2$s</div>',
 	      			implode( ' ', apply_filters( 'tc_colophon_left_block_class', array( 'span3', 'social-block', is_rtl() ? 'pull-right' : 'pull-left' ) ) ),
 	      			( ! $_nothing_to_render ) ? sprintf('<span class="tc-footer-social-links-wrapper" %1$s>%2$s</span>',
@@ -265,7 +265,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
         return;
 
     	echo apply_filters(
-    		'tc_colophon_right_block',
+    		'czr_colophon_right_block',
     		sprintf('<div class="%1$s"><p class="%3$s"><a class="back-to-top" href="#">%2$s</a></p></div>',
     			implode( ' ', apply_filters( 'tc_colophon_right_block_class', array( 'span3', 'backtop' ) ) ),
                 __( 'Back to top' , 'customizr' ),

--- a/inc/parts/class-footer-footer_main.php
+++ b/inc/parts/class-footer-footer_main.php
@@ -36,7 +36,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    function tc_footer_hook_setup() {
+    function czr_footer_hook_setup() {
       //add sticky_footer body class
       add_filter ( 'body_class' , array( $this, 'tc_add_sticky_footer_body_class' ) );
 
@@ -77,7 +77,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 		* @package Customizr
 		* @since Customizr 3.0.10
 		*/
-	  function tc_widgets_footer() {
+	  function czr_widgets_footer() {
     	//checks if there's at least one active widget area in footer.php.php
     	$status 					= false;
     	$footer_widgets 			= apply_filters( 'tc_footer_widgets', CZR_init::$instance -> footer_widgets );
@@ -131,7 +131,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
     * @param : string position left or right
     * @since Customizr 3.3
     */
-    private function tc_display_footer_placeholder() {
+    private function czr_display_footer_placeholder() {
       if ( ! CZR_placeholders::tc_is_widget_placeholder_enabled( 'footer' ) )
         return;
 
@@ -172,7 +172,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 		 * @package Customizr
 		 * @since Customizr 3.0.10
 		 */
-	    function tc_colophon_display() {
+	    function czr_colophon_display() {
 
 	    	?>
 	    	<?php ob_start() ?>
@@ -203,7 +203,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 		 * @package Customizr
 		 * @since Customizr 3.0.10
 		 */
-	    function tc_colophon_left_block() {
+	    function czr_colophon_left_block() {
 	    	//when do we display this block ?
 	        //1) if customizing always. (is hidden if empty of disabled)
 	        //2) if not customizing : must be enabled and have social networks.
@@ -234,7 +234,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 		 * @package Customizr
 		 * @since Customizr 3.0.6
 		 */
-	    function tc_colophon_center_block() {
+	    function czr_colophon_center_block() {
 	    	echo apply_filters(
 	    		'tc_credits_display',
 	    		sprintf('<div class="%1$s">%2$s</div>',
@@ -259,7 +259,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 		* @package Customizr
 		* @since Customizr 3.0.10
 		*/
-        function tc_colophon_right_block() {
+        function czr_colophon_right_block() {
           //since 3.4.16 BTT button excludes BTT text
       if ( ! apply_filters('tc_show_text_btt', 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_back_to_top' ) ) ) )
         return;
@@ -286,7 +286,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    function tc_set_rtl_colophon_priority( $_priority, $_location ) {
+    function czr_set_rtl_colophon_priority( $_priority, $_location ) {
       if ( ! is_rtl() )
         return $_priority;
       //tc_colophon_right_priority OR tc_colophon_left_priority
@@ -301,7 +301,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
     * @package Customizr
     * @since Customizr 3.3.27
     */
-    function tc_write_sticky_footer_inline_css( $_css ){
+    function czr_write_sticky_footer_inline_css( $_css ){
       if ( ! ( $this -> is_sticky_footer_enabled() || CZR___::$instance -> tc_is_customizing() ) )
         return $_css;
 
@@ -319,7 +319,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
     * @package Customizr
     * @since Customizr 3.3.27
     */
-    function tc_add_sticky_footer_body_class($_classes) {
+    function czr_add_sticky_footer_body_class($_classes) {
       if ( $this -> is_sticky_footer_enabled() )
         $_classes = array_merge( $_classes, array( 'tc-sticky-footer') );
 
@@ -337,7 +337,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
     * @hook __after_main_container
     *
     */
-    function tc_sticky_footer_push() {
+    function czr_sticky_footer_push() {
       if ( ! ( $this -> is_sticky_footer_enabled() || CZR___::$instance -> tc_is_customizing() ) )
         return;
 
@@ -352,7 +352,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 		* @package Customizr
 		* @since Customizr 3.2.0
 		*/
-		function tc_render_back_to_top() {
+		function czr_render_back_to_top() {
 			if ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_back_to_top' ) ) )
                 return;
             printf('<div id="tc-footer-btt-wrapper" class="tc-btt-wrapper %1$s"><i class="btt-arrow"></i></div>',
@@ -368,7 +368,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 		* @package Customizr
 		* @since Customizr 3.2.0
 		*/
-		function tc_set_widget_wrapper_class( $_original_classes ) {
+		function czr_set_widget_wrapper_class( $_original_classes ) {
 			$_no_icons_classes = array_merge($_original_classes, array('no-widget-icons'));
 
 			if ( 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_footer_widget_icon' ) ) )

--- a/inc/parts/class-footer-footer_main.php
+++ b/inc/parts/class-footer-footer_main.php
@@ -118,7 +118,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 			<?php
 			$html = ob_get_contents();
 	        if ($html) ob_end_clean();
-	        echo apply_filters( 'czr_fn_widgets_footer', $html , $footer_widgets );
+	        echo apply_filters( 'tc_widgets_footer', $html , $footer_widgets );
 		}//end of function
 
 
@@ -190,7 +190,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 	    	<?php
 	    	$html = ob_get_contents();
 	        if ($html) ob_end_clean();
-	        echo apply_filters( 'czr_fn_colophon_display', $html );
+	        echo apply_filters( 'tc_colophon_display', $html );
 	    }
 
 
@@ -212,7 +212,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 	    	$_nothing_to_render = $_nothing_to_render && ! CZR___::$instance -> czr_fn_is_customizing();
 
 	      	echo apply_filters(
-	      		'czr_fn_colophon_left_block',
+	      		'tc_colophon_left_block',
 	      		sprintf('<div class="%1$s">%2$s</div>',
 	      			implode( ' ', apply_filters( 'tc_colophon_left_block_class', array( 'span3', 'social-block', is_rtl() ? 'pull-right' : 'pull-left' ) ) ),
 	      			( ! $_nothing_to_render ) ? sprintf('<span class="tc-footer-social-links-wrapper" %1$s>%2$s</span>',
@@ -244,7 +244,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
                             apply_filters( 'tc_credit_link', sprintf( '&middot; <span class="tc-credits-text">Designed by</span> %1$s', '<a href="'.CZR_WEBSITE.'">Press Customizr</a>' ) ),
                             apply_filters( 'tc_wp_powered', sprintf( '&middot; <span class="tc-wp-powered-text">%1$s</span> <a class="icon-wordpress" target="_blank" href="https://wordpress.org" title="%2$s"></a> &middot;',
                               __('Powered by', 'customizr'),
-                              __('Powered by Wordpress', 'customizr')
+                              __('Powered by WordPress', 'customizr')
                             ))
 					)
 	    		)
@@ -265,7 +265,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
         return;
 
     	echo apply_filters(
-    		'czr_fn_colophon_right_block',
+    		'tc_colophon_right_block',
     		sprintf('<div class="%1$s"><p class="%3$s"><a class="back-to-top" href="#">%2$s</a></p></div>',
     			implode( ' ', apply_filters( 'tc_colophon_right_block_class', array( 'span3', 'backtop' ) ) ),
                 __( 'Back to top' , 'customizr' ),

--- a/inc/parts/class-footer-footer_main.php
+++ b/inc/parts/class-footer-footer_main.php
@@ -87,12 +87,12 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 
       //if no active widget area yet, display the footer widget placeholder
 			if ( ! $status ) {
-        $this -> tc_display_footer_placeholder();
+        $this -> czr_display_footer_placeholder();
         return;
       }
 
 			//hack to render white color icons if skin is grey or black
-			$skin_class 					= ( in_array( CZR_utils::$inst->tc_opt( 'tc_skin') , array('grey.css' , 'black.css')) ) ? 'white-icons' : '';
+			$skin_class 					= ( in_array( CZR_utils::$inst->czr_opt( 'tc_skin') , array('grey.css' , 'black.css')) ) ? 'white-icons' : '';
 			$footer_widgets_wrapper_classes = implode(" ", apply_filters( 'tc_footer_widget_wrapper_class' , array('container' , 'footer-widgets', $skin_class) ) );
 			ob_start();
 			?>
@@ -132,7 +132,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
     * @since Customizr 3.3
     */
     private function czr_display_footer_placeholder() {
-      if ( ! CZR_placeholders::tc_is_widget_placeholder_enabled( 'footer' ) )
+      if ( ! CZR_placeholders::czr_is_widget_placeholder_enabled( 'footer' ) )
         return;
 
       ?>
@@ -148,7 +148,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 
           printf('<p><strong>%1$s</strong></p>',
               sprintf( __("Add widgets to the footer %s or %s.", "customizr"),
-                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', CZR_utils::tc_get_customizer_url( array( 'panel' => 'widgets') ), __( "Add widgets", "customizr"), __("now", "customizr") ),
+                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', CZR_utils::czr_get_customizer_url( array( 'panel' => 'widgets') ), __( "Add widgets", "customizr"), __("now", "customizr") ),
                 sprintf('<a class="tc-inline-dismiss-notice" data-position="footer" href="#" title="%1$s">%1$s</a>',
                   __( 'dismiss this notice', 'customizr')
                 )
@@ -207,9 +207,9 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 	    	//when do we display this block ?
 	        //1) if customizing always. (is hidden if empty of disabled)
 	        //2) if not customizing : must be enabled and have social networks.
-	    	$_nothing_to_render = ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_social_in_footer') ) ) || ! tc__f( '__get_socials' );
-	    	$_hide_socials = $_nothing_to_render && CZR___::$instance -> tc_is_customizing();
-	    	$_nothing_to_render = $_nothing_to_render && ! CZR___::$instance -> tc_is_customizing();
+	    	$_nothing_to_render = ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_social_in_footer') ) ) || ! czr__f( '__get_socials' );
+	    	$_hide_socials = $_nothing_to_render && CZR___::$instance -> czr_is_customizing();
+	    	$_nothing_to_render = $_nothing_to_render && ! CZR___::$instance -> czr_is_customizing();
 
 	      	echo apply_filters(
 	      		'tc_colophon_left_block',
@@ -217,7 +217,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 	      			implode( ' ', apply_filters( 'tc_colophon_left_block_class', array( 'span3', 'social-block', is_rtl() ? 'pull-right' : 'pull-left' ) ) ),
 	      			( ! $_nothing_to_render ) ? sprintf('<span class="tc-footer-social-links-wrapper" %1$s>%2$s</span>',
 	      				( $_hide_socials ) ? 'style="display:none"' : '',
-	      				tc__f( '__get_socials' )
+	      				czr__f( '__get_socials' )
 	      			) : ''
 	      		)
 	      	);
@@ -261,7 +261,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 		*/
         function czr_colophon_right_block() {
           //since 3.4.16 BTT button excludes BTT text
-      if ( ! apply_filters('tc_show_text_btt', 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_back_to_top' ) ) ) )
+      if ( ! apply_filters('tc_show_text_btt', 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_back_to_top' ) ) ) )
         return;
 
     	echo apply_filters(
@@ -302,7 +302,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
     * @since Customizr 3.3.27
     */
     function czr_write_sticky_footer_inline_css( $_css ){
-      if ( ! ( $this -> is_sticky_footer_enabled() || CZR___::$instance -> tc_is_customizing() ) )
+      if ( ! ( $this -> is_sticky_footer_enabled() || CZR___::$instance -> czr_is_customizing() ) )
         return $_css;
 
       $_css = sprintf("%s\n%s",
@@ -338,7 +338,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
     *
     */
     function czr_sticky_footer_push() {
-      if ( ! ( $this -> is_sticky_footer_enabled() || CZR___::$instance -> tc_is_customizing() ) )
+      if ( ! ( $this -> is_sticky_footer_enabled() || CZR___::$instance -> czr_is_customizing() ) )
         return;
 
       echo '<div id="tc-push-footer"></div>';
@@ -353,10 +353,10 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 		* @since Customizr 3.2.0
 		*/
 		function czr_render_back_to_top() {
-			if ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_back_to_top' ) ) )
+			if ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_back_to_top' ) ) )
                 return;
             printf('<div id="tc-footer-btt-wrapper" class="tc-btt-wrapper %1$s"><i class="btt-arrow"></i></div>',
-                esc_attr( CZR_utils::$inst -> tc_opt( 'tc_back_to_top_position' ) )
+                esc_attr( CZR_utils::$inst -> czr_opt( 'tc_back_to_top_position' ) )
             );
 		}
 
@@ -371,8 +371,8 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
 		function czr_set_widget_wrapper_class( $_original_classes ) {
 			$_no_icons_classes = array_merge($_original_classes, array('no-widget-icons'));
 
-			if ( 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_footer_widget_icon' ) ) )
-				return ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_title_icon' ) ) ) ? $_no_icons_classes : $_original_classes;
+			if ( 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_footer_widget_icon' ) ) )
+				return ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_title_icon' ) ) ) ? $_no_icons_classes : $_original_classes;
 			 //last condition
           	return $_no_icons_classes;
         }
@@ -386,7 +386,7 @@ if ( ! class_exists( 'CZR_footer_main' ) ) :
     * @return bool
     */
     function is_sticky_footer_enabled() {
-      return 1 == esc_attr( CZR_utils::$inst -> tc_opt( 'tc_sticky_footer') );
+      return 1 == esc_attr( CZR_utils::$inst -> czr_opt( 'tc_sticky_footer') );
     }
   }//end of class
 endif;

--- a/inc/parts/class-footer-footer_main.php
+++ b/inc/parts/class-footer-footer_main.php
@@ -11,8 +11,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_footer_main' ) ) :
-	class TC_footer_main {
+if ( ! class_exists( 'CZR_footer_main' ) ) :
+	class CZR_footer_main {
     static $instance;
     function __construct () {
       self::$instance =& $this;
@@ -80,7 +80,7 @@ if ( ! class_exists( 'TC_footer_main' ) ) :
 	  function tc_widgets_footer() {
     	//checks if there's at least one active widget area in footer.php.php
     	$status 					= false;
-    	$footer_widgets 			= apply_filters( 'tc_footer_widgets', TC_init::$instance -> footer_widgets );
+    	$footer_widgets 			= apply_filters( 'tc_footer_widgets', CZR_init::$instance -> footer_widgets );
     	foreach ( $footer_widgets as $key => $area ) {
     		$status = is_active_sidebar( $key ) ? true : $status;
     	}
@@ -92,7 +92,7 @@ if ( ! class_exists( 'TC_footer_main' ) ) :
       }
 
 			//hack to render white color icons if skin is grey or black
-			$skin_class 					= ( in_array( TC_utils::$inst->tc_opt( 'tc_skin') , array('grey.css' , 'black.css')) ) ? 'white-icons' : '';
+			$skin_class 					= ( in_array( CZR_utils::$inst->tc_opt( 'tc_skin') , array('grey.css' , 'black.css')) ) ? 'white-icons' : '';
 			$footer_widgets_wrapper_classes = implode(" ", apply_filters( 'tc_footer_widget_wrapper_class' , array('container' , 'footer-widgets', $skin_class) ) );
 			ob_start();
 			?>
@@ -132,7 +132,7 @@ if ( ! class_exists( 'TC_footer_main' ) ) :
     * @since Customizr 3.3
     */
     private function tc_display_footer_placeholder() {
-      if ( ! TC_placeholders::tc_is_widget_placeholder_enabled( 'footer' ) )
+      if ( ! CZR_placeholders::tc_is_widget_placeholder_enabled( 'footer' ) )
         return;
 
       ?>
@@ -148,7 +148,7 @@ if ( ! class_exists( 'TC_footer_main' ) ) :
 
           printf('<p><strong>%1$s</strong></p>',
               sprintf( __("Add widgets to the footer %s or %s.", "customizr"),
-                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', TC_utils::tc_get_customizer_url( array( 'panel' => 'widgets') ), __( "Add widgets", "customizr"), __("now", "customizr") ),
+                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', CZR_utils::tc_get_customizer_url( array( 'panel' => 'widgets') ), __( "Add widgets", "customizr"), __("now", "customizr") ),
                 sprintf('<a class="tc-inline-dismiss-notice" data-position="footer" href="#" title="%1$s">%1$s</a>',
                   __( 'dismiss this notice', 'customizr')
                 )
@@ -207,9 +207,9 @@ if ( ! class_exists( 'TC_footer_main' ) ) :
 	    	//when do we display this block ?
 	        //1) if customizing always. (is hidden if empty of disabled)
 	        //2) if not customizing : must be enabled and have social networks.
-	    	$_nothing_to_render = ( 0 == esc_attr( TC_utils::$inst->tc_opt( 'tc_social_in_footer') ) ) || ! tc__f( '__get_socials' );
-	    	$_hide_socials = $_nothing_to_render && TC___::$instance -> tc_is_customizing();
-	    	$_nothing_to_render = $_nothing_to_render && ! TC___::$instance -> tc_is_customizing();
+	    	$_nothing_to_render = ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_social_in_footer') ) ) || ! tc__f( '__get_socials' );
+	    	$_hide_socials = $_nothing_to_render && CZR___::$instance -> tc_is_customizing();
+	    	$_nothing_to_render = $_nothing_to_render && ! CZR___::$instance -> tc_is_customizing();
 
 	      	echo apply_filters(
 	      		'tc_colophon_left_block',
@@ -241,7 +241,7 @@ if ( ! class_exists( 'TC_footer_main' ) ) :
 		    		apply_filters( 'tc_colophon_center_block_class', 'span6 credits' ),
 		    		sprintf( '<p>%1$s %2$s %3$s</p>',
 						    apply_filters( 'tc_copyright_link', sprintf( '&middot; <span class="tc-copyright-text">&copy; %1$s</span> <a href="%2$s" title="%3$s" rel="bookmark">%3$s</a>', esc_attr( date( 'Y' ) ), esc_url( home_url() ), esc_attr( get_bloginfo() ) ) ),
-                            apply_filters( 'tc_credit_link', sprintf( '&middot; <span class="tc-credits-text">Designed by</span> %1$s', '<a href="'.TC_WEBSITE.'">Press Customizr</a>' ) ),
+                            apply_filters( 'tc_credit_link', sprintf( '&middot; <span class="tc-credits-text">Designed by</span> %1$s', '<a href="'.CZR_WEBSITE.'">Press Customizr</a>' ) ),
                             apply_filters( 'tc_wp_powered', sprintf( '&middot; <span class="tc-wp-powered-text">%1$s</span> <a class="icon-wordpress" target="_blank" href="https://wordpress.org" title="%2$s"></a> &middot;',
                               __('Powered by', 'customizr'),
                               __('Powered by Wordpress', 'customizr')
@@ -261,7 +261,7 @@ if ( ! class_exists( 'TC_footer_main' ) ) :
 		*/
         function tc_colophon_right_block() {
           //since 3.4.16 BTT button excludes BTT text
-      if ( ! apply_filters('tc_show_text_btt', 0 == esc_attr( TC_utils::$inst->tc_opt( 'tc_show_back_to_top' ) ) ) )
+      if ( ! apply_filters('tc_show_text_btt', 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_back_to_top' ) ) ) )
         return;
 
     	echo apply_filters(
@@ -302,7 +302,7 @@ if ( ! class_exists( 'TC_footer_main' ) ) :
     * @since Customizr 3.3.27
     */
     function tc_write_sticky_footer_inline_css( $_css ){
-      if ( ! ( $this -> is_sticky_footer_enabled() || TC___::$instance -> tc_is_customizing() ) )
+      if ( ! ( $this -> is_sticky_footer_enabled() || CZR___::$instance -> tc_is_customizing() ) )
         return $_css;
 
       $_css = sprintf("%s\n%s",
@@ -338,7 +338,7 @@ if ( ! class_exists( 'TC_footer_main' ) ) :
     *
     */
     function tc_sticky_footer_push() {
-      if ( ! ( $this -> is_sticky_footer_enabled() || TC___::$instance -> tc_is_customizing() ) )
+      if ( ! ( $this -> is_sticky_footer_enabled() || CZR___::$instance -> tc_is_customizing() ) )
         return;
 
       echo '<div id="tc-push-footer"></div>';
@@ -353,10 +353,10 @@ if ( ! class_exists( 'TC_footer_main' ) ) :
 		* @since Customizr 3.2.0
 		*/
 		function tc_render_back_to_top() {
-			if ( 0 == esc_attr( TC_utils::$inst->tc_opt( 'tc_show_back_to_top' ) ) )
+			if ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_back_to_top' ) ) )
                 return;
             printf('<div id="tc-footer-btt-wrapper" class="tc-btt-wrapper %1$s"><i class="btt-arrow"></i></div>',
-                esc_attr( TC_utils::$inst -> tc_opt( 'tc_back_to_top_position' ) )
+                esc_attr( CZR_utils::$inst -> tc_opt( 'tc_back_to_top_position' ) )
             );
 		}
 
@@ -371,8 +371,8 @@ if ( ! class_exists( 'TC_footer_main' ) ) :
 		function tc_set_widget_wrapper_class( $_original_classes ) {
 			$_no_icons_classes = array_merge($_original_classes, array('no-widget-icons'));
 
-			if ( 1 == esc_attr( TC_utils::$inst->tc_opt( 'tc_show_footer_widget_icon' ) ) )
-				return ( 0 == esc_attr( TC_utils::$inst->tc_opt( 'tc_show_title_icon' ) ) ) ? $_no_icons_classes : $_original_classes;
+			if ( 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_footer_widget_icon' ) ) )
+				return ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_title_icon' ) ) ) ? $_no_icons_classes : $_original_classes;
 			 //last condition
           	return $_no_icons_classes;
         }
@@ -386,7 +386,7 @@ if ( ! class_exists( 'TC_footer_main' ) ) :
     * @return bool
     */
     function is_sticky_footer_enabled() {
-      return 1 == esc_attr( TC_utils::$inst -> tc_opt( 'tc_sticky_footer') );
+      return 1 == esc_attr( CZR_utils::$inst -> tc_opt( 'tc_sticky_footer') );
     }
   }//end of class
 endif;

--- a/inc/parts/class-header-header_main.php
+++ b/inc/parts/class-header-header_main.php
@@ -76,7 +76,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
   	  }
 
       //add a 100% wide container just after the sticky header to reset margin top
-      if ( 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_sticky_header' ) ) || CZR___::$instance -> tc_is_customizing() )
+      if ( 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_sticky_header' ) ) || CZR___::$instance -> czr_is_customizing() )
         add_action( '__after_header'              , array( $this, 'tc_reset_margin_top_after_sticky_header'), 0 );
 
     }
@@ -153,7 +153,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
       if ( function_exists('has_site_icon') && has_site_icon() )
         return;
 
-      $_fav_option  			= esc_attr( CZR_utils::$inst->tc_opt( 'tc_fav_upload') );
+      $_fav_option  			= esc_attr( CZR_utils::$inst->czr_opt( 'tc_fav_upload') );
      	if ( ! $_fav_option || is_null($_fav_option) )
      		return;
 
@@ -164,7 +164,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
      		$_attachment_data 	= apply_filters( 'tc_fav_attachment_img' , wp_get_attachment_image_src( $_fav_option , 'full' ) );
      		$_fav_src 			= $_attachment_data[0];
      	} else { //old treatment
-     		$_saved_path 		= esc_url ( CZR_utils::$inst->tc_opt( 'tc_fav_upload') );
+     		$_saved_path 		= esc_url ( CZR_utils::$inst->czr_opt( 'tc_fav_upload') );
      		//rebuild the path : check if the full path is already saved in DB. If not, then rebuild it.
        	$upload_dir 		= wp_upload_dir();
        	$_fav_src 			= ( false !== strpos( $_saved_path , '/wp-content/' ) ) ? $_saved_path : $upload_dir['baseurl'] . $_saved_path;
@@ -206,7 +206,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
       $logo_classes 			= array( 'brand', 'span3');
       foreach ( $logos_type as $logo_type ){
           // check if we have to print the sticky logo
-          if ( '_sticky_' == $logo_type && ! $this -> tc_use_sticky_logo() )
+          if ( '_sticky_' == $logo_type && ! $this -> czr_use_sticky_logo() )
               continue;
 
           //check if the logo is a path or is numeric
@@ -215,7 +215,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
           $_width 				= false;
           $_height 				= false;
           $_attachement_id 		= false;
-          $_logo_option  			= esc_attr( CZR_utils::$inst->tc_opt( "tc{$logo_type}logo_upload") );
+          $_logo_option  			= esc_attr( CZR_utils::$inst->czr_opt( "tc{$logo_type}logo_upload") );
           //check if option is an attachement id or a path (for backward compatibility)
           if ( is_numeric($_logo_option) ) {
               $_attachement_id 	= $_logo_option;
@@ -226,15 +226,15 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
           } else { //old treatment
               //rebuild the logo path : check if the full path is already saved in DB. If not, then rebuild it.
               $upload_dir 			= wp_upload_dir();
-              $_saved_path 			= esc_url ( CZR_utils::$inst->tc_opt( "tc{$logo_type}logo_upload") );
+              $_saved_path 			= esc_url ( CZR_utils::$inst->czr_opt( "tc{$logo_type}logo_upload") );
               $_logo_src 				= ( false !== strpos( $_saved_path , '/wp-content/' ) ) ? $_saved_path : $upload_dir['baseurl'] . $_saved_path;
           }
 
           //hook + makes ssl compliant
           $_logo_src    			= apply_filters( "tc{$logo_type}logo_src" , is_ssl() ? str_replace('http://', 'https://', $_logo_src) : $_logo_src ) ;
 
-          $logo_resize 			= ( $logo_type == '_' ) ? esc_attr( CZR_utils::$inst->tc_opt( 'tc_logo_resize') ) : '';
-          $filetype 				= CZR_utils::$inst -> tc_check_filetype ($_logo_src);
+          $logo_resize 			= ( $logo_type == '_' ) ? esc_attr( CZR_utils::$inst->czr_opt( 'tc_logo_resize') ) : '';
+          $filetype 				= CZR_utils::$inst -> czr_check_filetype ($_logo_src);
           if( ! empty($_logo_src) && in_array( $filetype['ext'], $accepted_formats ) ) {
               $_args 		= array(
                       'logo_src' 				=> $_logo_src,
@@ -244,14 +244,14 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
                       'logo_height' 			=> $_height,
                       'logo_type'             => trim($logo_type,'_')
               );
-              $logos_img[] = $this -> tc_logo_img_view($_args);
+              $logos_img[] = $this -> czr_logo_img_view($_args);
           }
       }//end foreach
       //render
       if ( count($logos_img) == 0 )
-          $this -> tc_title_view($logo_classes);
+          $this -> czr_title_view($logo_classes);
       else
-          $this -> tc_logo_view( array (
+          $this -> czr_logo_view( array (
             'logo_class'   => $logo_classes,
             // normal logo first
             'logos_img'    => array_reverse($logos_img)
@@ -313,7 +313,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
                                 apply_filters( 'tc_logo_max_width', 250 ),
                                 apply_filters( 'tc_logo_max_height', 100 )
                                 ) : '',
-        implode(' ' , apply_filters('tc_logo_other_attributes' , ( 0 == CZR_utils::$inst->tc_opt( 'tc_retina_support' ) ) ? array('data-no-retina') : array() ) ),
+        implode(' ' , apply_filters('tc_logo_other_attributes' , ( 0 == CZR_utils::$inst->czr_opt( 'tc_retina_support' ) ) ? array('data-no-retina') : array() ) ),
         $logo_type,
         $logo_attachment_id ? sprintf( 'attachment-%1$s', $logo_attachment_id ) : ''
       );
@@ -440,8 +440,8 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
         //when do we display this block ?
         //1) if customizing always. (is hidden if empty of disabled)
         //2) if not customizing : must be enabled and have social networks.
-        $_nothing_to_render = ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_social_in_header') ) ) || ! tc__f( '__get_socials' );
-        if ( ! CZR___::$instance -> tc_is_customizing() && $_nothing_to_render )
+        $_nothing_to_render = ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_social_in_header') ) ) || ! czr__f( '__get_socials' );
+        if ( ! CZR___::$instance -> czr_is_customizing() && $_nothing_to_render )
         	return;
 
         //class added if not resp
@@ -450,7 +450,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 
         $html = sprintf('<div class="social-block %1$s" %3$s>%2$s</div>',
         		$social_header_block_class,
-        		tc__f( '__get_socials' ),
+        		czr__f( '__get_socials' ),
         		$_nothing_to_render ? 'style="display:none"' : ''
         );
 
@@ -518,7 +518,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
     */
 		function czr_write_header_inline_css( $_css ) {
       //TOP BORDER
-			if ( 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_top_border') ) ) {
+			if ( 1 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_top_border') ) ) {
   			$_css = sprintf("%s\n%s",
   				$_css,
   				"header.tc-header {border-top: none;}\n"
@@ -526,7 +526,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 	    }
 
       //STICKY HEADER
-	    if ( 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_sticky_shrink_title_logo') ) || CZR___::$instance -> tc_is_customizing() ) {
+	    if ( 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_sticky_shrink_title_logo') ) || CZR___::$instance -> czr_is_customizing() ) {
 	    	$_logo_shrink 	= implode (';' , apply_filters('tc_logo_shrink_css' , array("height:30px!important","width:auto!important") )	);
 
 	    	$_title_font 	= implode (';' , apply_filters('tc_title_shrink_css' , array("font-size:0.6em","opacity:0.8","line-height:1.2em") ) );
@@ -543,7 +543,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 			}
 
       //STICKY LOGO
-      if ( $this -> tc_use_sticky_logo() ) {
+      if ( $this -> czr_use_sticky_logo() ) {
         $_css = sprintf( "%s\n%s",
             $_css,
             ".site-logo img.sticky {
@@ -559,8 +559,8 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
       }
 
 			//HEADER Z-INDEX
-	    if ( 100 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_sticky_z_index') ) ) {
-	    	$_custom_z_index 	= esc_attr( CZR_utils::$inst->tc_opt( 'tc_sticky_z_index') );
+	    if ( 100 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_sticky_z_index') ) ) {
+	    	$_custom_z_index 	= esc_attr( CZR_utils::$inst->czr_opt( 'tc_sticky_z_index') );
 		    $_css = sprintf("%s\n%s",
   		      $_css,
   		      ".tc-no-sticky-header .tc-header, .tc-sticky-header .tc-header {
@@ -582,10 +582,10 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
     */
     function czr_add_body_classes($_classes) {
       //STICKY HEADER
-    	if ( 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_sticky_header' ) ) ) {
+    	if ( 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_sticky_header' ) ) ) {
      		$_classes = array_merge( $_classes, array('tc-sticky-header', 'sticky-disabled') );
      		//STICKY TRANSPARENT ON SCROLL
-       	if ( 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_sticky_transparent_on_scroll' ) ) )
+       	if ( 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_sticky_transparent_on_scroll' ) ) )
        		$_classes = array_merge( $_classes, array('tc-transparent-on-scroll') );
        	else
        		$_classes = array_merge( $_classes, array('tc-solid-color-on-scroll') );
@@ -595,11 +595,11 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
      	}
 
       //No navbar box
-      if ( 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_display_boxed_navbar') ) )
+      if ( 1 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_display_boxed_navbar') ) )
           $_classes = array_merge( $_classes , array('no-navbar' ) );
 
       //SKIN CLASS
-      $_skin = sprintf( 'skin-%s' , basename( CZR_init::$instance -> tc_get_style_src() ) );
+      $_skin = sprintf( 'skin-%s' , basename( CZR_init::$instance -> czr_get_style_src() ) );
       array_push( $_classes, substr( $_skin , 0 , strpos($_skin, '.') ) );
 
       return $_classes;
@@ -619,12 +619,12 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 			if ( ! is_array($_classes) )
 				return $_classes;
 
-			$_show_tagline 			= 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_sticky_show_tagline') );
-      $_show_title_logo 		= 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_sticky_show_title_logo') );
-      $_use_sticky_logo 		= $this -> tc_use_sticky_logo();
-			$_shrink_title_logo 	= 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_sticky_shrink_title_logo') );
-			$_show_menu 			  = 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_sticky_show_menu') );
-			$_header_layout 		= "logo-" . esc_attr( CZR_utils::$inst->tc_opt( 'tc_header_layout' ) );
+			$_show_tagline 			= 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_sticky_show_tagline') );
+      $_show_title_logo 		= 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_sticky_show_title_logo') );
+      $_use_sticky_logo 		= $this -> czr_use_sticky_logo();
+			$_shrink_title_logo 	= 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_sticky_shrink_title_logo') );
+			$_show_menu 			  = 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_sticky_show_menu') );
+			$_header_layout 		= "logo-" . esc_attr( CZR_utils::$inst->czr_opt( 'tc_header_layout' ) );
 			$_add_classes 			= array(
 				$_show_tagline ? 'tc-tagline-on' : 'tc-tagline-off',
         $_show_title_logo ? 'tc-title-logo-on' : 'tc-title-logo-off',
@@ -645,10 +645,10 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
     * @since Customizr 3.2.9
     */
     function czr_use_sticky_logo(){
-        if ( ! esc_attr( CZR_utils::$inst->tc_opt( "tc_sticky_logo_upload") ) )
+        if ( ! esc_attr( CZR_utils::$inst->czr_opt( "tc_sticky_logo_upload") ) )
             return false;
-        if ( ! ( esc_attr( CZR_utils::$inst->tc_opt( "tc_sticky_header") ) &&
-                     esc_attr( CZR_utils::$inst->tc_opt( 'tc_sticky_show_title_logo') )
+        if ( ! ( esc_attr( CZR_utils::$inst->czr_opt( "tc_sticky_header") ) &&
+                     esc_attr( CZR_utils::$inst->czr_opt( 'tc_sticky_show_title_logo') )
                )
         )
             return false;
@@ -664,10 +664,10 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
    	*/
 		function czr_set_tagline_visibility($html) {
 			//if customizing just hide it
-			if ( CZR___::$instance -> tc_is_customizing() && 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_tagline') ) )
+			if ( CZR___::$instance -> czr_is_customizing() && 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_tagline') ) )
 				return str_replace('site-description"', 'site-description" style="display:none"', $html);
 			//live context, don't paint it at all
-			if ( ! CZR___::$instance -> tc_is_customizing() && 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_tagline') ) )
+			if ( ! CZR___::$instance -> czr_is_customizing() && 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_tagline') ) )
 				return '';
 			return $html;
 		}
@@ -684,7 +684,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 			if ( ! is_array($_classes) )
 				return $_classes;
 
-			$_layout = esc_attr( CZR_utils::$inst->tc_opt( 'tc_header_layout') );
+			$_layout = esc_attr( CZR_utils::$inst->czr_opt( 'tc_header_layout') );
 			switch ($_layout) {
 				case 'left':
 					$_classes = array('brand', 'span3' , 'pull-left');

--- a/inc/parts/class-header-header_main.php
+++ b/inc/parts/class-header-header_main.php
@@ -440,7 +440,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
         //when do we display this block ?
         //1) if customizing always. (is hidden if empty of disabled)
         //2) if not customizing : must be enabled and have social networks.
-        $_nothing_to_render = ( 0 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'czr_fn_social_in_header') ) ) || ! czr_fn__f( '__get_socials' );
+        $_nothing_to_render = ( 0 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_social_in_header') ) ) || ! czr_fn__f( '__get_socials' );
         if ( ! CZR___::$instance -> czr_fn_is_customizing() && $_nothing_to_render )
         	return;
 

--- a/inc/parts/class-header-header_main.php
+++ b/inc/parts/class-header-header_main.php
@@ -11,13 +11,13 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_header_main' ) ) :
-	class TC_header_main {
+if ( ! class_exists( 'CZR_header_main' ) ) :
+	class CZR_header_main {
     static $instance;
     function __construct () {
       self::$instance =& $this;
       //Set header hooks
-      //we have to use 'wp' action hook to show header in multisite wp-signup/wp-activate.php which don't fire template_redirect hook 
+      //we have to use 'wp' action hook to show header in multisite wp-signup/wp-activate.php which don't fire template_redirect hook
       //(see https://github.com/presscustomizr/customizr/issues/395)
       add_action ( 'wp'                    , array( $this , 'tc_set_header_hooks' ) );
 
@@ -76,7 +76,7 @@ if ( ! class_exists( 'TC_header_main' ) ) :
   	  }
 
       //add a 100% wide container just after the sticky header to reset margin top
-      if ( 1 == esc_attr( TC_utils::$inst->tc_opt( 'tc_sticky_header' ) ) || TC___::$instance -> tc_is_customizing() )
+      if ( 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_sticky_header' ) ) || CZR___::$instance -> tc_is_customizing() )
         add_action( '__after_header'              , array( $this, 'tc_reset_margin_top_after_sticky_header'), 0 );
 
     }
@@ -153,7 +153,7 @@ if ( ! class_exists( 'TC_header_main' ) ) :
       if ( function_exists('has_site_icon') && has_site_icon() )
         return;
 
-      $_fav_option  			= esc_attr( TC_utils::$inst->tc_opt( 'tc_fav_upload') );
+      $_fav_option  			= esc_attr( CZR_utils::$inst->tc_opt( 'tc_fav_upload') );
      	if ( ! $_fav_option || is_null($_fav_option) )
      		return;
 
@@ -164,7 +164,7 @@ if ( ! class_exists( 'TC_header_main' ) ) :
      		$_attachment_data 	= apply_filters( 'tc_fav_attachment_img' , wp_get_attachment_image_src( $_fav_option , 'full' ) );
      		$_fav_src 			= $_attachment_data[0];
      	} else { //old treatment
-     		$_saved_path 		= esc_url ( TC_utils::$inst->tc_opt( 'tc_fav_upload') );
+     		$_saved_path 		= esc_url ( CZR_utils::$inst->tc_opt( 'tc_fav_upload') );
      		//rebuild the path : check if the full path is already saved in DB. If not, then rebuild it.
        	$upload_dir 		= wp_upload_dir();
        	$_fav_src 			= ( false !== strpos( $_saved_path , '/wp-content/' ) ) ? $_saved_path : $upload_dir['baseurl'] . $_saved_path;
@@ -215,7 +215,7 @@ if ( ! class_exists( 'TC_header_main' ) ) :
           $_width 				= false;
           $_height 				= false;
           $_attachement_id 		= false;
-          $_logo_option  			= esc_attr( TC_utils::$inst->tc_opt( "tc{$logo_type}logo_upload") );
+          $_logo_option  			= esc_attr( CZR_utils::$inst->tc_opt( "tc{$logo_type}logo_upload") );
           //check if option is an attachement id or a path (for backward compatibility)
           if ( is_numeric($_logo_option) ) {
               $_attachement_id 	= $_logo_option;
@@ -226,15 +226,15 @@ if ( ! class_exists( 'TC_header_main' ) ) :
           } else { //old treatment
               //rebuild the logo path : check if the full path is already saved in DB. If not, then rebuild it.
               $upload_dir 			= wp_upload_dir();
-              $_saved_path 			= esc_url ( TC_utils::$inst->tc_opt( "tc{$logo_type}logo_upload") );
+              $_saved_path 			= esc_url ( CZR_utils::$inst->tc_opt( "tc{$logo_type}logo_upload") );
               $_logo_src 				= ( false !== strpos( $_saved_path , '/wp-content/' ) ) ? $_saved_path : $upload_dir['baseurl'] . $_saved_path;
           }
 
           //hook + makes ssl compliant
           $_logo_src    			= apply_filters( "tc{$logo_type}logo_src" , is_ssl() ? str_replace('http://', 'https://', $_logo_src) : $_logo_src ) ;
 
-          $logo_resize 			= ( $logo_type == '_' ) ? esc_attr( TC_utils::$inst->tc_opt( 'tc_logo_resize') ) : '';
-          $filetype 				= TC_utils::$inst -> tc_check_filetype ($_logo_src);
+          $logo_resize 			= ( $logo_type == '_' ) ? esc_attr( CZR_utils::$inst->tc_opt( 'tc_logo_resize') ) : '';
+          $filetype 				= CZR_utils::$inst -> tc_check_filetype ($_logo_src);
           if( ! empty($_logo_src) && in_array( $filetype['ext'], $accepted_formats ) ) {
               $_args 		= array(
                       'logo_src' 				=> $_logo_src,
@@ -313,7 +313,7 @@ if ( ! class_exists( 'TC_header_main' ) ) :
                                 apply_filters( 'tc_logo_max_width', 250 ),
                                 apply_filters( 'tc_logo_max_height', 100 )
                                 ) : '',
-        implode(' ' , apply_filters('tc_logo_other_attributes' , ( 0 == TC_utils::$inst->tc_opt( 'tc_retina_support' ) ) ? array('data-no-retina') : array() ) ),
+        implode(' ' , apply_filters('tc_logo_other_attributes' , ( 0 == CZR_utils::$inst->tc_opt( 'tc_retina_support' ) ) ? array('data-no-retina') : array() ) ),
         $logo_type,
         $logo_attachment_id ? sprintf( 'attachment-%1$s', $logo_attachment_id ) : ''
       );
@@ -403,7 +403,7 @@ if ( ! class_exists( 'TC_header_main' ) ) :
 		/**
   	* New menu view.
   	* One menu instead of two
-  	* Original function : TC_header::tc_navbar_display
+  	* Original function : CZR_header::tc_navbar_display
   	*
   	* @package Customizr
   	* @since Customizr 3.2.0
@@ -440,8 +440,8 @@ if ( ! class_exists( 'TC_header_main' ) ) :
         //when do we display this block ?
         //1) if customizing always. (is hidden if empty of disabled)
         //2) if not customizing : must be enabled and have social networks.
-        $_nothing_to_render = ( 0 == esc_attr( TC_utils::$inst->tc_opt( 'tc_social_in_header') ) ) || ! tc__f( '__get_socials' );
-        if ( ! TC___::$instance -> tc_is_customizing() && $_nothing_to_render )
+        $_nothing_to_render = ( 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_social_in_header') ) ) || ! tc__f( '__get_socials' );
+        if ( ! CZR___::$instance -> tc_is_customizing() && $_nothing_to_render )
         	return;
 
         //class added if not resp
@@ -518,7 +518,7 @@ if ( ! class_exists( 'TC_header_main' ) ) :
     */
 		function tc_write_header_inline_css( $_css ) {
       //TOP BORDER
-			if ( 1 != esc_attr( TC_utils::$inst->tc_opt( 'tc_top_border') ) ) {
+			if ( 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_top_border') ) ) {
   			$_css = sprintf("%s\n%s",
   				$_css,
   				"header.tc-header {border-top: none;}\n"
@@ -526,7 +526,7 @@ if ( ! class_exists( 'TC_header_main' ) ) :
 	    }
 
       //STICKY HEADER
-	    if ( 0 != esc_attr( TC_utils::$inst->tc_opt( 'tc_sticky_shrink_title_logo') ) || TC___::$instance -> tc_is_customizing() ) {
+	    if ( 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_sticky_shrink_title_logo') ) || CZR___::$instance -> tc_is_customizing() ) {
 	    	$_logo_shrink 	= implode (';' , apply_filters('tc_logo_shrink_css' , array("height:30px!important","width:auto!important") )	);
 
 	    	$_title_font 	= implode (';' , apply_filters('tc_title_shrink_css' , array("font-size:0.6em","opacity:0.8","line-height:1.2em") ) );
@@ -559,8 +559,8 @@ if ( ! class_exists( 'TC_header_main' ) ) :
       }
 
 			//HEADER Z-INDEX
-	    if ( 100 != esc_attr( TC_utils::$inst->tc_opt( 'tc_sticky_z_index') ) ) {
-	    	$_custom_z_index 	= esc_attr( TC_utils::$inst->tc_opt( 'tc_sticky_z_index') );
+	    if ( 100 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_sticky_z_index') ) ) {
+	    	$_custom_z_index 	= esc_attr( CZR_utils::$inst->tc_opt( 'tc_sticky_z_index') );
 		    $_css = sprintf("%s\n%s",
   		      $_css,
   		      ".tc-no-sticky-header .tc-header, .tc-sticky-header .tc-header {
@@ -582,10 +582,10 @@ if ( ! class_exists( 'TC_header_main' ) ) :
     */
     function tc_add_body_classes($_classes) {
       //STICKY HEADER
-    	if ( 1 == esc_attr( TC_utils::$inst->tc_opt( 'tc_sticky_header' ) ) ) {
+    	if ( 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_sticky_header' ) ) ) {
      		$_classes = array_merge( $_classes, array('tc-sticky-header', 'sticky-disabled') );
      		//STICKY TRANSPARENT ON SCROLL
-       	if ( 1 == esc_attr( TC_utils::$inst->tc_opt( 'tc_sticky_transparent_on_scroll' ) ) )
+       	if ( 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_sticky_transparent_on_scroll' ) ) )
        		$_classes = array_merge( $_classes, array('tc-transparent-on-scroll') );
        	else
        		$_classes = array_merge( $_classes, array('tc-solid-color-on-scroll') );
@@ -595,11 +595,11 @@ if ( ! class_exists( 'TC_header_main' ) ) :
      	}
 
       //No navbar box
-      if ( 1 != esc_attr( TC_utils::$inst->tc_opt( 'tc_display_boxed_navbar') ) )
+      if ( 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_display_boxed_navbar') ) )
           $_classes = array_merge( $_classes , array('no-navbar' ) );
 
       //SKIN CLASS
-      $_skin = sprintf( 'skin-%s' , basename( TC_init::$instance -> tc_get_style_src() ) );
+      $_skin = sprintf( 'skin-%s' , basename( CZR_init::$instance -> tc_get_style_src() ) );
       array_push( $_classes, substr( $_skin , 0 , strpos($_skin, '.') ) );
 
       return $_classes;
@@ -619,12 +619,12 @@ if ( ! class_exists( 'TC_header_main' ) ) :
 			if ( ! is_array($_classes) )
 				return $_classes;
 
-			$_show_tagline 			= 0 != esc_attr( TC_utils::$inst->tc_opt( 'tc_sticky_show_tagline') );
-      $_show_title_logo 		= 0 != esc_attr( TC_utils::$inst->tc_opt( 'tc_sticky_show_title_logo') );
+			$_show_tagline 			= 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_sticky_show_tagline') );
+      $_show_title_logo 		= 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_sticky_show_title_logo') );
       $_use_sticky_logo 		= $this -> tc_use_sticky_logo();
-			$_shrink_title_logo 	= 0 != esc_attr( TC_utils::$inst->tc_opt( 'tc_sticky_shrink_title_logo') );
-			$_show_menu 			  = 0 != esc_attr( TC_utils::$inst->tc_opt( 'tc_sticky_show_menu') );
-			$_header_layout 		= "logo-" . esc_attr( TC_utils::$inst->tc_opt( 'tc_header_layout' ) );
+			$_shrink_title_logo 	= 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_sticky_shrink_title_logo') );
+			$_show_menu 			  = 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_sticky_show_menu') );
+			$_header_layout 		= "logo-" . esc_attr( CZR_utils::$inst->tc_opt( 'tc_header_layout' ) );
 			$_add_classes 			= array(
 				$_show_tagline ? 'tc-tagline-on' : 'tc-tagline-off',
         $_show_title_logo ? 'tc-title-logo-on' : 'tc-title-logo-off',
@@ -645,10 +645,10 @@ if ( ! class_exists( 'TC_header_main' ) ) :
     * @since Customizr 3.2.9
     */
     function tc_use_sticky_logo(){
-        if ( ! esc_attr( TC_utils::$inst->tc_opt( "tc_sticky_logo_upload") ) )
+        if ( ! esc_attr( CZR_utils::$inst->tc_opt( "tc_sticky_logo_upload") ) )
             return false;
-        if ( ! ( esc_attr( TC_utils::$inst->tc_opt( "tc_sticky_header") ) &&
-                     esc_attr( TC_utils::$inst->tc_opt( 'tc_sticky_show_title_logo') )
+        if ( ! ( esc_attr( CZR_utils::$inst->tc_opt( "tc_sticky_header") ) &&
+                     esc_attr( CZR_utils::$inst->tc_opt( 'tc_sticky_show_title_logo') )
                )
         )
             return false;
@@ -664,10 +664,10 @@ if ( ! class_exists( 'TC_header_main' ) ) :
    	*/
 		function tc_set_tagline_visibility($html) {
 			//if customizing just hide it
-			if ( TC___::$instance -> tc_is_customizing() && 0 == esc_attr( TC_utils::$inst->tc_opt( 'tc_show_tagline') ) )
+			if ( CZR___::$instance -> tc_is_customizing() && 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_tagline') ) )
 				return str_replace('site-description"', 'site-description" style="display:none"', $html);
 			//live context, don't paint it at all
-			if ( ! TC___::$instance -> tc_is_customizing() && 0 == esc_attr( TC_utils::$inst->tc_opt( 'tc_show_tagline') ) )
+			if ( ! CZR___::$instance -> tc_is_customizing() && 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_tagline') ) )
 				return '';
 			return $html;
 		}
@@ -684,7 +684,7 @@ if ( ! class_exists( 'TC_header_main' ) ) :
 			if ( ! is_array($_classes) )
 				return $_classes;
 
-			$_layout = esc_attr( TC_utils::$inst->tc_opt( 'tc_header_layout') );
+			$_layout = esc_attr( CZR_utils::$inst->tc_opt( 'tc_header_layout') );
 			switch ($_layout) {
 				case 'left':
 					$_classes = array('brand', 'span3' , 'pull-left');

--- a/inc/parts/class-header-header_main.php
+++ b/inc/parts/class-header-header_main.php
@@ -19,16 +19,16 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
       //Set header hooks
       //we have to use 'wp' action hook to show header in multisite wp-signup/wp-activate.php which don't fire template_redirect hook
       //(see https://github.com/presscustomizr/customizr/issues/395)
-      add_action ( 'wp'                    , array( $this , 'tc_set_header_hooks' ) );
+      add_action ( 'wp'                    , array( $this , 'czr_set_header_hooks' ) );
 
       //Set header options
-      add_action ( 'wp'                    , array( $this , 'tc_set_header_options' ) );
+      add_action ( 'wp'                    , array( $this , 'czr_set_header_options' ) );
 
       //! tc_user_options_style filter is shared by several classes => must always check the local context inside the callback before appending new css
       //fired on hook : wp_enqueue_scripts
       //Set thumbnail specific design based on user options
       //Set top border style option
-      add_filter( 'tc_user_options_style'  , array( $this , 'tc_write_header_inline_css') );
+      add_filter( 'tc_user_options_style'  , array( $this , 'czr_write_header_inline_css') );
     }
 
 
@@ -45,10 +45,10 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 		*/
     function czr_set_header_hooks() {
     	//html > head actions
-      add_action ( '__before_body'	  , array( $this , 'tc_head_display' ));
+      add_action ( '__before_body'	  , array( $this , 'czr_head_display' ));
 
       //The WP favicon (introduced in WP 4.3) will be used in priority
-      add_action ( 'wp_head'     		  , array( $this , 'tc_favicon_display' ));
+      add_action ( 'wp_head'     		  , array( $this , 'czr_favicon_display' ));
 
       //html > header actions
       add_action ( '__before_main_wrapper'	, 'get_header');
@@ -57,27 +57,27 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
       if ( ! apply_filters( 'tc_display_header', true ) )
         return;
 
-      add_action ( '__header' 				, array( $this , 'tc_prepare_logo_title_display' ) , 10 );
-      add_action ( '__header' 				, array( $this , 'tc_tagline_display' ) , 20, 1 );
-      add_action ( '__header' 				, array( $this , 'tc_navbar_display' ) , 30 );
+      add_action ( '__header' 				, array( $this , 'czr_prepare_logo_title_display' ) , 10 );
+      add_action ( '__header' 				, array( $this , 'czr_tagline_display' ) , 20, 1 );
+      add_action ( '__header' 				, array( $this , 'czr_navbar_display' ) , 30 );
 
       //New menu view (since 3.2.0)
-      add_filter ( 'tc_navbar_display', array( $this , 'tc_new_menu_view'), 10, 2);
+      add_filter ( 'czr_navbar_display', array( $this , 'czr_new_menu_view'), 10, 2);
 
       //body > header > navbar actions ordered by priority
   	  // GY : switch order for RTL sites
   	  if (is_rtl()) {
-        add_action ( '__navbar' 				, array( $this , 'tc_social_in_header' ) , 20, 2 );
-        add_action ( '__navbar' 				, array( $this , 'tc_tagline_display' ) , 10, 1 );
+        add_action ( '__navbar' 				, array( $this , 'czr_social_in_header' ) , 20, 2 );
+        add_action ( '__navbar' 				, array( $this , 'czr_tagline_display' ) , 10, 1 );
   	  }
   	  else {
-        add_action ( '__navbar' 				, array( $this , 'tc_social_in_header' ) , 10, 2 );
-        add_action ( '__navbar' 				, array( $this , 'tc_tagline_display' ) , 20, 1 );
+        add_action ( '__navbar' 				, array( $this , 'czr_social_in_header' ) , 10, 2 );
+        add_action ( '__navbar' 				, array( $this , 'czr_tagline_display' ) , 20, 1 );
   	  }
 
       //add a 100% wide container just after the sticky header to reset margin top
       if ( 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_sticky_header' ) ) || CZR___::$instance -> czr_is_customizing() )
-        add_action( '__after_header'              , array( $this, 'tc_reset_margin_top_after_sticky_header'), 0 );
+        add_action( '__after_header'              , array( $this, 'czr_reset_margin_top_after_sticky_header'), 0 );
 
     }
 
@@ -92,13 +92,13 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
     */
     function czr_set_header_options() {
       //Set some body classes
-      add_filter( 'body_class'               , array( $this , 'tc_add_body_classes') );
+      add_filter( 'body_class'               , array( $this , 'czr_add_body_classes') );
       //Set header classes from options
-      add_filter( 'tc_header_classes'        , array( $this , 'tc_set_header_classes') );
+      add_filter( 'tc_header_classes'        , array( $this , 'czr_set_header_classes') );
       //Set tagline visibility with a customizer option (since 3.2.0)
-      add_filter( 'tc_tagline_display'       , array( $this , 'tc_set_tagline_visibility') );
+      add_filter( 'czr_tagline_display'       , array( $this , 'czr_set_tagline_visibility') );
       //Set logo layout with a customizer option (since 3.2.0)
-      add_filter( 'tc_logo_class'            , array( $this , 'tc_set_logo_title_layout') );
+      add_filter( 'tc_logo_class'            , array( $this , 'czr_set_logo_title_layout') );
     }
 
 
@@ -134,7 +134,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 				<?php
 			$html = ob_get_contents();
 		    if ($html) ob_end_clean();
-		    echo apply_filters( 'tc_head_display', $html );
+		    echo apply_filters( 'czr_head_display', $html );
 		}
 
 
@@ -180,7 +180,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
       	if ( strpos( $_fav_src, '.png') ) $type = "image/png";
       	if ( strpos( $_fav_src, '.gif') ) $type = "image/gif";
 
-    	echo apply_filters( 'tc_favicon_display',
+    	echo apply_filters( 'czr_favicon_display',
       		sprintf('<link id="czr-favicon" rel="shortcut icon" href="%1$s" type="%2$s">' ,
       			$_fav_src,
       			$type
@@ -317,7 +317,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
         $logo_type,
         $logo_attachment_id ? sprintf( 'attachment-%1$s', $logo_attachment_id ) : ''
       );
-      return apply_filters( 'tc_logo_img_view', $_html, $_args);
+      return apply_filters( 'czr_logo_img_view', $_html, $_args);
     }
 
 
@@ -395,7 +395,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 
 			$html = ob_get_contents();
 	       	if ($html) ob_end_clean();
-	       	echo apply_filters( 'tc_navbar_display', $html );
+	       	echo apply_filters( 'czr_navbar_display', $html );
 		}
 
 
@@ -440,7 +440,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
         //when do we display this block ?
         //1) if customizing always. (is hidden if empty of disabled)
         //2) if not customizing : must be enabled and have social networks.
-        $_nothing_to_render = ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_social_in_header') ) ) || ! czr__f( '__get_socials' );
+        $_nothing_to_render = ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'czr_social_in_header') ) ) || ! czr__f( '__get_socials' );
         if ( ! CZR___::$instance -> czr_is_customizing() && $_nothing_to_render )
         	return;
 
@@ -454,7 +454,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
         		$_nothing_to_render ? 'style="display:none"' : ''
         );
 
-        echo apply_filters( 'tc_social_in_header', $html, $resp );
+        echo apply_filters( 'czr_social_in_header', $html, $resp );
     }
 
 
@@ -483,7 +483,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 				);
 
 			}
-	        echo apply_filters( 'tc_tagline_display', $html );
+	        echo apply_filters( 'czr_tagline_display', $html );
 		}//end of fn
 
 
@@ -496,7 +496,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
     */
     function czr_reset_margin_top_after_sticky_header() {
       echo apply_filters(
-        'tc_reset_margin_top_after_sticky_header',
+        'czr_reset_margin_top_after_sticky_header',
         sprintf('<div id="tc-reset-margin-top" class="container-fluid" style="margin-top:%1$spx"></div>',
           apply_filters('tc_default_sticky_header_height' , 103 )
         )

--- a/inc/parts/class-header-header_main.php
+++ b/inc/parts/class-header-header_main.php
@@ -19,16 +19,16 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
       //Set header hooks
       //we have to use 'wp' action hook to show header in multisite wp-signup/wp-activate.php which don't fire template_redirect hook
       //(see https://github.com/presscustomizr/customizr/issues/395)
-      add_action ( 'wp'                    , array( $this , 'czr_set_header_hooks' ) );
+      add_action ( 'wp'                    , array( $this , 'czr_fn_set_header_hooks' ) );
 
       //Set header options
-      add_action ( 'wp'                    , array( $this , 'czr_set_header_options' ) );
+      add_action ( 'wp'                    , array( $this , 'czr_fn_set_header_options' ) );
 
       //! tc_user_options_style filter is shared by several classes => must always check the local context inside the callback before appending new css
       //fired on hook : wp_enqueue_scripts
       //Set thumbnail specific design based on user options
       //Set top border style option
-      add_filter( 'tc_user_options_style'  , array( $this , 'czr_write_header_inline_css') );
+      add_filter( 'tc_user_options_style'  , array( $this , 'czr_fn_write_header_inline_css') );
     }
 
 
@@ -43,12 +43,12 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 		* @package Customizr
 		* @since Customizr 3.2.6
 		*/
-    function czr_set_header_hooks() {
+    function czr_fn_set_header_hooks() {
     	//html > head actions
-      add_action ( '__before_body'	  , array( $this , 'czr_head_display' ));
+      add_action ( '__before_body'	  , array( $this , 'czr_fn_head_display' ));
 
       //The WP favicon (introduced in WP 4.3) will be used in priority
-      add_action ( 'wp_head'     		  , array( $this , 'czr_favicon_display' ));
+      add_action ( 'wp_head'     		  , array( $this , 'czr_fn_favicon_display' ));
 
       //html > header actions
       add_action ( '__before_main_wrapper'	, 'get_header');
@@ -57,27 +57,27 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
       if ( ! apply_filters( 'tc_display_header', true ) )
         return;
 
-      add_action ( '__header' 				, array( $this , 'czr_prepare_logo_title_display' ) , 10 );
-      add_action ( '__header' 				, array( $this , 'czr_tagline_display' ) , 20, 1 );
-      add_action ( '__header' 				, array( $this , 'czr_navbar_display' ) , 30 );
+      add_action ( '__header' 				, array( $this , 'czr_fn_prepare_logo_title_display' ) , 10 );
+      add_action ( '__header' 				, array( $this , 'czr_fn_tagline_display' ) , 20, 1 );
+      add_action ( '__header' 				, array( $this , 'czr_fn_navbar_display' ) , 30 );
 
       //New menu view (since 3.2.0)
-      add_filter ( 'czr_navbar_display', array( $this , 'czr_new_menu_view'), 10, 2);
+      add_filter ( 'czr_fn_navbar_display', array( $this , 'czr_fn_new_menu_view'), 10, 2);
 
       //body > header > navbar actions ordered by priority
   	  // GY : switch order for RTL sites
   	  if (is_rtl()) {
-        add_action ( '__navbar' 				, array( $this , 'czr_social_in_header' ) , 20, 2 );
-        add_action ( '__navbar' 				, array( $this , 'czr_tagline_display' ) , 10, 1 );
+        add_action ( '__navbar' 				, array( $this , 'czr_fn_social_in_header' ) , 20, 2 );
+        add_action ( '__navbar' 				, array( $this , 'czr_fn_tagline_display' ) , 10, 1 );
   	  }
   	  else {
-        add_action ( '__navbar' 				, array( $this , 'czr_social_in_header' ) , 10, 2 );
-        add_action ( '__navbar' 				, array( $this , 'czr_tagline_display' ) , 20, 1 );
+        add_action ( '__navbar' 				, array( $this , 'czr_fn_social_in_header' ) , 10, 2 );
+        add_action ( '__navbar' 				, array( $this , 'czr_fn_tagline_display' ) , 20, 1 );
   	  }
 
       //add a 100% wide container just after the sticky header to reset margin top
-      if ( 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_sticky_header' ) ) || CZR___::$instance -> czr_is_customizing() )
-        add_action( '__after_header'              , array( $this, 'czr_reset_margin_top_after_sticky_header'), 0 );
+      if ( 1 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_sticky_header' ) ) || CZR___::$instance -> czr_fn_is_customizing() )
+        add_action( '__after_header'              , array( $this, 'czr_fn_reset_margin_top_after_sticky_header'), 0 );
 
     }
 
@@ -90,15 +90,15 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
     * @package Customizr
     * @since Customizr 3.2.0
     */
-    function czr_set_header_options() {
+    function czr_fn_set_header_options() {
       //Set some body classes
-      add_filter( 'body_class'               , array( $this , 'czr_add_body_classes') );
+      add_filter( 'body_class'               , array( $this , 'czr_fn_add_body_classes') );
       //Set header classes from options
-      add_filter( 'tc_header_classes'        , array( $this , 'czr_set_header_classes') );
+      add_filter( 'tc_header_classes'        , array( $this , 'czr_fn_set_header_classes') );
       //Set tagline visibility with a customizer option (since 3.2.0)
-      add_filter( 'czr_tagline_display'       , array( $this , 'czr_set_tagline_visibility') );
+      add_filter( 'czr_fn_tagline_display'       , array( $this , 'czr_fn_set_tagline_visibility') );
       //Set logo layout with a customizer option (since 3.2.0)
-      add_filter( 'tc_logo_class'            , array( $this , 'czr_set_logo_title_layout') );
+      add_filter( 'tc_logo_class'            , array( $this , 'czr_fn_set_logo_title_layout') );
     }
 
 
@@ -112,7 +112,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 		* @package Customizr
 		* @since Customizr 3.0
 		*/
-		function czr_head_display() {
+		function czr_fn_head_display() {
 			ob_start();
 				?>
 				<head>
@@ -134,7 +134,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 				<?php
 			$html = ob_get_contents();
 		    if ($html) ob_end_clean();
-		    echo apply_filters( 'czr_head_display', $html );
+		    echo apply_filters( 'czr_fn_head_display', $html );
 		}
 
 
@@ -147,13 +147,13 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
     * @package Customizr
     * @since Customizr 3.0
     */
-    function czr_favicon_display() {
+    function czr_fn_favicon_display() {
      	//is there a WP favicon set ?
       //if yes then let WP do the job
       if ( function_exists('has_site_icon') && has_site_icon() )
         return;
 
-      $_fav_option  			= esc_attr( CZR_utils::$inst->czr_opt( 'tc_fav_upload') );
+      $_fav_option  			= esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_fav_upload') );
      	if ( ! $_fav_option || is_null($_fav_option) )
      		return;
 
@@ -164,7 +164,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
      		$_attachment_data 	= apply_filters( 'tc_fav_attachment_img' , wp_get_attachment_image_src( $_fav_option , 'full' ) );
      		$_fav_src 			= $_attachment_data[0];
      	} else { //old treatment
-     		$_saved_path 		= esc_url ( CZR_utils::$inst->czr_opt( 'tc_fav_upload') );
+     		$_saved_path 		= esc_url ( CZR_utils::$inst->czr_fn_opt( 'tc_fav_upload') );
      		//rebuild the path : check if the full path is already saved in DB. If not, then rebuild it.
        	$upload_dir 		= wp_upload_dir();
        	$_fav_src 			= ( false !== strpos( $_saved_path , '/wp-content/' ) ) ? $_saved_path : $upload_dir['baseurl'] . $_saved_path;
@@ -180,7 +180,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
       	if ( strpos( $_fav_src, '.png') ) $type = "image/png";
       	if ( strpos( $_fav_src, '.gif') ) $type = "image/gif";
 
-    	echo apply_filters( 'czr_favicon_display',
+    	echo apply_filters( 'czr_fn_favicon_display',
       		sprintf('<link id="czr-favicon" rel="shortcut icon" href="%1$s" type="%2$s">' ,
       			$_fav_src,
       			$type
@@ -198,7 +198,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 		* @package Customizr
 		* @since Customizr 3.2.3
 		*/
-		function czr_prepare_logo_title_display() {
+		function czr_fn_prepare_logo_title_display() {
       $logos_type = array( '_sticky_', '_');
       $logos_img  = array();
 
@@ -206,7 +206,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
       $logo_classes 			= array( 'brand', 'span3');
       foreach ( $logos_type as $logo_type ){
           // check if we have to print the sticky logo
-          if ( '_sticky_' == $logo_type && ! $this -> czr_use_sticky_logo() )
+          if ( '_sticky_' == $logo_type && ! $this -> czr_fn_use_sticky_logo() )
               continue;
 
           //check if the logo is a path or is numeric
@@ -215,7 +215,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
           $_width 				= false;
           $_height 				= false;
           $_attachement_id 		= false;
-          $_logo_option  			= esc_attr( CZR_utils::$inst->czr_opt( "tc{$logo_type}logo_upload") );
+          $_logo_option  			= esc_attr( CZR_utils::$inst->czr_fn_opt( "tc{$logo_type}logo_upload") );
           //check if option is an attachement id or a path (for backward compatibility)
           if ( is_numeric($_logo_option) ) {
               $_attachement_id 	= $_logo_option;
@@ -226,15 +226,15 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
           } else { //old treatment
               //rebuild the logo path : check if the full path is already saved in DB. If not, then rebuild it.
               $upload_dir 			= wp_upload_dir();
-              $_saved_path 			= esc_url ( CZR_utils::$inst->czr_opt( "tc{$logo_type}logo_upload") );
+              $_saved_path 			= esc_url ( CZR_utils::$inst->czr_fn_opt( "tc{$logo_type}logo_upload") );
               $_logo_src 				= ( false !== strpos( $_saved_path , '/wp-content/' ) ) ? $_saved_path : $upload_dir['baseurl'] . $_saved_path;
           }
 
           //hook + makes ssl compliant
           $_logo_src    			= apply_filters( "tc{$logo_type}logo_src" , is_ssl() ? str_replace('http://', 'https://', $_logo_src) : $_logo_src ) ;
 
-          $logo_resize 			= ( $logo_type == '_' ) ? esc_attr( CZR_utils::$inst->czr_opt( 'tc_logo_resize') ) : '';
-          $filetype 				= CZR_utils::$inst -> czr_check_filetype ($_logo_src);
+          $logo_resize 			= ( $logo_type == '_' ) ? esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_logo_resize') ) : '';
+          $filetype 				= CZR_utils::$inst -> czr_fn_check_filetype ($_logo_src);
           if( ! empty($_logo_src) && in_array( $filetype['ext'], $accepted_formats ) ) {
               $_args 		= array(
                       'logo_src' 				=> $_logo_src,
@@ -244,14 +244,14 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
                       'logo_height' 			=> $_height,
                       'logo_type'             => trim($logo_type,'_')
               );
-              $logos_img[] = $this -> czr_logo_img_view($_args);
+              $logos_img[] = $this -> czr_fn_logo_img_view($_args);
           }
       }//end foreach
       //render
       if ( count($logos_img) == 0 )
-          $this -> czr_title_view($logo_classes);
+          $this -> czr_fn_title_view($logo_classes);
       else
-          $this -> czr_logo_view( array (
+          $this -> czr_fn_logo_view( array (
             'logo_class'   => $logo_classes,
             // normal logo first
             'logos_img'    => array_reverse($logos_img)
@@ -268,7 +268,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 		* @package Customizr
 		* @since Customizr 3.2.3
 		*/
-		function czr_title_view( $logo_classes ) {
+		function czr_fn_title_view( $logo_classes ) {
 			ob_start();
 			?>
       <div class="<?php echo implode( " ", apply_filters( 'tc_logo_class', array_merge($logo_classes , array('pull-left') ) ) ) ?> ">
@@ -301,7 +301,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
     * @package Customizr
     * @since Customizr 3.2.9
     */
-    function czr_logo_img_view( $_args ){
+    function czr_fn_logo_img_view( $_args ){
       //Extracts $args : logo_src, logo_resize, logo_attachment_id, logo_width, logo_height, logo_type
       extract($_args);
       $_html = sprintf( '<img src="%1$s" alt="%2$s" %3$s %4$s %5$s %6$s class="%7$s %8$s"/>',
@@ -313,11 +313,11 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
                                 apply_filters( 'tc_logo_max_width', 250 ),
                                 apply_filters( 'tc_logo_max_height', 100 )
                                 ) : '',
-        implode(' ' , apply_filters('tc_logo_other_attributes' , ( 0 == CZR_utils::$inst->czr_opt( 'tc_retina_support' ) ) ? array('data-no-retina') : array() ) ),
+        implode(' ' , apply_filters('tc_logo_other_attributes' , ( 0 == CZR_utils::$inst->czr_fn_opt( 'tc_retina_support' ) ) ? array('data-no-retina') : array() ) ),
         $logo_type,
         $logo_attachment_id ? sprintf( 'attachment-%1$s', $logo_attachment_id ) : ''
       );
-      return apply_filters( 'czr_logo_img_view', $_html, $_args);
+      return apply_filters( 'czr_fn_logo_img_view', $_html, $_args);
     }
 
 
@@ -329,7 +329,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
     * @package Customizr
     * @since Customizr 3.2.3
     */
-    function czr_logo_view( $_args ) {
+    function czr_fn_logo_view( $_args ) {
         //Exctracts $args : $logo_class, $logos_img (array of <img>)
         extract($_args);
         ob_start();
@@ -364,7 +364,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 		* @package Customizr
 		* @since Customizr 3.0.10
 		*/
-		function czr_navbar_display() {
+		function czr_fn_navbar_display() {
 			$_navbar_classes = implode( " ", apply_filters( 'tc_navbar_wrapper_class', array('navbar-wrapper', 'clearfix', 'span9') ) );
 			ob_start();
 			do_action( '__before_navbar' );
@@ -395,7 +395,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 
 			$html = ob_get_contents();
 	       	if ($html) ob_end_clean();
-	       	echo apply_filters( 'czr_navbar_display', $html );
+	       	echo apply_filters( 'czr_fn_navbar_display', $html );
 		}
 
 
@@ -408,7 +408,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
   	* @package Customizr
   	* @since Customizr 3.2.0
   	*/
-  	function czr_new_menu_view() {
+  	function czr_fn_new_menu_view() {
     	$_navbar_classes = implode( " ", apply_filters( 'tc_navbar_wrapper_class', array('navbar-wrapper', 'clearfix', 'span9') ) );
     	do_action( '__before_navbar' );
       	?>
@@ -436,12 +436,12 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 		* @package Customizr
 		* @since Customizr 3.0.10
 		*/
-    function czr_social_in_header($resp = null) {
+    function czr_fn_social_in_header($resp = null) {
         //when do we display this block ?
         //1) if customizing always. (is hidden if empty of disabled)
         //2) if not customizing : must be enabled and have social networks.
-        $_nothing_to_render = ( 0 == esc_attr( CZR_utils::$inst->czr_opt( 'czr_social_in_header') ) ) || ! czr__f( '__get_socials' );
-        if ( ! CZR___::$instance -> czr_is_customizing() && $_nothing_to_render )
+        $_nothing_to_render = ( 0 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'czr_fn_social_in_header') ) ) || ! czr_fn__f( '__get_socials' );
+        if ( ! CZR___::$instance -> czr_fn_is_customizing() && $_nothing_to_render )
         	return;
 
         //class added if not resp
@@ -450,11 +450,11 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 
         $html = sprintf('<div class="social-block %1$s" %3$s>%2$s</div>',
         		$social_header_block_class,
-        		czr__f( '__get_socials' ),
+        		czr_fn__f( '__get_socials' ),
         		$_nothing_to_render ? 'style="display:none"' : ''
         );
 
-        echo apply_filters( 'czr_social_in_header', $html, $resp );
+        echo apply_filters( 'czr_fn_social_in_header', $html, $resp );
     }
 
 
@@ -466,7 +466,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 		* @package Customizr
 		* @since Customizr 3.0
 		*/
-		function czr_tagline_display() {
+		function czr_fn_tagline_display() {
 			if ( '__header' == current_filter() ) { //when hooked on  __header
 
 				$html = sprintf('<div class="container outside"><%1$s class="site-description">%2$s</%1$s></div>',
@@ -483,7 +483,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 				);
 
 			}
-	        echo apply_filters( 'czr_tagline_display', $html );
+	        echo apply_filters( 'czr_fn_tagline_display', $html );
 		}//end of fn
 
 
@@ -494,9 +494,9 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
     * @package Customizr
     * @since Customizr 3.2.0
     */
-    function czr_reset_margin_top_after_sticky_header() {
+    function czr_fn_reset_margin_top_after_sticky_header() {
       echo apply_filters(
-        'czr_reset_margin_top_after_sticky_header',
+        'czr_fn_reset_margin_top_after_sticky_header',
         sprintf('<div id="tc-reset-margin-top" class="container-fluid" style="margin-top:%1$spx"></div>',
           apply_filters('tc_default_sticky_header_height' , 103 )
         )
@@ -516,9 +516,9 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
     * @package Customizr
     * @since Customizr 3.2.6
     */
-		function czr_write_header_inline_css( $_css ) {
+		function czr_fn_write_header_inline_css( $_css ) {
       //TOP BORDER
-			if ( 1 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_top_border') ) ) {
+			if ( 1 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_top_border') ) ) {
   			$_css = sprintf("%s\n%s",
   				$_css,
   				"header.tc-header {border-top: none;}\n"
@@ -526,7 +526,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 	    }
 
       //STICKY HEADER
-	    if ( 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_sticky_shrink_title_logo') ) || CZR___::$instance -> czr_is_customizing() ) {
+	    if ( 0 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_sticky_shrink_title_logo') ) || CZR___::$instance -> czr_fn_is_customizing() ) {
 	    	$_logo_shrink 	= implode (';' , apply_filters('tc_logo_shrink_css' , array("height:30px!important","width:auto!important") )	);
 
 	    	$_title_font 	= implode (';' , apply_filters('tc_title_shrink_css' , array("font-size:0.6em","opacity:0.8","line-height:1.2em") ) );
@@ -543,7 +543,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 			}
 
       //STICKY LOGO
-      if ( $this -> czr_use_sticky_logo() ) {
+      if ( $this -> czr_fn_use_sticky_logo() ) {
         $_css = sprintf( "%s\n%s",
             $_css,
             ".site-logo img.sticky {
@@ -559,8 +559,8 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
       }
 
 			//HEADER Z-INDEX
-	    if ( 100 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_sticky_z_index') ) ) {
-	    	$_custom_z_index 	= esc_attr( CZR_utils::$inst->czr_opt( 'tc_sticky_z_index') );
+	    if ( 100 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_sticky_z_index') ) ) {
+	    	$_custom_z_index 	= esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_sticky_z_index') );
 		    $_css = sprintf("%s\n%s",
   		      $_css,
   		      ".tc-no-sticky-header .tc-header, .tc-sticky-header .tc-header {
@@ -580,12 +580,12 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
     * @package Customizr
     * @since Customizr 3.2.0
     */
-    function czr_add_body_classes($_classes) {
+    function czr_fn_add_body_classes($_classes) {
       //STICKY HEADER
-    	if ( 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_sticky_header' ) ) ) {
+    	if ( 1 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_sticky_header' ) ) ) {
      		$_classes = array_merge( $_classes, array('tc-sticky-header', 'sticky-disabled') );
      		//STICKY TRANSPARENT ON SCROLL
-       	if ( 1 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_sticky_transparent_on_scroll' ) ) )
+       	if ( 1 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_sticky_transparent_on_scroll' ) ) )
        		$_classes = array_merge( $_classes, array('tc-transparent-on-scroll') );
        	else
        		$_classes = array_merge( $_classes, array('tc-solid-color-on-scroll') );
@@ -595,11 +595,11 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
      	}
 
       //No navbar box
-      if ( 1 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_display_boxed_navbar') ) )
+      if ( 1 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_display_boxed_navbar') ) )
           $_classes = array_merge( $_classes , array('no-navbar' ) );
 
       //SKIN CLASS
-      $_skin = sprintf( 'skin-%s' , basename( CZR_init::$instance -> czr_get_style_src() ) );
+      $_skin = sprintf( 'skin-%s' , basename( CZR_init::$instance -> czr_fn_get_style_src() ) );
       array_push( $_classes, substr( $_skin , 0 , strpos($_skin, '.') ) );
 
       return $_classes;
@@ -614,17 +614,17 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
    	* @package Customizr
    	* @since Customizr 3.2.0
    	*/
-		function czr_set_header_classes( $_classes ) {
+		function czr_fn_set_header_classes( $_classes ) {
 			//backward compatibility (was not handled has an array in previous versions)
 			if ( ! is_array($_classes) )
 				return $_classes;
 
-			$_show_tagline 			= 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_sticky_show_tagline') );
-      $_show_title_logo 		= 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_sticky_show_title_logo') );
-      $_use_sticky_logo 		= $this -> czr_use_sticky_logo();
-			$_shrink_title_logo 	= 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_sticky_shrink_title_logo') );
-			$_show_menu 			  = 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_sticky_show_menu') );
-			$_header_layout 		= "logo-" . esc_attr( CZR_utils::$inst->czr_opt( 'tc_header_layout' ) );
+			$_show_tagline 			= 0 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_sticky_show_tagline') );
+      $_show_title_logo 		= 0 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_sticky_show_title_logo') );
+      $_use_sticky_logo 		= $this -> czr_fn_use_sticky_logo();
+			$_shrink_title_logo 	= 0 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_sticky_shrink_title_logo') );
+			$_show_menu 			  = 0 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_sticky_show_menu') );
+			$_header_layout 		= "logo-" . esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_header_layout' ) );
 			$_add_classes 			= array(
 				$_show_tagline ? 'tc-tagline-on' : 'tc-tagline-off',
         $_show_title_logo ? 'tc-title-logo-on' : 'tc-title-logo-off',
@@ -644,11 +644,11 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
     * @package Customizr
     * @since Customizr 3.2.9
     */
-    function czr_use_sticky_logo(){
-        if ( ! esc_attr( CZR_utils::$inst->czr_opt( "tc_sticky_logo_upload") ) )
+    function czr_fn_use_sticky_logo(){
+        if ( ! esc_attr( CZR_utils::$inst->czr_fn_opt( "tc_sticky_logo_upload") ) )
             return false;
-        if ( ! ( esc_attr( CZR_utils::$inst->czr_opt( "tc_sticky_header") ) &&
-                     esc_attr( CZR_utils::$inst->czr_opt( 'tc_sticky_show_title_logo') )
+        if ( ! ( esc_attr( CZR_utils::$inst->czr_fn_opt( "tc_sticky_header") ) &&
+                     esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_sticky_show_title_logo') )
                )
         )
             return false;
@@ -662,12 +662,12 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
    	* @package Customizr
    	* @since Customizr 3.2.0
    	*/
-		function czr_set_tagline_visibility($html) {
+		function czr_fn_set_tagline_visibility($html) {
 			//if customizing just hide it
-			if ( CZR___::$instance -> czr_is_customizing() && 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_tagline') ) )
+			if ( CZR___::$instance -> czr_fn_is_customizing() && 0 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_tagline') ) )
 				return str_replace('site-description"', 'site-description" style="display:none"', $html);
 			//live context, don't paint it at all
-			if ( ! CZR___::$instance -> czr_is_customizing() && 0 == esc_attr( CZR_utils::$inst->czr_opt( 'tc_show_tagline') ) )
+			if ( ! CZR___::$instance -> czr_fn_is_customizing() && 0 == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_show_tagline') ) )
 				return '';
 			return $html;
 		}
@@ -679,12 +679,12 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
    	* @package Customizr
    	* @since Customizr 3.2.0
    	*/
-		function czr_set_logo_title_layout( $_classes ) {
+		function czr_fn_set_logo_title_layout( $_classes ) {
 			//backward compatibility (was not handled has an array in previous versions)
 			if ( ! is_array($_classes) )
 				return $_classes;
 
-			$_layout = esc_attr( CZR_utils::$inst->czr_opt( 'tc_header_layout') );
+			$_layout = esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_header_layout') );
 			switch ($_layout) {
 				case 'left':
 					$_classes = array('brand', 'span3' , 'pull-left');

--- a/inc/parts/class-header-header_main.php
+++ b/inc/parts/class-header-header_main.php
@@ -62,7 +62,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
       add_action ( '__header' 				, array( $this , 'czr_fn_navbar_display' ) , 30 );
 
       //New menu view (since 3.2.0)
-      add_filter ( 'czr_fn_navbar_display', array( $this , 'czr_fn_new_menu_view'), 10, 2);
+      add_filter ( 'tc_navbar_display', array( $this , 'czr_fn_new_menu_view'), 10, 2);
 
       //body > header > navbar actions ordered by priority
   	  // GY : switch order for RTL sites
@@ -96,7 +96,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
       //Set header classes from options
       add_filter( 'tc_header_classes'        , array( $this , 'czr_fn_set_header_classes') );
       //Set tagline visibility with a customizer option (since 3.2.0)
-      add_filter( 'czr_fn_tagline_display'       , array( $this , 'czr_fn_set_tagline_visibility') );
+      add_filter( 'tc_tagline_display'       , array( $this , 'czr_fn_set_tagline_visibility') );
       //Set logo layout with a customizer option (since 3.2.0)
       add_filter( 'tc_logo_class'            , array( $this , 'czr_fn_set_logo_title_layout') );
     }
@@ -134,7 +134,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 				<?php
 			$html = ob_get_contents();
 		    if ($html) ob_end_clean();
-		    echo apply_filters( 'czr_fn_head_display', $html );
+		    echo apply_filters( 'tc_head_display', $html );
 		}
 
 
@@ -180,7 +180,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
       	if ( strpos( $_fav_src, '.png') ) $type = "image/png";
       	if ( strpos( $_fav_src, '.gif') ) $type = "image/gif";
 
-    	echo apply_filters( 'czr_fn_favicon_display',
+    	echo apply_filters( 'tc_favicon_display',
       		sprintf('<link id="czr-favicon" rel="shortcut icon" href="%1$s" type="%2$s">' ,
       			$_fav_src,
       			$type
@@ -317,7 +317,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
         $logo_type,
         $logo_attachment_id ? sprintf( 'attachment-%1$s', $logo_attachment_id ) : ''
       );
-      return apply_filters( 'czr_fn_logo_img_view', $_html, $_args);
+      return apply_filters( 'tc_logo_img_view', $_html, $_args);
     }
 
 
@@ -395,7 +395,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 
 			$html = ob_get_contents();
 	       	if ($html) ob_end_clean();
-	       	echo apply_filters( 'czr_fn_navbar_display', $html );
+	       	echo apply_filters( 'tc_navbar_display', $html );
 		}
 
 
@@ -454,7 +454,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
         		$_nothing_to_render ? 'style="display:none"' : ''
         );
 
-        echo apply_filters( 'czr_fn_social_in_header', $html, $resp );
+        echo apply_filters( 'tc_social_in_header', $html, $resp );
     }
 
 
@@ -483,7 +483,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 				);
 
 			}
-	        echo apply_filters( 'czr_fn_tagline_display', $html );
+	        echo apply_filters( 'tc_tagline_display', $html );
 		}//end of fn
 
 
@@ -496,7 +496,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
     */
     function czr_fn_reset_margin_top_after_sticky_header() {
       echo apply_filters(
-        'czr_fn_reset_margin_top_after_sticky_header',
+        'tc_reset_margin_top_after_sticky_header',
         sprintf('<div id="tc-reset-margin-top" class="container-fluid" style="margin-top:%1$spx"></div>',
           apply_filters('tc_default_sticky_header_height' , 103 )
         )

--- a/inc/parts/class-header-header_main.php
+++ b/inc/parts/class-header-header_main.php
@@ -43,7 +43,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 		* @package Customizr
 		* @since Customizr 3.2.6
 		*/
-    function tc_set_header_hooks() {
+    function czr_set_header_hooks() {
     	//html > head actions
       add_action ( '__before_body'	  , array( $this , 'tc_head_display' ));
 
@@ -90,7 +90,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
     * @package Customizr
     * @since Customizr 3.2.0
     */
-    function tc_set_header_options() {
+    function czr_set_header_options() {
       //Set some body classes
       add_filter( 'body_class'               , array( $this , 'tc_add_body_classes') );
       //Set header classes from options
@@ -112,7 +112,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 		* @package Customizr
 		* @since Customizr 3.0
 		*/
-		function tc_head_display() {
+		function czr_head_display() {
 			ob_start();
 				?>
 				<head>
@@ -147,7 +147,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
     * @package Customizr
     * @since Customizr 3.0
     */
-    function tc_favicon_display() {
+    function czr_favicon_display() {
      	//is there a WP favicon set ?
       //if yes then let WP do the job
       if ( function_exists('has_site_icon') && has_site_icon() )
@@ -198,7 +198,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 		* @package Customizr
 		* @since Customizr 3.2.3
 		*/
-		function tc_prepare_logo_title_display() {
+		function czr_prepare_logo_title_display() {
       $logos_type = array( '_sticky_', '_');
       $logos_img  = array();
 
@@ -268,7 +268,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 		* @package Customizr
 		* @since Customizr 3.2.3
 		*/
-		function tc_title_view( $logo_classes ) {
+		function czr_title_view( $logo_classes ) {
 			ob_start();
 			?>
       <div class="<?php echo implode( " ", apply_filters( 'tc_logo_class', array_merge($logo_classes , array('pull-left') ) ) ) ?> ">
@@ -301,7 +301,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
     * @package Customizr
     * @since Customizr 3.2.9
     */
-    function tc_logo_img_view( $_args ){
+    function czr_logo_img_view( $_args ){
       //Extracts $args : logo_src, logo_resize, logo_attachment_id, logo_width, logo_height, logo_type
       extract($_args);
       $_html = sprintf( '<img src="%1$s" alt="%2$s" %3$s %4$s %5$s %6$s class="%7$s %8$s"/>',
@@ -329,7 +329,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
     * @package Customizr
     * @since Customizr 3.2.3
     */
-    function tc_logo_view( $_args ) {
+    function czr_logo_view( $_args ) {
         //Exctracts $args : $logo_class, $logos_img (array of <img>)
         extract($_args);
         ob_start();
@@ -364,7 +364,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 		* @package Customizr
 		* @since Customizr 3.0.10
 		*/
-		function tc_navbar_display() {
+		function czr_navbar_display() {
 			$_navbar_classes = implode( " ", apply_filters( 'tc_navbar_wrapper_class', array('navbar-wrapper', 'clearfix', 'span9') ) );
 			ob_start();
 			do_action( '__before_navbar' );
@@ -408,7 +408,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
   	* @package Customizr
   	* @since Customizr 3.2.0
   	*/
-  	function tc_new_menu_view() {
+  	function czr_new_menu_view() {
     	$_navbar_classes = implode( " ", apply_filters( 'tc_navbar_wrapper_class', array('navbar-wrapper', 'clearfix', 'span9') ) );
     	do_action( '__before_navbar' );
       	?>
@@ -436,7 +436,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 		* @package Customizr
 		* @since Customizr 3.0.10
 		*/
-    function tc_social_in_header($resp = null) {
+    function czr_social_in_header($resp = null) {
         //when do we display this block ?
         //1) if customizing always. (is hidden if empty of disabled)
         //2) if not customizing : must be enabled and have social networks.
@@ -466,7 +466,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
 		* @package Customizr
 		* @since Customizr 3.0
 		*/
-		function tc_tagline_display() {
+		function czr_tagline_display() {
 			if ( '__header' == current_filter() ) { //when hooked on  __header
 
 				$html = sprintf('<div class="container outside"><%1$s class="site-description">%2$s</%1$s></div>',
@@ -494,7 +494,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
     * @package Customizr
     * @since Customizr 3.2.0
     */
-    function tc_reset_margin_top_after_sticky_header() {
+    function czr_reset_margin_top_after_sticky_header() {
       echo apply_filters(
         'tc_reset_margin_top_after_sticky_header',
         sprintf('<div id="tc-reset-margin-top" class="container-fluid" style="margin-top:%1$spx"></div>',
@@ -516,7 +516,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
     * @package Customizr
     * @since Customizr 3.2.6
     */
-		function tc_write_header_inline_css( $_css ) {
+		function czr_write_header_inline_css( $_css ) {
       //TOP BORDER
 			if ( 1 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_top_border') ) ) {
   			$_css = sprintf("%s\n%s",
@@ -580,7 +580,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
     * @package Customizr
     * @since Customizr 3.2.0
     */
-    function tc_add_body_classes($_classes) {
+    function czr_add_body_classes($_classes) {
       //STICKY HEADER
     	if ( 1 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_sticky_header' ) ) ) {
      		$_classes = array_merge( $_classes, array('tc-sticky-header', 'sticky-disabled') );
@@ -614,7 +614,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
    	* @package Customizr
    	* @since Customizr 3.2.0
    	*/
-		function tc_set_header_classes( $_classes ) {
+		function czr_set_header_classes( $_classes ) {
 			//backward compatibility (was not handled has an array in previous versions)
 			if ( ! is_array($_classes) )
 				return $_classes;
@@ -644,7 +644,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
     * @package Customizr
     * @since Customizr 3.2.9
     */
-    function tc_use_sticky_logo(){
+    function czr_use_sticky_logo(){
         if ( ! esc_attr( CZR_utils::$inst->tc_opt( "tc_sticky_logo_upload") ) )
             return false;
         if ( ! ( esc_attr( CZR_utils::$inst->tc_opt( "tc_sticky_header") ) &&
@@ -662,7 +662,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
    	* @package Customizr
    	* @since Customizr 3.2.0
    	*/
-		function tc_set_tagline_visibility($html) {
+		function czr_set_tagline_visibility($html) {
 			//if customizing just hide it
 			if ( CZR___::$instance -> tc_is_customizing() && 0 == esc_attr( CZR_utils::$inst->tc_opt( 'tc_show_tagline') ) )
 				return str_replace('site-description"', 'site-description" style="display:none"', $html);
@@ -679,7 +679,7 @@ if ( ! class_exists( 'CZR_header_main' ) ) :
    	* @package Customizr
    	* @since Customizr 3.2.0
    	*/
-		function tc_set_logo_title_layout( $_classes ) {
+		function czr_set_logo_title_layout( $_classes ) {
 			//backward compatibility (was not handled has an array in previous versions)
 			if ( ! is_array($_classes) )
 				return $_classes;

--- a/inc/parts/class-header-menu.php
+++ b/inc/parts/class-header-menu.php
@@ -17,7 +17,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     function __construct () {
       self::$instance =& $this;
       //Set menu customizer options (since 3.2.0)
-      add_action( 'wp'             , array( $this, 'czr_set_menu_hooks') );
+      add_action( 'wp'             , array( $this, 'czr_fn_set_menu_hooks') );
     }
 
 
@@ -30,40 +30,40 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @package Customizr
     * @since Customizr 3.2.0
     */
-    function czr_set_menu_hooks() {
-      if ( (bool) CZR_utils::$inst->czr_opt('tc_hide_all_menus') )
+    function czr_fn_set_menu_hooks() {
+      if ( (bool) CZR_utils::$inst->czr_fn_opt('tc_hide_all_menus') )
         return;
       //VARIOUS USER OPTIONS
-      add_filter( 'body_class'                    , array( $this , 'czr_add_body_classes') );
+      add_filter( 'body_class'                    , array( $this , 'czr_fn_add_body_classes') );
       //Set header css classes based on user options
-      add_filter( 'tc_header_classes'             , array( $this , 'czr_set_header_classes') );
-      add_filter( 'tc_social_header_block_class'  , array( $this, 'czr_set_social_header_class') );
+      add_filter( 'tc_header_classes'             , array( $this , 'czr_fn_set_header_classes') );
+      add_filter( 'tc_social_header_block_class'  , array( $this, 'czr_fn_set_social_header_class') );
 
       //! tc_user_options_style filter is shared by several classes => must always check the local context inside the callback before appending new css
       //fired on hook : wp_enqueue_scripts
-      add_filter( 'tc_user_options_style'         , array( $this , 'czr_menu_item_style_first_letter_css') );
+      add_filter( 'tc_user_options_style'         , array( $this , 'czr_fn_menu_item_style_first_letter_css') );
       //set second menu specific style including @media rules
-      add_filter( 'tc_user_options_style'         , array( $this , 'czr_add_second_menu_inline_style') );
+      add_filter( 'tc_user_options_style'         , array( $this , 'czr_fn_add_second_menu_inline_style') );
 
       //SIDE MENU HOOKS SINCE v3.3+
-      if ( $this -> czr_is_sidenav_enabled() ){
-        add_action( 'wp_head'                     , array( $this , 'czr_set_sidenav_hooks') );
-        add_filter( 'tc_user_options_style'       , array( $this , 'czr_set_sidenav_style') );
+      if ( $this -> czr_fn_is_sidenav_enabled() ){
+        add_action( 'wp_head'                     , array( $this , 'czr_fn_set_sidenav_hooks') );
+        add_filter( 'tc_user_options_style'       , array( $this , 'czr_fn_set_sidenav_style') );
       } else {
         // add main menu notice
-        add_action( '__navbar'                    , array( $this, 'czr_maybe_display_main_menu_notice'), 50 );
+        add_action( '__navbar'                    , array( $this, 'czr_fn_maybe_display_main_menu_notice'), 50 );
       }
       //this adds css classes to the navbar-wrapper :
       //1) to the main menu if regular (sidenav not enabled)
       //2) to the secondary menu if enabled
-      if ( ! $this -> czr_is_sidenav_enabled() || CZR_utils::$inst->czr_is_secondary_menu_enabled() ) {
-        add_filter( 'tc_navbar_wrapper_class'     , array( $this, 'czr_set_menu_style_options'), 0 );
+      if ( ! $this -> czr_fn_is_sidenav_enabled() || CZR_utils::$inst->czr_fn_is_secondary_menu_enabled() ) {
+        add_filter( 'tc_navbar_wrapper_class'     , array( $this, 'czr_fn_set_menu_style_options'), 0 );
       }
 
       //body > header > navbar action ordered by priority
-      add_action ( '__navbar'                     , array( $this , 'czr_menu_display' ), 30 );
+      add_action ( '__navbar'                     , array( $this , 'czr_fn_menu_display' ), 30 );
       //adds class
-      add_filter ( 'wp_page_menu'                 , array( $this , 'czr_add_menuclass' ));
+      add_filter ( 'wp_page_menu'                 , array( $this , 'czr_fn_add_menuclass' ));
     }
 
 
@@ -76,20 +76,20 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * hook : wp_head
     * @return void
     */
-    function czr_set_sidenav_hooks() {
-      add_filter( 'body_class'              , array( $this, 'czr_sidenav_body_class') );
+    function czr_fn_set_sidenav_hooks() {
+      add_filter( 'body_class'              , array( $this, 'czr_fn_sidenav_body_class') );
 
       // disable dropdown on click
-      add_filter( 'tc_menu_open_on_click'   , array( $this, 'czr_disable_dropdown_on_click'), 10, 3 );
+      add_filter( 'tc_menu_open_on_click'   , array( $this, 'czr_fn_disable_dropdown_on_click'), 10, 3 );
 
       // add side menu before the page wrapper
-      add_action( '__before_page_wrapper'   , array( $this, 'czr_sidenav_display'), 0 );
+      add_action( '__before_page_wrapper'   , array( $this, 'czr_fn_sidenav_display'), 0 );
       // add side menu help block
-      add_action( '__sidenav'               , array( $this, 'czr_maybe_display_sidenav_help') );
+      add_action( '__sidenav'               , array( $this, 'czr_fn_maybe_display_sidenav_help') );
       // add menu button to the sidebar
-      add_action( '__sidenav'               , array( $this, 'czr_sidenav_toggle_button_display'), 5 );
+      add_action( '__sidenav'               , array( $this, 'czr_fn_sidenav_toggle_button_display'), 5 );
       // add menu
-      add_action( '__sidenav'               , array( $this, 'czr_sidenav_display_menu_customizer'), 10 );
+      add_action( '__sidenav'               , array( $this, 'czr_fn_sidenav_display_menu_customizer'), 10 );
     }
 
 
@@ -97,8 +97,8 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * Displays a dismissable block of information in the sidenav wrapper when conditions are met
     * hook : __sidenav
     */
-    function czr_maybe_display_sidenav_help() {
-      if (  ! CZR_placeholders::czr_is_sidenav_help_on() )
+    function czr_fn_maybe_display_sidenav_help() {
+      if (  ! CZR_placeholders::czr_fn_is_sidenav_help_on() )
         return;
       ?>
       <div class="tc-placeholder-wrap tc-sidenav-help">
@@ -107,7 +107,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
               __( "This is a default page menu.", "customizr" ),
               __( "( If you don't have any pages in your website, then this side menu is empty for the moment. )" , "customizr"),
               sprintf( __("If you have already created menu(s), you can %s. If you need to create a new menu, jump to the %s.", "customizr"),
-                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', CZR_utils::czr_get_customizer_url( array( "section" => "nav") ), __( "change the default menu", "customizr"), __("replace this default menu by another one", "customizr") ),
+                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', CZR_utils::czr_fn_get_customizer_url( array( "section" => "nav") ), __( "change the default menu", "customizr"), __("replace this default menu by another one", "customizr") ),
                 sprintf( '<a href="%1$s" title="%2$s" target="blank">%2$s</a>', admin_url('nav-menus.php'), __( "menu creation screen", "customizr") )
               )
           );
@@ -130,24 +130,24 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @package Customizr
     * @since Customizr 3.0
     */
-    function czr_menu_display() {
+    function czr_fn_menu_display() {
       ob_start();
 
         //renders the regular menu + responsive button
-        if ( ! $this -> czr_is_sidenav_enabled() ) {
-          $this -> czr_regular_menu_display( 'main' );
+        if ( ! $this -> czr_fn_is_sidenav_enabled() ) {
+          $this -> czr_fn_regular_menu_display( 'main' );
         } else {
-          $this -> czr_sidenav_toggle_button_display();
-          if ( $this -> czr_is_second_menu_enabled() )
-            $this -> czr_regular_menu_display( 'secondary' );
+          $this -> czr_fn_sidenav_toggle_button_display();
+          if ( $this -> czr_fn_is_second_menu_enabled() )
+            $this -> czr_fn_regular_menu_display( 'secondary' );
           else
-            $this -> czr_maybe_display_second_menu_placeholder();
+            $this -> czr_fn_maybe_display_second_menu_placeholder();
         }
 
       $html = ob_get_contents();
       ob_end_clean();
 
-      echo apply_filters( 'czr_menu_display', $html );
+      echo apply_filters( 'czr_fn_menu_display', $html );
     }
 
 
@@ -159,7 +159,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @since v3.3+
     *
     */
-    function czr_menu_button_view( $args ) {
+    function czr_fn_menu_button_view( $args ) {
       //extracts : 'type', 'button_class', 'button_attr'
       extract( $args );
 
@@ -170,7 +170,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
         implode(' ', apply_filters( "tc_{$type}_button_class", $button_class ) ),
         apply_filters( "tc_{$type}_menu_button_attr", $button_attr),
         '<span class="icon-bar"></span>',
-        (bool)esc_attr( CZR_utils::$inst->czr_opt('tc_display_menu_label') ) ? $_button_label : '',
+        (bool)esc_attr( CZR_utils::$inst->czr_fn_opt('tc_display_menu_label') ) ? $_button_label : '',
         '__sidenav' == current_filter() ? __('Close', 'customizr') : __('Open the menu' , 'customizr')
       );
       return apply_filters( "tc_{$type}_menu_button_view", $_button );
@@ -186,7 +186,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @package Customizr
     * @since Customizr 1.0
     */
-    function czr_link_to_menu_editor( $args ) {
+    function czr_fn_link_to_menu_editor( $args ) {
       if ( ! current_user_can( 'manage_options' ) )
           return;
 
@@ -229,19 +229,19 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @since v3.3+
     *
     */
-    function czr_regular_menu_display( $_location = 'main' ){
+    function czr_fn_regular_menu_display( $_location = 'main' ){
       $type               = 'regular';
-      $where              = 'right' != esc_attr( CZR_utils::$inst->czr_opt( 'tc_header_layout') ) ? 'pull-right' : 'pull-left';
+      $where              = 'right' != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_header_layout') ) ? 'pull-right' : 'pull-left';
       $button_class       = array( 'btn-toggle-nav', $where );
       $button_attr        = 'data-toggle="collapse" data-target=".nav-collapse"';
 
-      $menu_class         = ( ! wp_is_mobile() && 'hover' == esc_attr( CZR_utils::$inst->czr_opt( 'tc_menu_type' ) ) ) ? array( 'nav tc-hover-menu' ) : array( 'nav' ) ;
-      $menu_wrapper_class = ( ! wp_is_mobile() && 'hover' == esc_attr( CZR_utils::$inst->czr_opt( 'tc_menu_type' ) ) ) ? array( 'nav-collapse collapse', 'tc-hover-menu-wrapper' ) : array( 'nav-collapse', 'collapse' );
+      $menu_class         = ( ! wp_is_mobile() && 'hover' == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_menu_type' ) ) ) ? array( 'nav tc-hover-menu' ) : array( 'nav' ) ;
+      $menu_wrapper_class = ( ! wp_is_mobile() && 'hover' == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_menu_type' ) ) ) ? array( 'nav-collapse collapse', 'tc-hover-menu-wrapper' ) : array( 'nav-collapse', 'collapse' );
 
-      $menu_view = $this -> czr_wp_nav_menu_view( compact( '_location', 'type', 'menu_class', 'menu_wrapper_class' ) );
+      $menu_view = $this -> czr_fn_wp_nav_menu_view( compact( '_location', 'type', 'menu_class', 'menu_wrapper_class' ) );
 
       if ( $menu_view && 'main' == $_location )
-        $menu_view = $menu_view . $this -> czr_menu_button_view( compact( 'type', 'button_class', 'button_attr') );
+        $menu_view = $menu_view . $this -> czr_fn_menu_button_view( compact( 'type', 'button_class', 'button_attr') );
 
       echo $menu_view;
     }
@@ -257,7 +257,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     *
     * hook: __before_page_wrapper
     */
-    function czr_sidenav_display() {
+    function czr_fn_sidenav_display() {
       ob_start();
         $tc_side_nav_class        = implode(' ', apply_filters('tc_side_nav_class', array( 'tc-sn', 'navbar' ) ) );
         $tc_side_nav_inner_class  = implode(' ', apply_filters('tc_side_nav_inner_class', array( 'tc-sn-inner', 'nav-collapse') ) );
@@ -270,7 +270,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
         <?php
       $_sidenav = ob_get_contents();
       ob_end_clean();
-      echo apply_filters( 'czr_sidenav_display', $_sidenav );
+      echo apply_filters( 'czr_fn_sidenav_display', $_sidenav );
     }
 
 
@@ -280,7 +280,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     *
     * hook: __sidenav
     */
-    function czr_sidenav_display_menu_customizer(){
+    function czr_fn_sidenav_display_menu_customizer(){
        //menu setup
        $type               = 'sidenav';
        $menu_class         = array('nav', 'sn-nav' );
@@ -288,7 +288,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
        //sidenav menu is always "main"
        $_location          = 'main';
 
-       echo $this -> czr_wp_nav_menu_view( compact( '_location', 'type', 'menu_class', 'menu_wrapper_class') );
+       echo $this -> czr_fn_wp_nav_menu_view( compact( '_location', 'type', 'menu_class', 'menu_wrapper_class') );
     }
 
     /**
@@ -297,13 +297,13 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     *
     * hooks: __sidenav, __navbar
     */
-    function czr_sidenav_toggle_button_display() {
+    function czr_fn_sidenav_toggle_button_display() {
       $type          = 'sidenav';
-      $where         = 'right' != esc_attr( CZR_utils::$inst->czr_opt( 'tc_header_layout') ) ? 'pull-right' : 'pull-left';
+      $where         = 'right' != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_header_layout') ) ? 'pull-right' : 'pull-left';
       $button_class  = array( 'btn-toggle-nav', 'sn-toggle', $where );
       $button_attr   = '';
 
-      echo $this -> czr_menu_button_view( compact( 'type', 'button_class', 'button_attr') );
+      echo $this -> czr_fn_menu_button_view( compact( 'type', 'button_class', 'button_attr') );
     }
 
 
@@ -317,7 +317,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    function czr_wp_nav_menu_view( $args ) {
+    function czr_fn_wp_nav_menu_view( $args ) {
       extract( $args );
       //'_location', 'type', 'menu_class', 'menu_wrapper_class'
 
@@ -325,10 +325,10 @@ if ( ! class_exists( 'CZR_menu' ) ) :
           array(
             'theme_location'  => $_location,
             'menu_class'      => implode(' ', apply_filters( "tc_{$type}_menu_class", $menu_class ) ),
-            'fallback_cb'     => array( $this, 'czr_page_menu' ),
+            'fallback_cb'     => array( $this, 'czr_fn_page_menu' ),
             //if no menu is set to the required location, fallsback to tc_page_menu
             //=> tc_page_menu has it's own class extension of Walker, therefore no need to specify one below
-            'walker'          => ! CZR_utils::$inst -> czr_has_location_menu($_location) ? '' : new CZR_nav_walker($_location),
+            'walker'          => ! CZR_utils::$inst -> czr_fn_has_location_menu($_location) ? '' : new CZR_nav_walker($_location),
             'echo'            => false,
         )
       );
@@ -349,12 +349,12 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * PLACEHOLDERS VIEW
     ****************************************/
     /**
-    * Displays the placeholder view if conditions are met in CZR_placeholders::czr_is_main_menu_notice_on()
-    * fired in czr_menu_display(), hook : __navbar
+    * Displays the placeholder view if conditions are met in CZR_placeholders::czr_fn_is_main_menu_notice_on()
+    * fired in czr_fn_menu_display(), hook : __navbar
     * @since Customizr 3.4+
     */
-    function czr_maybe_display_main_menu_notice() {
-      if (  ! CZR_placeholders::czr_is_main_menu_notice_on() )
+    function czr_fn_maybe_display_main_menu_notice() {
+      if (  ! CZR_placeholders::czr_fn_is_main_menu_notice_on() )
           return;
       ?>
       <div class="tc-placeholder-wrap tc-main-menu-notice">
@@ -363,7 +363,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
               __( "You can now display your menu as a vertical and mobile friendly side menu, animated when revealed.", "customizr" ),
               sprintf( __("%s or %s.", "customizr"),
                 sprintf( '<a href="%1$s" title="%2$s" target="blank">%2$s</a><span class="tc-external"></span>', esc_url('demo.presscustomizr.com?design=nav'), __( "Try it with the demo", "customizr") ),
-                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', CZR_utils::czr_get_customizer_url( array( "section" => "nav") ), __( "open the customizer menu section", "customizr"), __("change your menu design now", "customizr") )
+                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', CZR_utils::czr_fn_get_customizer_url( array( "section" => "nav") ), __( "open the customizer menu section", "customizr"), __("change your menu design now", "customizr") )
               )
           );
           printf('<a class="tc-dismiss-notice" href="#" title="%1$s">%1$s x</a>',
@@ -376,12 +376,12 @@ if ( ! class_exists( 'CZR_menu' ) ) :
 
 
     /**
-    * Displays the placeholder view if conditions are met in CZR_placeholders::czr_is_second_menu_placeholder_on()
-    * fired in czr_menu_display(), hook : __navbar
+    * Displays the placeholder view if conditions are met in CZR_placeholders::czr_fn_is_second_menu_placeholder_on()
+    * fired in czr_fn_menu_display(), hook : __navbar
     * @since Customizr 3.4
     */
-    function czr_maybe_display_second_menu_placeholder() {
-      if (  ! CZR_placeholders::czr_is_second_menu_placeholder_on() )
+    function czr_fn_maybe_display_second_menu_placeholder() {
+      if (  ! CZR_placeholders::czr_fn_is_second_menu_placeholder_on() )
           return;
       ?>
       <div class="nav-collapse collapse tc-placeholder-wrap tc-menu-placeholder">
@@ -389,7 +389,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
           printf('<p><strong>%1$s<br/>%2$s</strong></p>',
               __( "You can display your main menu or a second menu here horizontally.", "customizr" ),
               sprintf( __("%s or read the %s.", "customizr"),
-                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', CZR_utils::czr_get_customizer_url( array( "section" => "nav") ), __( "Manage menus in the header", "customizr"), __("Manage your menus in the header now", "customizr") ),
+                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', CZR_utils::czr_fn_get_customizer_url( array( "section" => "nav") ), __( "Manage menus in the header", "customizr"), __("Manage your menus in the header now", "customizr") ),
                 sprintf( '<a href="%1$s" title="%2$s" target="blank">%2$s</a><span class="tc-external"></span>', esc_url('http://docs.presscustomizr.com/article/101-customizr-theme-options-header-settings/#navigation'), __( "documentation", "customizr") )
               )
           );
@@ -413,18 +413,18 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @package Customizr
     * @since Customizr 3.2.0
     */
-    function czr_set_menu_style_options( $_classes ) {
-      $_classes = ( ! wp_is_mobile() && 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_menu_submenu_fade_effect') ) ) ? array_merge( $_classes, array( 'tc-submenu-fade' ) ) : $_classes;
-      $_classes = ( 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_menu_submenu_item_move_effect') ) ) ? array_merge( $_classes, array( 'tc-submenu-move' ) ) : $_classes;
-      $_classes = ( ! wp_is_mobile() && 'hover' == esc_attr( CZR_utils::$inst->czr_opt( 'tc_menu_type' ) ) ) ? array_merge( $_classes, array( 'tc-open-on-hover' ) ) : array_merge( $_classes, array( 'tc-open-on-click' ) );
+    function czr_fn_set_menu_style_options( $_classes ) {
+      $_classes = ( ! wp_is_mobile() && 0 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_menu_submenu_fade_effect') ) ) ? array_merge( $_classes, array( 'tc-submenu-fade' ) ) : $_classes;
+      $_classes = ( 0 != esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_menu_submenu_item_move_effect') ) ) ? array_merge( $_classes, array( 'tc-submenu-move' ) ) : $_classes;
+      $_classes = ( ! wp_is_mobile() && 'hover' == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_menu_type' ) ) ) ? array_merge( $_classes, array( 'tc-open-on-hover' ) ) : array_merge( $_classes, array( 'tc-open-on-click' ) );
 
       //Navbar menus positions (not sidenav)
       //CASE 1 : regular menu (sidenav not enabled), controled by option 'tc_menu_position'
       //CASE 2 : second menu ( is_secondary_menu_enabled ?), controled by option 'tc_second_menu_position'
-      if ( ! $this -> czr_is_sidenav_enabled() )
-        array_push( $_classes , esc_attr( CZR_utils::$inst->czr_opt( 'tc_menu_position') ) );
-      if ( CZR_utils::$inst->czr_is_secondary_menu_enabled() )
-        array_push( $_classes , esc_attr( CZR_utils::$inst->czr_opt( 'tc_second_menu_position') ) );
+      if ( ! $this -> czr_fn_is_sidenav_enabled() )
+        array_push( $_classes , esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_menu_position') ) );
+      if ( CZR_utils::$inst->czr_fn_is_secondary_menu_enabled() )
+        array_push( $_classes , esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_second_menu_position') ) );
 
       return $_classes;
     }
@@ -436,9 +436,9 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @package Customizr
     * @since Customizr 3.2.0
     */
-    function czr_add_body_classes($_classes) {
+    function czr_fn_add_body_classes($_classes) {
       //menu type class
-      $_menu_type = $this -> czr_is_sidenav_enabled() ? 'tc-side-menu' : 'tc-regular-menu';
+      $_menu_type = $this -> czr_fn_is_sidenav_enabled() ? 'tc-side-menu' : 'tc-regular-menu';
       array_push( $_classes, $_menu_type );
 
       return $_classes;
@@ -453,16 +453,16 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function czr_set_header_classes( $_classes ) {
+    function czr_fn_set_header_classes( $_classes ) {
       //backward compatibility (was not handled has an array in previous versions)
       if ( ! is_array($_classes) )
         return $_classes;
 
       //adds the second menu state
-      if ( CZR_Utils::$inst -> czr_is_secondary_menu_enabled() )
+      if ( CZR_Utils::$inst -> czr_fn_is_secondary_menu_enabled() )
         array_push( $_classes, 'tc-second-menu-on' );
       //adds the resp. behaviour option for secondary menu
-      array_push( $_classes, 'tc-second-menu-' . esc_attr( CZR_utils::$inst->czr_opt( 'tc_second_menu_resp_setting' ) . '-when-mobile' ) );
+      array_push( $_classes, 'tc-second-menu-' . esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_second_menu_resp_setting' ) . '-when-mobile' ) );
 
       return $_classes;
     }
@@ -475,7 +475,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @package Customizr
     * @since Customizr 3.2.0
     */
-    function czr_set_social_header_class($_classes) {
+    function czr_fn_set_social_header_class($_classes) {
       return 'span5';
     }
 
@@ -488,9 +488,9 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @package Customizr
     * @since Customizr 3.0
     */
-    function czr_add_menuclass( $ulclass) {
+    function czr_fn_add_menuclass( $ulclass) {
       $html =  preg_replace( '/<ul>/' , '<ul class="nav">' , $ulclass, 1);
-      return apply_filters( 'czr_add_menuclass', $html );
+      return apply_filters( 'czr_fn_add_menuclass', $html );
     }
 
 
@@ -502,8 +502,8 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @package Customizr
     * @since Customizr 3.2.11
     */
-    function czr_menu_item_style_first_letter_css( $_css ) {
-      if ( ! apply_filters( 'tc_menu_item_style_first_letter' , CZR_utils::$inst -> czr_user_started_before_version( '3.2.0' , '1.0.0' ) ? true : false ) )
+    function czr_fn_menu_item_style_first_letter_css( $_css ) {
+      if ( ! apply_filters( 'tc_menu_item_style_first_letter' , CZR_utils::$inst -> czr_fn_user_started_before_version( '3.2.0' , '1.0.0' ) ? true : false ) )
         return $_css;
 
       return sprintf("%s\n%s",
@@ -518,8 +518,8 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * Second menu
     * This actually "restore" regular menu style (user options in particular) by overriding the max-width: 979px media query
     */
-    function czr_add_second_menu_inline_style( $_css ) {
-      if ( ! CZR_Utils::$inst -> czr_is_secondary_menu_enabled() )
+    function czr_fn_add_second_menu_inline_style( $_css ) {
+      if ( ! CZR_Utils::$inst -> czr_fn_is_secondary_menu_enabled() )
         return $_css;
 
       return sprintf("%s\n%s",
@@ -641,7 +641,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @package Customizr
     * @since Customizr 3.2.11
     */
-    function czr_set_sidenav_style( $_css ) {
+    function czr_fn_set_sidenav_style( $_css ) {
       $sidenav_width = apply_filters( 'tc_sidenav_width', 330 );
 
       $_sidenav_mobile_css = '
@@ -701,9 +701,9 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     *
     * @since Customizr 3.3+
     */
-    function czr_sidenav_body_class( $_classes ){
-      $_where = str_replace( 'pull-menu-', '', esc_attr( CZR_utils::$inst->czr_opt( 'tc_menu_position') ) );
-      array_push( $_classes, apply_filters( 'czr_sidenav_body_class', "sn-$_where" ) );
+    function czr_fn_sidenav_body_class( $_classes ){
+      $_where = str_replace( 'pull-menu-', '', esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_menu_position') ) );
+      array_push( $_classes, apply_filters( 'czr_fn_sidenav_body_class', "sn-$_where" ) );
 
       return $_classes;
     }
@@ -716,7 +716,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
      *
      * hook :tc_menu_open_on_click
      */
-    function czr_disable_dropdown_on_click( $replace, $search, $_location = null ) {
+    function czr_fn_disable_dropdown_on_click( $replace, $search, $_location = null ) {
       return 'main' == $_location ? $search : $replace ;
     }
 
@@ -730,16 +730,16 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     /**
     * @return bool
     */
-    function czr_is_sidenav_enabled() {
-      return apply_filters( 'czr_is_sidenav_enabled', 'aside' == esc_attr( CZR_utils::$inst->czr_opt( 'tc_menu_style' ) ) );
+    function czr_fn_is_sidenav_enabled() {
+      return apply_filters( 'czr_fn_is_sidenav_enabled', 'aside' == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_menu_style' ) ) );
     }
 
 
     /**
     * @return bool
     */
-    function czr_is_second_menu_enabled() {
-      return apply_filters( 'czr_is_second_menu_enabled', (bool)esc_attr( CZR_utils::$inst->czr_opt( 'tc_display_second_menu' ) ) );
+    function czr_fn_is_second_menu_enabled() {
+      return apply_filters( 'czr_fn_is_second_menu_enabled', (bool)esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_display_second_menu' ) ) );
     }
 
 
@@ -748,7 +748,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
      * Modified copy of wp_page_menu()
      * @return string html menu
      */
-    function czr_page_menu( $args = array() ) {
+    function czr_fn_page_menu( $args = array() ) {
       $defaults = array('sort_column' => 'menu_order, post_title', 'menu_class' => 'menu', 'echo' => true, 'link_before' => '', 'link_after' => '');
       $args = wp_parse_args( $args, $defaults );
 
@@ -781,7 +781,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
 
       $list_args['echo'] = false;
       $list_args['title_li'] = '';
-      $menu .= str_replace( array( "\r", "\n", "\t" ), '', $this -> czr_list_pages($list_args) );
+      $menu .= str_replace( array( "\r", "\n", "\t" ), '', $this -> czr_fn_list_pages($list_args) );
 
       // if ( $menu )
       //   $menu = '<ul>' . $menu . '</ul>';
@@ -804,7 +804,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
      * Modified copy of wp_list_pages
      * @return string HTML list of pages.
      */
-    function czr_list_pages( $args = '' ) {
+    function czr_fn_list_pages( $args = '' ) {
       $defaults = array(
         'depth' => 0, 'show_date' => '',
         'date_format' => get_option( 'date_format' ),
@@ -845,7 +845,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
           }
         }
 
-        $output .= $this -> czr_walk_page_tree( $pages, $r['depth'], $current_page, $r );
+        $output .= $this -> czr_fn_walk_page_tree( $pages, $r['depth'], $current_page, $r );
 
         if ( $r['title_li'] ) {
           $output .= '</ul></li>';
@@ -869,7 +869,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
      * @since 2.1.0
      * @see Walker_Page::walk() for parameters and return description.
      */
-    function czr_walk_page_tree($pages, $depth, $current_page, $r) {
+    function czr_fn_walk_page_tree($pages, $depth, $current_page, $r) {
       // if ( empty($r['walker']) )
       //   $walker = new Walker_Page;
       // else

--- a/inc/parts/class-header-menu.php
+++ b/inc/parts/class-header-menu.php
@@ -11,8 +11,8 @@
 * @link         http://presscustomizr.com/customizr
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_menu' ) ) :
-  class TC_menu {
+if ( ! class_exists( 'CZR_menu' ) ) :
+  class CZR_menu {
     static $instance;
     function __construct () {
       self::$instance =& $this;
@@ -31,7 +31,7 @@ if ( ! class_exists( 'TC_menu' ) ) :
     * @since Customizr 3.2.0
     */
     function tc_set_menu_hooks() {
-      if ( (bool) TC_utils::$inst->tc_opt('tc_hide_all_menus') )
+      if ( (bool) CZR_utils::$inst->tc_opt('tc_hide_all_menus') )
         return;
       //VARIOUS USER OPTIONS
       add_filter( 'body_class'                    , array( $this , 'tc_add_body_classes') );
@@ -56,7 +56,7 @@ if ( ! class_exists( 'TC_menu' ) ) :
       //this adds css classes to the navbar-wrapper :
       //1) to the main menu if regular (sidenav not enabled)
       //2) to the secondary menu if enabled
-      if ( ! $this -> tc_is_sidenav_enabled() || TC_utils::$inst->tc_is_secondary_menu_enabled() ) {
+      if ( ! $this -> tc_is_sidenav_enabled() || CZR_utils::$inst->tc_is_secondary_menu_enabled() ) {
         add_filter( 'tc_navbar_wrapper_class'     , array( $this, 'tc_set_menu_style_options'), 0 );
       }
 
@@ -98,7 +98,7 @@ if ( ! class_exists( 'TC_menu' ) ) :
     * hook : __sidenav
     */
     function tc_maybe_display_sidenav_help() {
-      if (  ! TC_placeholders::tc_is_sidenav_help_on() )
+      if (  ! CZR_placeholders::tc_is_sidenav_help_on() )
         return;
       ?>
       <div class="tc-placeholder-wrap tc-sidenav-help">
@@ -107,7 +107,7 @@ if ( ! class_exists( 'TC_menu' ) ) :
               __( "This is a default page menu.", "customizr" ),
               __( "( If you don't have any pages in your website, then this side menu is empty for the moment. )" , "customizr"),
               sprintf( __("If you have already created menu(s), you can %s. If you need to create a new menu, jump to the %s.", "customizr"),
-                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', TC_utils::tc_get_customizer_url( array( "section" => "nav") ), __( "change the default menu", "customizr"), __("replace this default menu by another one", "customizr") ),
+                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', CZR_utils::tc_get_customizer_url( array( "section" => "nav") ), __( "change the default menu", "customizr"), __("replace this default menu by another one", "customizr") ),
                 sprintf( '<a href="%1$s" title="%2$s" target="blank">%2$s</a>', admin_url('nav-menus.php'), __( "menu creation screen", "customizr") )
               )
           );
@@ -170,7 +170,7 @@ if ( ! class_exists( 'TC_menu' ) ) :
         implode(' ', apply_filters( "tc_{$type}_button_class", $button_class ) ),
         apply_filters( "tc_{$type}_menu_button_attr", $button_attr),
         '<span class="icon-bar"></span>',
-        (bool)esc_attr( TC_utils::$inst->tc_opt('tc_display_menu_label') ) ? $_button_label : '',
+        (bool)esc_attr( CZR_utils::$inst->tc_opt('tc_display_menu_label') ) ? $_button_label : '',
         '__sidenav' == current_filter() ? __('Close', 'customizr') : __('Open the menu' , 'customizr')
       );
       return apply_filters( "tc_{$type}_menu_button_view", $_button );
@@ -231,12 +231,12 @@ if ( ! class_exists( 'TC_menu' ) ) :
     */
     function tc_regular_menu_display( $_location = 'main' ){
       $type               = 'regular';
-      $where              = 'right' != esc_attr( TC_utils::$inst->tc_opt( 'tc_header_layout') ) ? 'pull-right' : 'pull-left';
+      $where              = 'right' != esc_attr( CZR_utils::$inst->tc_opt( 'tc_header_layout') ) ? 'pull-right' : 'pull-left';
       $button_class       = array( 'btn-toggle-nav', $where );
       $button_attr        = 'data-toggle="collapse" data-target=".nav-collapse"';
 
-      $menu_class         = ( ! wp_is_mobile() && 'hover' == esc_attr( TC_utils::$inst->tc_opt( 'tc_menu_type' ) ) ) ? array( 'nav tc-hover-menu' ) : array( 'nav' ) ;
-      $menu_wrapper_class = ( ! wp_is_mobile() && 'hover' == esc_attr( TC_utils::$inst->tc_opt( 'tc_menu_type' ) ) ) ? array( 'nav-collapse collapse', 'tc-hover-menu-wrapper' ) : array( 'nav-collapse', 'collapse' );
+      $menu_class         = ( ! wp_is_mobile() && 'hover' == esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_type' ) ) ) ? array( 'nav tc-hover-menu' ) : array( 'nav' ) ;
+      $menu_wrapper_class = ( ! wp_is_mobile() && 'hover' == esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_type' ) ) ) ? array( 'nav-collapse collapse', 'tc-hover-menu-wrapper' ) : array( 'nav-collapse', 'collapse' );
 
       $menu_view = $this -> tc_wp_nav_menu_view( compact( '_location', 'type', 'menu_class', 'menu_wrapper_class' ) );
 
@@ -299,7 +299,7 @@ if ( ! class_exists( 'TC_menu' ) ) :
     */
     function tc_sidenav_toggle_button_display() {
       $type          = 'sidenav';
-      $where         = 'right' != esc_attr( TC_utils::$inst->tc_opt( 'tc_header_layout') ) ? 'pull-right' : 'pull-left';
+      $where         = 'right' != esc_attr( CZR_utils::$inst->tc_opt( 'tc_header_layout') ) ? 'pull-right' : 'pull-left';
       $button_class  = array( 'btn-toggle-nav', 'sn-toggle', $where );
       $button_attr   = '';
 
@@ -328,7 +328,7 @@ if ( ! class_exists( 'TC_menu' ) ) :
             'fallback_cb'     => array( $this, 'tc_page_menu' ),
             //if no menu is set to the required location, fallsback to tc_page_menu
             //=> tc_page_menu has it's own class extension of Walker, therefore no need to specify one below
-            'walker'          => ! TC_utils::$inst -> tc_has_location_menu($_location) ? '' : new TC_nav_walker($_location),
+            'walker'          => ! CZR_utils::$inst -> tc_has_location_menu($_location) ? '' : new CZR_nav_walker($_location),
             'echo'            => false,
         )
       );
@@ -349,12 +349,12 @@ if ( ! class_exists( 'TC_menu' ) ) :
     * PLACEHOLDERS VIEW
     ****************************************/
     /**
-    * Displays the placeholder view if conditions are met in TC_placeholders::tc_is_main_menu_notice_on()
+    * Displays the placeholder view if conditions are met in CZR_placeholders::tc_is_main_menu_notice_on()
     * fired in tc_menu_display(), hook : __navbar
     * @since Customizr 3.4+
     */
     function tc_maybe_display_main_menu_notice() {
-      if (  ! TC_placeholders::tc_is_main_menu_notice_on() )
+      if (  ! CZR_placeholders::tc_is_main_menu_notice_on() )
           return;
       ?>
       <div class="tc-placeholder-wrap tc-main-menu-notice">
@@ -363,7 +363,7 @@ if ( ! class_exists( 'TC_menu' ) ) :
               __( "You can now display your menu as a vertical and mobile friendly side menu, animated when revealed.", "customizr" ),
               sprintf( __("%s or %s.", "customizr"),
                 sprintf( '<a href="%1$s" title="%2$s" target="blank">%2$s</a><span class="tc-external"></span>', esc_url('demo.presscustomizr.com?design=nav'), __( "Try it with the demo", "customizr") ),
-                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', TC_utils::tc_get_customizer_url( array( "section" => "nav") ), __( "open the customizer menu section", "customizr"), __("change your menu design now", "customizr") )
+                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', CZR_utils::tc_get_customizer_url( array( "section" => "nav") ), __( "open the customizer menu section", "customizr"), __("change your menu design now", "customizr") )
               )
           );
           printf('<a class="tc-dismiss-notice" href="#" title="%1$s">%1$s x</a>',
@@ -376,12 +376,12 @@ if ( ! class_exists( 'TC_menu' ) ) :
 
 
     /**
-    * Displays the placeholder view if conditions are met in TC_placeholders::tc_is_second_menu_placeholder_on()
+    * Displays the placeholder view if conditions are met in CZR_placeholders::tc_is_second_menu_placeholder_on()
     * fired in tc_menu_display(), hook : __navbar
     * @since Customizr 3.4
     */
     function tc_maybe_display_second_menu_placeholder() {
-      if (  ! TC_placeholders::tc_is_second_menu_placeholder_on() )
+      if (  ! CZR_placeholders::tc_is_second_menu_placeholder_on() )
           return;
       ?>
       <div class="nav-collapse collapse tc-placeholder-wrap tc-menu-placeholder">
@@ -389,7 +389,7 @@ if ( ! class_exists( 'TC_menu' ) ) :
           printf('<p><strong>%1$s<br/>%2$s</strong></p>',
               __( "You can display your main menu or a second menu here horizontally.", "customizr" ),
               sprintf( __("%s or read the %s.", "customizr"),
-                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', TC_utils::tc_get_customizer_url( array( "section" => "nav") ), __( "Manage menus in the header", "customizr"), __("Manage your menus in the header now", "customizr") ),
+                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', CZR_utils::tc_get_customizer_url( array( "section" => "nav") ), __( "Manage menus in the header", "customizr"), __("Manage your menus in the header now", "customizr") ),
                 sprintf( '<a href="%1$s" title="%2$s" target="blank">%2$s</a><span class="tc-external"></span>', esc_url('http://docs.presscustomizr.com/article/101-customizr-theme-options-header-settings/#navigation'), __( "documentation", "customizr") )
               )
           );
@@ -414,17 +414,17 @@ if ( ! class_exists( 'TC_menu' ) ) :
     * @since Customizr 3.2.0
     */
     function tc_set_menu_style_options( $_classes ) {
-      $_classes = ( ! wp_is_mobile() && 0 != esc_attr( TC_utils::$inst->tc_opt( 'tc_menu_submenu_fade_effect') ) ) ? array_merge( $_classes, array( 'tc-submenu-fade' ) ) : $_classes;
-      $_classes = ( 0 != esc_attr( TC_utils::$inst->tc_opt( 'tc_menu_submenu_item_move_effect') ) ) ? array_merge( $_classes, array( 'tc-submenu-move' ) ) : $_classes;
-      $_classes = ( ! wp_is_mobile() && 'hover' == esc_attr( TC_utils::$inst->tc_opt( 'tc_menu_type' ) ) ) ? array_merge( $_classes, array( 'tc-open-on-hover' ) ) : array_merge( $_classes, array( 'tc-open-on-click' ) );
+      $_classes = ( ! wp_is_mobile() && 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_submenu_fade_effect') ) ) ? array_merge( $_classes, array( 'tc-submenu-fade' ) ) : $_classes;
+      $_classes = ( 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_submenu_item_move_effect') ) ) ? array_merge( $_classes, array( 'tc-submenu-move' ) ) : $_classes;
+      $_classes = ( ! wp_is_mobile() && 'hover' == esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_type' ) ) ) ? array_merge( $_classes, array( 'tc-open-on-hover' ) ) : array_merge( $_classes, array( 'tc-open-on-click' ) );
 
       //Navbar menus positions (not sidenav)
       //CASE 1 : regular menu (sidenav not enabled), controled by option 'tc_menu_position'
       //CASE 2 : second menu ( is_secondary_menu_enabled ?), controled by option 'tc_second_menu_position'
       if ( ! $this -> tc_is_sidenav_enabled() )
-        array_push( $_classes , esc_attr( TC_utils::$inst->tc_opt( 'tc_menu_position') ) );
-      if ( TC_utils::$inst->tc_is_secondary_menu_enabled() )
-        array_push( $_classes , esc_attr( TC_utils::$inst->tc_opt( 'tc_second_menu_position') ) );
+        array_push( $_classes , esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_position') ) );
+      if ( CZR_utils::$inst->tc_is_secondary_menu_enabled() )
+        array_push( $_classes , esc_attr( CZR_utils::$inst->tc_opt( 'tc_second_menu_position') ) );
 
       return $_classes;
     }
@@ -459,10 +459,10 @@ if ( ! class_exists( 'TC_menu' ) ) :
         return $_classes;
 
       //adds the second menu state
-      if ( TC_Utils::$inst -> tc_is_secondary_menu_enabled() )
+      if ( CZR_Utils::$inst -> tc_is_secondary_menu_enabled() )
         array_push( $_classes, 'tc-second-menu-on' );
       //adds the resp. behaviour option for secondary menu
-      array_push( $_classes, 'tc-second-menu-' . esc_attr( TC_utils::$inst->tc_opt( 'tc_second_menu_resp_setting' ) . '-when-mobile' ) );
+      array_push( $_classes, 'tc-second-menu-' . esc_attr( CZR_utils::$inst->tc_opt( 'tc_second_menu_resp_setting' ) . '-when-mobile' ) );
 
       return $_classes;
     }
@@ -503,7 +503,7 @@ if ( ! class_exists( 'TC_menu' ) ) :
     * @since Customizr 3.2.11
     */
     function tc_menu_item_style_first_letter_css( $_css ) {
-      if ( ! apply_filters( 'tc_menu_item_style_first_letter' , TC_utils::$inst -> tc_user_started_before_version( '3.2.0' , '1.0.0' ) ? true : false ) )
+      if ( ! apply_filters( 'tc_menu_item_style_first_letter' , CZR_utils::$inst -> tc_user_started_before_version( '3.2.0' , '1.0.0' ) ? true : false ) )
         return $_css;
 
       return sprintf("%s\n%s",
@@ -519,7 +519,7 @@ if ( ! class_exists( 'TC_menu' ) ) :
     * This actually "restore" regular menu style (user options in particular) by overriding the max-width: 979px media query
     */
     function tc_add_second_menu_inline_style( $_css ) {
-      if ( ! TC_Utils::$inst -> tc_is_secondary_menu_enabled() )
+      if ( ! CZR_Utils::$inst -> tc_is_secondary_menu_enabled() )
         return $_css;
 
       return sprintf("%s\n%s",
@@ -702,7 +702,7 @@ if ( ! class_exists( 'TC_menu' ) ) :
     * @since Customizr 3.3+
     */
     function tc_sidenav_body_class( $_classes ){
-      $_where = str_replace( 'pull-menu-', '', esc_attr( TC_utils::$inst->tc_opt( 'tc_menu_position') ) );
+      $_where = str_replace( 'pull-menu-', '', esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_position') ) );
       array_push( $_classes, apply_filters( 'tc_sidenav_body_class', "sn-$_where" ) );
 
       return $_classes;
@@ -731,7 +731,7 @@ if ( ! class_exists( 'TC_menu' ) ) :
     * @return bool
     */
     function tc_is_sidenav_enabled() {
-      return apply_filters( 'tc_is_sidenav_enabled', 'aside' == esc_attr( TC_utils::$inst->tc_opt( 'tc_menu_style' ) ) );
+      return apply_filters( 'tc_is_sidenav_enabled', 'aside' == esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_style' ) ) );
     }
 
 
@@ -739,7 +739,7 @@ if ( ! class_exists( 'TC_menu' ) ) :
     * @return bool
     */
     function tc_is_second_menu_enabled() {
-      return apply_filters( 'tc_is_second_menu_enabled', (bool)esc_attr( TC_utils::$inst->tc_opt( 'tc_display_second_menu' ) ) );
+      return apply_filters( 'tc_is_second_menu_enabled', (bool)esc_attr( CZR_utils::$inst->tc_opt( 'tc_display_second_menu' ) ) );
     }
 
 
@@ -874,7 +874,7 @@ if ( ! class_exists( 'TC_menu' ) ) :
       //   $walker = new Walker_Page;
       // else
       //   $walker = $r['walker'];
-      $walker = new TC_nav_walker_page;
+      $walker = new CZR_nav_walker_page;
 
       foreach ( (array) $pages as $page ) {
         if ( $page->post_parent )

--- a/inc/parts/class-header-menu.php
+++ b/inc/parts/class-header-menu.php
@@ -30,7 +30,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @package Customizr
     * @since Customizr 3.2.0
     */
-    function tc_set_menu_hooks() {
+    function czr_set_menu_hooks() {
       if ( (bool) CZR_utils::$inst->tc_opt('tc_hide_all_menus') )
         return;
       //VARIOUS USER OPTIONS
@@ -76,7 +76,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * hook : wp_head
     * @return void
     */
-    function tc_set_sidenav_hooks() {
+    function czr_set_sidenav_hooks() {
       add_filter( 'body_class'              , array( $this, 'tc_sidenav_body_class') );
 
       // disable dropdown on click
@@ -97,7 +97,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * Displays a dismissable block of information in the sidenav wrapper when conditions are met
     * hook : __sidenav
     */
-    function tc_maybe_display_sidenav_help() {
+    function czr_maybe_display_sidenav_help() {
       if (  ! CZR_placeholders::tc_is_sidenav_help_on() )
         return;
       ?>
@@ -130,7 +130,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @package Customizr
     * @since Customizr 3.0
     */
-    function tc_menu_display() {
+    function czr_menu_display() {
       ob_start();
 
         //renders the regular menu + responsive button
@@ -159,7 +159,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @since v3.3+
     *
     */
-    function tc_menu_button_view( $args ) {
+    function czr_menu_button_view( $args ) {
       //extracts : 'type', 'button_class', 'button_attr'
       extract( $args );
 
@@ -186,7 +186,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @package Customizr
     * @since Customizr 1.0
     */
-    function tc_link_to_menu_editor( $args ) {
+    function czr_link_to_menu_editor( $args ) {
       if ( ! current_user_can( 'manage_options' ) )
           return;
 
@@ -229,7 +229,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @since v3.3+
     *
     */
-    function tc_regular_menu_display( $_location = 'main' ){
+    function czr_regular_menu_display( $_location = 'main' ){
       $type               = 'regular';
       $where              = 'right' != esc_attr( CZR_utils::$inst->tc_opt( 'tc_header_layout') ) ? 'pull-right' : 'pull-left';
       $button_class       = array( 'btn-toggle-nav', $where );
@@ -257,7 +257,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     *
     * hook: __before_page_wrapper
     */
-    function tc_sidenav_display() {
+    function czr_sidenav_display() {
       ob_start();
         $tc_side_nav_class        = implode(' ', apply_filters('tc_side_nav_class', array( 'tc-sn', 'navbar' ) ) );
         $tc_side_nav_inner_class  = implode(' ', apply_filters('tc_side_nav_inner_class', array( 'tc-sn-inner', 'nav-collapse') ) );
@@ -280,7 +280,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     *
     * hook: __sidenav
     */
-    function tc_sidenav_display_menu_customizer(){
+    function czr_sidenav_display_menu_customizer(){
        //menu setup
        $type               = 'sidenav';
        $menu_class         = array('nav', 'sn-nav' );
@@ -297,7 +297,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     *
     * hooks: __sidenav, __navbar
     */
-    function tc_sidenav_toggle_button_display() {
+    function czr_sidenav_toggle_button_display() {
       $type          = 'sidenav';
       $where         = 'right' != esc_attr( CZR_utils::$inst->tc_opt( 'tc_header_layout') ) ? 'pull-right' : 'pull-left';
       $button_class  = array( 'btn-toggle-nav', 'sn-toggle', $where );
@@ -317,7 +317,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @package Customizr
     * @since Customizr 3.3+
     */
-    function tc_wp_nav_menu_view( $args ) {
+    function czr_wp_nav_menu_view( $args ) {
       extract( $args );
       //'_location', 'type', 'menu_class', 'menu_wrapper_class'
 
@@ -353,7 +353,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * fired in tc_menu_display(), hook : __navbar
     * @since Customizr 3.4+
     */
-    function tc_maybe_display_main_menu_notice() {
+    function czr_maybe_display_main_menu_notice() {
       if (  ! CZR_placeholders::tc_is_main_menu_notice_on() )
           return;
       ?>
@@ -380,7 +380,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * fired in tc_menu_display(), hook : __navbar
     * @since Customizr 3.4
     */
-    function tc_maybe_display_second_menu_placeholder() {
+    function czr_maybe_display_second_menu_placeholder() {
       if (  ! CZR_placeholders::tc_is_second_menu_placeholder_on() )
           return;
       ?>
@@ -413,7 +413,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @package Customizr
     * @since Customizr 3.2.0
     */
-    function tc_set_menu_style_options( $_classes ) {
+    function czr_set_menu_style_options( $_classes ) {
       $_classes = ( ! wp_is_mobile() && 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_submenu_fade_effect') ) ) ? array_merge( $_classes, array( 'tc-submenu-fade' ) ) : $_classes;
       $_classes = ( 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_submenu_item_move_effect') ) ) ? array_merge( $_classes, array( 'tc-submenu-move' ) ) : $_classes;
       $_classes = ( ! wp_is_mobile() && 'hover' == esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_type' ) ) ) ? array_merge( $_classes, array( 'tc-open-on-hover' ) ) : array_merge( $_classes, array( 'tc-open-on-click' ) );
@@ -436,7 +436,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @package Customizr
     * @since Customizr 3.2.0
     */
-    function tc_add_body_classes($_classes) {
+    function czr_add_body_classes($_classes) {
       //menu type class
       $_menu_type = $this -> tc_is_sidenav_enabled() ? 'tc-side-menu' : 'tc-regular-menu';
       array_push( $_classes, $_menu_type );
@@ -453,7 +453,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @package Customizr
     * @since Customizr 3.4+
     */
-    function tc_set_header_classes( $_classes ) {
+    function czr_set_header_classes( $_classes ) {
       //backward compatibility (was not handled has an array in previous versions)
       if ( ! is_array($_classes) )
         return $_classes;
@@ -475,7 +475,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @package Customizr
     * @since Customizr 3.2.0
     */
-    function tc_set_social_header_class($_classes) {
+    function czr_set_social_header_class($_classes) {
       return 'span5';
     }
 
@@ -488,7 +488,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @package Customizr
     * @since Customizr 3.0
     */
-    function tc_add_menuclass( $ulclass) {
+    function czr_add_menuclass( $ulclass) {
       $html =  preg_replace( '/<ul>/' , '<ul class="nav">' , $ulclass, 1);
       return apply_filters( 'tc_add_menuclass', $html );
     }
@@ -502,7 +502,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @package Customizr
     * @since Customizr 3.2.11
     */
-    function tc_menu_item_style_first_letter_css( $_css ) {
+    function czr_menu_item_style_first_letter_css( $_css ) {
       if ( ! apply_filters( 'tc_menu_item_style_first_letter' , CZR_utils::$inst -> tc_user_started_before_version( '3.2.0' , '1.0.0' ) ? true : false ) )
         return $_css;
 
@@ -518,7 +518,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * Second menu
     * This actually "restore" regular menu style (user options in particular) by overriding the max-width: 979px media query
     */
-    function tc_add_second_menu_inline_style( $_css ) {
+    function czr_add_second_menu_inline_style( $_css ) {
       if ( ! CZR_Utils::$inst -> tc_is_secondary_menu_enabled() )
         return $_css;
 
@@ -641,7 +641,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @package Customizr
     * @since Customizr 3.2.11
     */
-    function tc_set_sidenav_style( $_css ) {
+    function czr_set_sidenav_style( $_css ) {
       $sidenav_width = apply_filters( 'tc_sidenav_width', 330 );
 
       $_sidenav_mobile_css = '
@@ -701,7 +701,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     *
     * @since Customizr 3.3+
     */
-    function tc_sidenav_body_class( $_classes ){
+    function czr_sidenav_body_class( $_classes ){
       $_where = str_replace( 'pull-menu-', '', esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_position') ) );
       array_push( $_classes, apply_filters( 'tc_sidenav_body_class', "sn-$_where" ) );
 
@@ -716,7 +716,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
      *
      * hook :tc_menu_open_on_click
      */
-    function tc_disable_dropdown_on_click( $replace, $search, $_location = null ) {
+    function czr_disable_dropdown_on_click( $replace, $search, $_location = null ) {
       return 'main' == $_location ? $search : $replace ;
     }
 
@@ -730,7 +730,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     /**
     * @return bool
     */
-    function tc_is_sidenav_enabled() {
+    function czr_is_sidenav_enabled() {
       return apply_filters( 'tc_is_sidenav_enabled', 'aside' == esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_style' ) ) );
     }
 
@@ -738,7 +738,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     /**
     * @return bool
     */
-    function tc_is_second_menu_enabled() {
+    function czr_is_second_menu_enabled() {
       return apply_filters( 'tc_is_second_menu_enabled', (bool)esc_attr( CZR_utils::$inst->tc_opt( 'tc_display_second_menu' ) ) );
     }
 
@@ -748,7 +748,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
      * Modified copy of wp_page_menu()
      * @return string html menu
      */
-    function tc_page_menu( $args = array() ) {
+    function czr_page_menu( $args = array() ) {
       $defaults = array('sort_column' => 'menu_order, post_title', 'menu_class' => 'menu', 'echo' => true, 'link_before' => '', 'link_after' => '');
       $args = wp_parse_args( $args, $defaults );
 
@@ -804,7 +804,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
      * Modified copy of wp_list_pages
      * @return string HTML list of pages.
      */
-    function tc_list_pages( $args = '' ) {
+    function czr_list_pages( $args = '' ) {
       $defaults = array(
         'depth' => 0, 'show_date' => '',
         'date_format' => get_option( 'date_format' ),
@@ -869,7 +869,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
      * @since 2.1.0
      * @see Walker_Page::walk() for parameters and return description.
      */
-    function tc_walk_page_tree($pages, $depth, $current_page, $r) {
+    function czr_walk_page_tree($pages, $depth, $current_page, $r) {
       // if ( empty($r['walker']) )
       //   $walker = new Walker_Page;
       // else

--- a/inc/parts/class-header-menu.php
+++ b/inc/parts/class-header-menu.php
@@ -17,7 +17,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     function __construct () {
       self::$instance =& $this;
       //Set menu customizer options (since 3.2.0)
-      add_action( 'wp'             , array( $this, 'tc_set_menu_hooks') );
+      add_action( 'wp'             , array( $this, 'czr_set_menu_hooks') );
     }
 
 
@@ -34,36 +34,36 @@ if ( ! class_exists( 'CZR_menu' ) ) :
       if ( (bool) CZR_utils::$inst->czr_opt('tc_hide_all_menus') )
         return;
       //VARIOUS USER OPTIONS
-      add_filter( 'body_class'                    , array( $this , 'tc_add_body_classes') );
+      add_filter( 'body_class'                    , array( $this , 'czr_add_body_classes') );
       //Set header css classes based on user options
-      add_filter( 'tc_header_classes'             , array( $this , 'tc_set_header_classes') );
-      add_filter( 'tc_social_header_block_class'  , array( $this, 'tc_set_social_header_class') );
+      add_filter( 'tc_header_classes'             , array( $this , 'czr_set_header_classes') );
+      add_filter( 'tc_social_header_block_class'  , array( $this, 'czr_set_social_header_class') );
 
       //! tc_user_options_style filter is shared by several classes => must always check the local context inside the callback before appending new css
       //fired on hook : wp_enqueue_scripts
-      add_filter( 'tc_user_options_style'         , array( $this , 'tc_menu_item_style_first_letter_css') );
+      add_filter( 'tc_user_options_style'         , array( $this , 'czr_menu_item_style_first_letter_css') );
       //set second menu specific style including @media rules
-      add_filter( 'tc_user_options_style'         , array( $this , 'tc_add_second_menu_inline_style') );
+      add_filter( 'tc_user_options_style'         , array( $this , 'czr_add_second_menu_inline_style') );
 
       //SIDE MENU HOOKS SINCE v3.3+
       if ( $this -> czr_is_sidenav_enabled() ){
-        add_action( 'wp_head'                     , array( $this , 'tc_set_sidenav_hooks') );
-        add_filter( 'tc_user_options_style'       , array( $this , 'tc_set_sidenav_style') );
+        add_action( 'wp_head'                     , array( $this , 'czr_set_sidenav_hooks') );
+        add_filter( 'tc_user_options_style'       , array( $this , 'czr_set_sidenav_style') );
       } else {
         // add main menu notice
-        add_action( '__navbar'                    , array( $this, 'tc_maybe_display_main_menu_notice'), 50 );
+        add_action( '__navbar'                    , array( $this, 'czr_maybe_display_main_menu_notice'), 50 );
       }
       //this adds css classes to the navbar-wrapper :
       //1) to the main menu if regular (sidenav not enabled)
       //2) to the secondary menu if enabled
       if ( ! $this -> czr_is_sidenav_enabled() || CZR_utils::$inst->czr_is_secondary_menu_enabled() ) {
-        add_filter( 'tc_navbar_wrapper_class'     , array( $this, 'tc_set_menu_style_options'), 0 );
+        add_filter( 'tc_navbar_wrapper_class'     , array( $this, 'czr_set_menu_style_options'), 0 );
       }
 
       //body > header > navbar action ordered by priority
-      add_action ( '__navbar'                     , array( $this , 'tc_menu_display' ), 30 );
+      add_action ( '__navbar'                     , array( $this , 'czr_menu_display' ), 30 );
       //adds class
-      add_filter ( 'wp_page_menu'                 , array( $this , 'tc_add_menuclass' ));
+      add_filter ( 'wp_page_menu'                 , array( $this , 'czr_add_menuclass' ));
     }
 
 
@@ -77,19 +77,19 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @return void
     */
     function czr_set_sidenav_hooks() {
-      add_filter( 'body_class'              , array( $this, 'tc_sidenav_body_class') );
+      add_filter( 'body_class'              , array( $this, 'czr_sidenav_body_class') );
 
       // disable dropdown on click
-      add_filter( 'tc_menu_open_on_click'   , array( $this, 'tc_disable_dropdown_on_click'), 10, 3 );
+      add_filter( 'tc_menu_open_on_click'   , array( $this, 'czr_disable_dropdown_on_click'), 10, 3 );
 
       // add side menu before the page wrapper
-      add_action( '__before_page_wrapper'   , array( $this, 'tc_sidenav_display'), 0 );
+      add_action( '__before_page_wrapper'   , array( $this, 'czr_sidenav_display'), 0 );
       // add side menu help block
-      add_action( '__sidenav'               , array( $this, 'tc_maybe_display_sidenav_help') );
+      add_action( '__sidenav'               , array( $this, 'czr_maybe_display_sidenav_help') );
       // add menu button to the sidebar
-      add_action( '__sidenav'               , array( $this, 'tc_sidenav_toggle_button_display'), 5 );
+      add_action( '__sidenav'               , array( $this, 'czr_sidenav_toggle_button_display'), 5 );
       // add menu
-      add_action( '__sidenav'               , array( $this, 'tc_sidenav_display_menu_customizer'), 10 );
+      add_action( '__sidenav'               , array( $this, 'czr_sidenav_display_menu_customizer'), 10 );
     }
 
 
@@ -147,7 +147,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
       $html = ob_get_contents();
       ob_end_clean();
 
-      echo apply_filters( 'tc_menu_display', $html );
+      echo apply_filters( 'czr_menu_display', $html );
     }
 
 
@@ -270,7 +270,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
         <?php
       $_sidenav = ob_get_contents();
       ob_end_clean();
-      echo apply_filters( 'tc_sidenav_display', $_sidenav );
+      echo apply_filters( 'czr_sidenav_display', $_sidenav );
     }
 
 
@@ -325,7 +325,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
           array(
             'theme_location'  => $_location,
             'menu_class'      => implode(' ', apply_filters( "tc_{$type}_menu_class", $menu_class ) ),
-            'fallback_cb'     => array( $this, 'tc_page_menu' ),
+            'fallback_cb'     => array( $this, 'czr_page_menu' ),
             //if no menu is set to the required location, fallsback to tc_page_menu
             //=> tc_page_menu has it's own class extension of Walker, therefore no need to specify one below
             'walker'          => ! CZR_utils::$inst -> czr_has_location_menu($_location) ? '' : new CZR_nav_walker($_location),
@@ -490,7 +490,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     */
     function czr_add_menuclass( $ulclass) {
       $html =  preg_replace( '/<ul>/' , '<ul class="nav">' , $ulclass, 1);
-      return apply_filters( 'tc_add_menuclass', $html );
+      return apply_filters( 'czr_add_menuclass', $html );
     }
 
 
@@ -703,7 +703,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     */
     function czr_sidenav_body_class( $_classes ){
       $_where = str_replace( 'pull-menu-', '', esc_attr( CZR_utils::$inst->czr_opt( 'tc_menu_position') ) );
-      array_push( $_classes, apply_filters( 'tc_sidenav_body_class', "sn-$_where" ) );
+      array_push( $_classes, apply_filters( 'czr_sidenav_body_class', "sn-$_where" ) );
 
       return $_classes;
     }
@@ -731,7 +731,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @return bool
     */
     function czr_is_sidenav_enabled() {
-      return apply_filters( 'tc_is_sidenav_enabled', 'aside' == esc_attr( CZR_utils::$inst->czr_opt( 'tc_menu_style' ) ) );
+      return apply_filters( 'czr_is_sidenav_enabled', 'aside' == esc_attr( CZR_utils::$inst->czr_opt( 'tc_menu_style' ) ) );
     }
 
 
@@ -739,7 +739,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @return bool
     */
     function czr_is_second_menu_enabled() {
-      return apply_filters( 'tc_is_second_menu_enabled', (bool)esc_attr( CZR_utils::$inst->czr_opt( 'tc_display_second_menu' ) ) );
+      return apply_filters( 'czr_is_second_menu_enabled', (bool)esc_attr( CZR_utils::$inst->czr_opt( 'tc_display_second_menu' ) ) );
     }
 
 

--- a/inc/parts/class-header-menu.php
+++ b/inc/parts/class-header-menu.php
@@ -147,7 +147,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
       $html = ob_get_contents();
       ob_end_clean();
 
-      echo apply_filters( 'czr_fn_menu_display', $html );
+      echo apply_filters( 'tc_menu_display', $html );
     }
 
 
@@ -259,8 +259,8 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     */
     function czr_fn_sidenav_display() {
       ob_start();
-        $tc_side_nav_class        = implode(' ', apply_filters('tc_side_nav_class', array( 'tc-sn', 'navbar' ) ) );
-        $tc_side_nav_inner_class  = implode(' ', apply_filters('tc_side_nav_inner_class', array( 'tc-sn-inner', 'nav-collapse') ) );
+        $tc_side_nav_class        = implode(' ', apply_filters( 'tc_side_nav_class', array( 'tc-sn', 'navbar' ) ) );
+        $tc_side_nav_inner_class  = implode(' ', apply_filters( 'tc_side_nav_inner_class', array( 'tc-sn-inner', 'nav-collapse') ) );
         ?>
           <nav id="tc-sn" class="<?php echo $tc_side_nav_class; ?>" role="navigation">
             <div class="<?php echo $tc_side_nav_inner_class; ?>">
@@ -270,7 +270,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
         <?php
       $_sidenav = ob_get_contents();
       ob_end_clean();
-      echo apply_filters( 'czr_fn_sidenav_display', $_sidenav );
+      echo apply_filters( 'tc_sidenav_display', $_sidenav );
     }
 
 
@@ -490,7 +490,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     */
     function czr_fn_add_menuclass( $ulclass) {
       $html =  preg_replace( '/<ul>/' , '<ul class="nav">' , $ulclass, 1);
-      return apply_filters( 'czr_fn_add_menuclass', $html );
+      return apply_filters( 'tc_add_menuclass', $html );
     }
 
 
@@ -703,7 +703,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     */
     function czr_fn_sidenav_body_class( $_classes ){
       $_where = str_replace( 'pull-menu-', '', esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_menu_position') ) );
-      array_push( $_classes, apply_filters( 'czr_fn_sidenav_body_class', "sn-$_where" ) );
+      array_push( $_classes, apply_filters( 'tc_sidenav_body_class', "sn-$_where" ) );
 
       return $_classes;
     }
@@ -731,7 +731,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @return bool
     */
     function czr_fn_is_sidenav_enabled() {
-      return apply_filters( 'czr_fn_is_sidenav_enabled', 'aside' == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_menu_style' ) ) );
+      return apply_filters( 'tc_is_sidenav_enabled', 'aside' == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_menu_style' ) ) );
     }
 
 
@@ -739,7 +739,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @return bool
     */
     function czr_fn_is_second_menu_enabled() {
-      return apply_filters( 'czr_fn_is_second_menu_enabled', (bool)esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_display_second_menu' ) ) );
+      return apply_filters( 'tc_is_second_menu_enabled', (bool)esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_display_second_menu' ) ) );
     }
 
 

--- a/inc/parts/class-header-menu.php
+++ b/inc/parts/class-header-menu.php
@@ -31,7 +31,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @since Customizr 3.2.0
     */
     function czr_set_menu_hooks() {
-      if ( (bool) CZR_utils::$inst->tc_opt('tc_hide_all_menus') )
+      if ( (bool) CZR_utils::$inst->czr_opt('tc_hide_all_menus') )
         return;
       //VARIOUS USER OPTIONS
       add_filter( 'body_class'                    , array( $this , 'tc_add_body_classes') );
@@ -46,7 +46,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
       add_filter( 'tc_user_options_style'         , array( $this , 'tc_add_second_menu_inline_style') );
 
       //SIDE MENU HOOKS SINCE v3.3+
-      if ( $this -> tc_is_sidenav_enabled() ){
+      if ( $this -> czr_is_sidenav_enabled() ){
         add_action( 'wp_head'                     , array( $this , 'tc_set_sidenav_hooks') );
         add_filter( 'tc_user_options_style'       , array( $this , 'tc_set_sidenav_style') );
       } else {
@@ -56,7 +56,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
       //this adds css classes to the navbar-wrapper :
       //1) to the main menu if regular (sidenav not enabled)
       //2) to the secondary menu if enabled
-      if ( ! $this -> tc_is_sidenav_enabled() || CZR_utils::$inst->tc_is_secondary_menu_enabled() ) {
+      if ( ! $this -> czr_is_sidenav_enabled() || CZR_utils::$inst->czr_is_secondary_menu_enabled() ) {
         add_filter( 'tc_navbar_wrapper_class'     , array( $this, 'tc_set_menu_style_options'), 0 );
       }
 
@@ -98,7 +98,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * hook : __sidenav
     */
     function czr_maybe_display_sidenav_help() {
-      if (  ! CZR_placeholders::tc_is_sidenav_help_on() )
+      if (  ! CZR_placeholders::czr_is_sidenav_help_on() )
         return;
       ?>
       <div class="tc-placeholder-wrap tc-sidenav-help">
@@ -107,7 +107,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
               __( "This is a default page menu.", "customizr" ),
               __( "( If you don't have any pages in your website, then this side menu is empty for the moment. )" , "customizr"),
               sprintf( __("If you have already created menu(s), you can %s. If you need to create a new menu, jump to the %s.", "customizr"),
-                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', CZR_utils::tc_get_customizer_url( array( "section" => "nav") ), __( "change the default menu", "customizr"), __("replace this default menu by another one", "customizr") ),
+                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', CZR_utils::czr_get_customizer_url( array( "section" => "nav") ), __( "change the default menu", "customizr"), __("replace this default menu by another one", "customizr") ),
                 sprintf( '<a href="%1$s" title="%2$s" target="blank">%2$s</a>', admin_url('nav-menus.php'), __( "menu creation screen", "customizr") )
               )
           );
@@ -134,14 +134,14 @@ if ( ! class_exists( 'CZR_menu' ) ) :
       ob_start();
 
         //renders the regular menu + responsive button
-        if ( ! $this -> tc_is_sidenav_enabled() ) {
-          $this -> tc_regular_menu_display( 'main' );
+        if ( ! $this -> czr_is_sidenav_enabled() ) {
+          $this -> czr_regular_menu_display( 'main' );
         } else {
-          $this -> tc_sidenav_toggle_button_display();
-          if ( $this -> tc_is_second_menu_enabled() )
-            $this -> tc_regular_menu_display( 'secondary' );
+          $this -> czr_sidenav_toggle_button_display();
+          if ( $this -> czr_is_second_menu_enabled() )
+            $this -> czr_regular_menu_display( 'secondary' );
           else
-            $this -> tc_maybe_display_second_menu_placeholder();
+            $this -> czr_maybe_display_second_menu_placeholder();
         }
 
       $html = ob_get_contents();
@@ -170,7 +170,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
         implode(' ', apply_filters( "tc_{$type}_button_class", $button_class ) ),
         apply_filters( "tc_{$type}_menu_button_attr", $button_attr),
         '<span class="icon-bar"></span>',
-        (bool)esc_attr( CZR_utils::$inst->tc_opt('tc_display_menu_label') ) ? $_button_label : '',
+        (bool)esc_attr( CZR_utils::$inst->czr_opt('tc_display_menu_label') ) ? $_button_label : '',
         '__sidenav' == current_filter() ? __('Close', 'customizr') : __('Open the menu' , 'customizr')
       );
       return apply_filters( "tc_{$type}_menu_button_view", $_button );
@@ -231,17 +231,17 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     */
     function czr_regular_menu_display( $_location = 'main' ){
       $type               = 'regular';
-      $where              = 'right' != esc_attr( CZR_utils::$inst->tc_opt( 'tc_header_layout') ) ? 'pull-right' : 'pull-left';
+      $where              = 'right' != esc_attr( CZR_utils::$inst->czr_opt( 'tc_header_layout') ) ? 'pull-right' : 'pull-left';
       $button_class       = array( 'btn-toggle-nav', $where );
       $button_attr        = 'data-toggle="collapse" data-target=".nav-collapse"';
 
-      $menu_class         = ( ! wp_is_mobile() && 'hover' == esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_type' ) ) ) ? array( 'nav tc-hover-menu' ) : array( 'nav' ) ;
-      $menu_wrapper_class = ( ! wp_is_mobile() && 'hover' == esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_type' ) ) ) ? array( 'nav-collapse collapse', 'tc-hover-menu-wrapper' ) : array( 'nav-collapse', 'collapse' );
+      $menu_class         = ( ! wp_is_mobile() && 'hover' == esc_attr( CZR_utils::$inst->czr_opt( 'tc_menu_type' ) ) ) ? array( 'nav tc-hover-menu' ) : array( 'nav' ) ;
+      $menu_wrapper_class = ( ! wp_is_mobile() && 'hover' == esc_attr( CZR_utils::$inst->czr_opt( 'tc_menu_type' ) ) ) ? array( 'nav-collapse collapse', 'tc-hover-menu-wrapper' ) : array( 'nav-collapse', 'collapse' );
 
-      $menu_view = $this -> tc_wp_nav_menu_view( compact( '_location', 'type', 'menu_class', 'menu_wrapper_class' ) );
+      $menu_view = $this -> czr_wp_nav_menu_view( compact( '_location', 'type', 'menu_class', 'menu_wrapper_class' ) );
 
       if ( $menu_view && 'main' == $_location )
-        $menu_view = $menu_view . $this -> tc_menu_button_view( compact( 'type', 'button_class', 'button_attr') );
+        $menu_view = $menu_view . $this -> czr_menu_button_view( compact( 'type', 'button_class', 'button_attr') );
 
       echo $menu_view;
     }
@@ -288,7 +288,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
        //sidenav menu is always "main"
        $_location          = 'main';
 
-       echo $this -> tc_wp_nav_menu_view( compact( '_location', 'type', 'menu_class', 'menu_wrapper_class') );
+       echo $this -> czr_wp_nav_menu_view( compact( '_location', 'type', 'menu_class', 'menu_wrapper_class') );
     }
 
     /**
@@ -299,11 +299,11 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     */
     function czr_sidenav_toggle_button_display() {
       $type          = 'sidenav';
-      $where         = 'right' != esc_attr( CZR_utils::$inst->tc_opt( 'tc_header_layout') ) ? 'pull-right' : 'pull-left';
+      $where         = 'right' != esc_attr( CZR_utils::$inst->czr_opt( 'tc_header_layout') ) ? 'pull-right' : 'pull-left';
       $button_class  = array( 'btn-toggle-nav', 'sn-toggle', $where );
       $button_attr   = '';
 
-      echo $this -> tc_menu_button_view( compact( 'type', 'button_class', 'button_attr') );
+      echo $this -> czr_menu_button_view( compact( 'type', 'button_class', 'button_attr') );
     }
 
 
@@ -328,7 +328,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
             'fallback_cb'     => array( $this, 'tc_page_menu' ),
             //if no menu is set to the required location, fallsback to tc_page_menu
             //=> tc_page_menu has it's own class extension of Walker, therefore no need to specify one below
-            'walker'          => ! CZR_utils::$inst -> tc_has_location_menu($_location) ? '' : new CZR_nav_walker($_location),
+            'walker'          => ! CZR_utils::$inst -> czr_has_location_menu($_location) ? '' : new CZR_nav_walker($_location),
             'echo'            => false,
         )
       );
@@ -349,12 +349,12 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * PLACEHOLDERS VIEW
     ****************************************/
     /**
-    * Displays the placeholder view if conditions are met in CZR_placeholders::tc_is_main_menu_notice_on()
-    * fired in tc_menu_display(), hook : __navbar
+    * Displays the placeholder view if conditions are met in CZR_placeholders::czr_is_main_menu_notice_on()
+    * fired in czr_menu_display(), hook : __navbar
     * @since Customizr 3.4+
     */
     function czr_maybe_display_main_menu_notice() {
-      if (  ! CZR_placeholders::tc_is_main_menu_notice_on() )
+      if (  ! CZR_placeholders::czr_is_main_menu_notice_on() )
           return;
       ?>
       <div class="tc-placeholder-wrap tc-main-menu-notice">
@@ -363,7 +363,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
               __( "You can now display your menu as a vertical and mobile friendly side menu, animated when revealed.", "customizr" ),
               sprintf( __("%s or %s.", "customizr"),
                 sprintf( '<a href="%1$s" title="%2$s" target="blank">%2$s</a><span class="tc-external"></span>', esc_url('demo.presscustomizr.com?design=nav'), __( "Try it with the demo", "customizr") ),
-                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', CZR_utils::tc_get_customizer_url( array( "section" => "nav") ), __( "open the customizer menu section", "customizr"), __("change your menu design now", "customizr") )
+                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', CZR_utils::czr_get_customizer_url( array( "section" => "nav") ), __( "open the customizer menu section", "customizr"), __("change your menu design now", "customizr") )
               )
           );
           printf('<a class="tc-dismiss-notice" href="#" title="%1$s">%1$s x</a>',
@@ -376,12 +376,12 @@ if ( ! class_exists( 'CZR_menu' ) ) :
 
 
     /**
-    * Displays the placeholder view if conditions are met in CZR_placeholders::tc_is_second_menu_placeholder_on()
-    * fired in tc_menu_display(), hook : __navbar
+    * Displays the placeholder view if conditions are met in CZR_placeholders::czr_is_second_menu_placeholder_on()
+    * fired in czr_menu_display(), hook : __navbar
     * @since Customizr 3.4
     */
     function czr_maybe_display_second_menu_placeholder() {
-      if (  ! CZR_placeholders::tc_is_second_menu_placeholder_on() )
+      if (  ! CZR_placeholders::czr_is_second_menu_placeholder_on() )
           return;
       ?>
       <div class="nav-collapse collapse tc-placeholder-wrap tc-menu-placeholder">
@@ -389,7 +389,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
           printf('<p><strong>%1$s<br/>%2$s</strong></p>',
               __( "You can display your main menu or a second menu here horizontally.", "customizr" ),
               sprintf( __("%s or read the %s.", "customizr"),
-                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', CZR_utils::tc_get_customizer_url( array( "section" => "nav") ), __( "Manage menus in the header", "customizr"), __("Manage your menus in the header now", "customizr") ),
+                sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', CZR_utils::czr_get_customizer_url( array( "section" => "nav") ), __( "Manage menus in the header", "customizr"), __("Manage your menus in the header now", "customizr") ),
                 sprintf( '<a href="%1$s" title="%2$s" target="blank">%2$s</a><span class="tc-external"></span>', esc_url('http://docs.presscustomizr.com/article/101-customizr-theme-options-header-settings/#navigation'), __( "documentation", "customizr") )
               )
           );
@@ -414,17 +414,17 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @since Customizr 3.2.0
     */
     function czr_set_menu_style_options( $_classes ) {
-      $_classes = ( ! wp_is_mobile() && 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_submenu_fade_effect') ) ) ? array_merge( $_classes, array( 'tc-submenu-fade' ) ) : $_classes;
-      $_classes = ( 0 != esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_submenu_item_move_effect') ) ) ? array_merge( $_classes, array( 'tc-submenu-move' ) ) : $_classes;
-      $_classes = ( ! wp_is_mobile() && 'hover' == esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_type' ) ) ) ? array_merge( $_classes, array( 'tc-open-on-hover' ) ) : array_merge( $_classes, array( 'tc-open-on-click' ) );
+      $_classes = ( ! wp_is_mobile() && 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_menu_submenu_fade_effect') ) ) ? array_merge( $_classes, array( 'tc-submenu-fade' ) ) : $_classes;
+      $_classes = ( 0 != esc_attr( CZR_utils::$inst->czr_opt( 'tc_menu_submenu_item_move_effect') ) ) ? array_merge( $_classes, array( 'tc-submenu-move' ) ) : $_classes;
+      $_classes = ( ! wp_is_mobile() && 'hover' == esc_attr( CZR_utils::$inst->czr_opt( 'tc_menu_type' ) ) ) ? array_merge( $_classes, array( 'tc-open-on-hover' ) ) : array_merge( $_classes, array( 'tc-open-on-click' ) );
 
       //Navbar menus positions (not sidenav)
       //CASE 1 : regular menu (sidenav not enabled), controled by option 'tc_menu_position'
       //CASE 2 : second menu ( is_secondary_menu_enabled ?), controled by option 'tc_second_menu_position'
-      if ( ! $this -> tc_is_sidenav_enabled() )
-        array_push( $_classes , esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_position') ) );
-      if ( CZR_utils::$inst->tc_is_secondary_menu_enabled() )
-        array_push( $_classes , esc_attr( CZR_utils::$inst->tc_opt( 'tc_second_menu_position') ) );
+      if ( ! $this -> czr_is_sidenav_enabled() )
+        array_push( $_classes , esc_attr( CZR_utils::$inst->czr_opt( 'tc_menu_position') ) );
+      if ( CZR_utils::$inst->czr_is_secondary_menu_enabled() )
+        array_push( $_classes , esc_attr( CZR_utils::$inst->czr_opt( 'tc_second_menu_position') ) );
 
       return $_classes;
     }
@@ -438,7 +438,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     */
     function czr_add_body_classes($_classes) {
       //menu type class
-      $_menu_type = $this -> tc_is_sidenav_enabled() ? 'tc-side-menu' : 'tc-regular-menu';
+      $_menu_type = $this -> czr_is_sidenav_enabled() ? 'tc-side-menu' : 'tc-regular-menu';
       array_push( $_classes, $_menu_type );
 
       return $_classes;
@@ -459,10 +459,10 @@ if ( ! class_exists( 'CZR_menu' ) ) :
         return $_classes;
 
       //adds the second menu state
-      if ( CZR_Utils::$inst -> tc_is_secondary_menu_enabled() )
+      if ( CZR_Utils::$inst -> czr_is_secondary_menu_enabled() )
         array_push( $_classes, 'tc-second-menu-on' );
       //adds the resp. behaviour option for secondary menu
-      array_push( $_classes, 'tc-second-menu-' . esc_attr( CZR_utils::$inst->tc_opt( 'tc_second_menu_resp_setting' ) . '-when-mobile' ) );
+      array_push( $_classes, 'tc-second-menu-' . esc_attr( CZR_utils::$inst->czr_opt( 'tc_second_menu_resp_setting' ) . '-when-mobile' ) );
 
       return $_classes;
     }
@@ -503,7 +503,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @since Customizr 3.2.11
     */
     function czr_menu_item_style_first_letter_css( $_css ) {
-      if ( ! apply_filters( 'tc_menu_item_style_first_letter' , CZR_utils::$inst -> tc_user_started_before_version( '3.2.0' , '1.0.0' ) ? true : false ) )
+      if ( ! apply_filters( 'tc_menu_item_style_first_letter' , CZR_utils::$inst -> czr_user_started_before_version( '3.2.0' , '1.0.0' ) ? true : false ) )
         return $_css;
 
       return sprintf("%s\n%s",
@@ -519,7 +519,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * This actually "restore" regular menu style (user options in particular) by overriding the max-width: 979px media query
     */
     function czr_add_second_menu_inline_style( $_css ) {
-      if ( ! CZR_Utils::$inst -> tc_is_secondary_menu_enabled() )
+      if ( ! CZR_Utils::$inst -> czr_is_secondary_menu_enabled() )
         return $_css;
 
       return sprintf("%s\n%s",
@@ -702,7 +702,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @since Customizr 3.3+
     */
     function czr_sidenav_body_class( $_classes ){
-      $_where = str_replace( 'pull-menu-', '', esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_position') ) );
+      $_where = str_replace( 'pull-menu-', '', esc_attr( CZR_utils::$inst->czr_opt( 'tc_menu_position') ) );
       array_push( $_classes, apply_filters( 'tc_sidenav_body_class', "sn-$_where" ) );
 
       return $_classes;
@@ -731,7 +731,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @return bool
     */
     function czr_is_sidenav_enabled() {
-      return apply_filters( 'tc_is_sidenav_enabled', 'aside' == esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_style' ) ) );
+      return apply_filters( 'tc_is_sidenav_enabled', 'aside' == esc_attr( CZR_utils::$inst->czr_opt( 'tc_menu_style' ) ) );
     }
 
 
@@ -739,7 +739,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
     * @return bool
     */
     function czr_is_second_menu_enabled() {
-      return apply_filters( 'tc_is_second_menu_enabled', (bool)esc_attr( CZR_utils::$inst->tc_opt( 'tc_display_second_menu' ) ) );
+      return apply_filters( 'tc_is_second_menu_enabled', (bool)esc_attr( CZR_utils::$inst->czr_opt( 'tc_display_second_menu' ) ) );
     }
 
 
@@ -781,7 +781,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
 
       $list_args['echo'] = false;
       $list_args['title_li'] = '';
-      $menu .= str_replace( array( "\r", "\n", "\t" ), '', $this -> tc_list_pages($list_args) );
+      $menu .= str_replace( array( "\r", "\n", "\t" ), '', $this -> czr_list_pages($list_args) );
 
       // if ( $menu )
       //   $menu = '<ul>' . $menu . '</ul>';
@@ -845,7 +845,7 @@ if ( ! class_exists( 'CZR_menu' ) ) :
           }
         }
 
-        $output .= $this -> tc_walk_page_tree( $pages, $r['depth'], $current_page, $r );
+        $output .= $this -> czr_walk_page_tree( $pages, $r['depth'], $current_page, $r );
 
         if ( $r['title_li'] ) {
           $output .= '</ul></li>';

--- a/inc/parts/class-header-nav_walker.php
+++ b/inc/parts/class-header-nav_walker.php
@@ -23,7 +23,7 @@ if ( ! class_exists( 'CZR_nav_walker' ) ) :
     /**
     * hook : nav_menu_css_class
     */
-    function tc_add_bootstrap_classes($classes, $item, $args, $depth ) {
+    function czr_add_bootstrap_classes($classes, $item, $args, $depth ) {
       //cast $classes into array
       $classes = (array)$classes;
       //check if $item is a dropdown ( a parent )
@@ -109,7 +109,7 @@ if ( ! class_exists( 'CZR_nav_walker_page' ) ) :
     /**
     * hook : page_css_class
     */
-    function tc_add_bootstrap_classes($css_class, $page = null, $depth = 0, $args = array(), $current_page = 0) {
+    function czr_add_bootstrap_classes($css_class, $page = null, $depth = 0, $args = array(), $current_page = 0) {
       if ( is_array($css_class) && in_array('page_item_has_children', $css_class ) ) {
         if ( 0 === $depth) {
           $css_class[] = 'dropdown';

--- a/inc/parts/class-header-nav_walker.php
+++ b/inc/parts/class-header-nav_walker.php
@@ -9,8 +9,8 @@
 * @since        3.0
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_nav_walker' ) ) :
-  class TC_nav_walker extends Walker_Nav_Menu {
+if ( ! class_exists( 'CZR_nav_walker' ) ) :
+  class CZR_nav_walker extends Walker_Nav_Menu {
     static $instance;
     public $tc_location;
     function __construct($_location) {
@@ -53,7 +53,7 @@ if ( ! class_exists( 'TC_nav_walker' ) ) :
       if ( $item->is_dropdown ) {
         //makes top menu not clickable (default bootstrap behaviour)
         $search         = '<a';
-        $replace        = ( ! wp_is_mobile() && 'hover' == esc_attr( TC_utils::$inst->tc_opt( 'tc_menu_type' ) ) ) ? '<a data-test="joie"' : '<a class="dropdown-toggle" data-toggle="dropdown" data-target="#"';
+        $replace        = ( ! wp_is_mobile() && 'hover' == esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_type' ) ) ) ? '<a data-test="joie"' : '<a class="dropdown-toggle" data-toggle="dropdown" data-target="#"';
         $replace       .= strpos($item_html, 'href=') ? '' : ' href="#"' ;
         $replace        = apply_filters( 'tc_menu_open_on_click', $replace , $search, $this -> tc_location );
         $item_html      = str_replace( $search , $replace , $item_html);
@@ -99,8 +99,8 @@ endif;
 * @since        3.0
 * @license      http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
-if ( ! class_exists( 'TC_nav_walker_page' ) ) :
-  class TC_nav_walker_page extends Walker_Page {
+if ( ! class_exists( 'CZR_nav_walker_page' ) ) :
+  class CZR_nav_walker_page extends Walker_Page {
     function __construct() {
       add_filter('page_css_class' , array($this, 'tc_add_bootstrap_classes'), 10, 5 );
     }
@@ -137,7 +137,7 @@ if ( ! class_exists( 'TC_nav_walker_page' ) ) :
       if ( $args['has_children'] ) {
         //makes top menu not clickable (default bootstrap behaviour)
         $search         = '<a';
-        $replace        = ( ! wp_is_mobile() && 'hover' == esc_attr( TC_utils::$inst->tc_opt( 'tc_menu_type' ) ) ) ? $search : '<a class="dropdown-toggle" data-toggle="dropdown" data-target="#"';
+        $replace        = ( ! wp_is_mobile() && 'hover' == esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_type' ) ) ) ? $search : '<a class="dropdown-toggle" data-toggle="dropdown" data-target="#"';
         $replace       .= strpos($item_html, 'href=') ? '' : ' href="#"' ;
         $replace        = apply_filters( 'tc_menu_open_on_click', $replace , $search );
         $item_html      = str_replace( $search , $replace , $item_html);

--- a/inc/parts/class-header-nav_walker.php
+++ b/inc/parts/class-header-nav_walker.php
@@ -16,7 +16,7 @@ if ( ! class_exists( 'CZR_nav_walker' ) ) :
     function __construct($_location) {
       self::$instance =& $this;
       $this -> tc_location = $_location;
-      add_filter( 'tc_nav_menu_css_class' , array($this, 'tc_add_bootstrap_classes'), 10, 4 );
+      add_filter( 'tc_nav_menu_css_class' , array($this, 'czr_add_bootstrap_classes'), 10, 4 );
     }
 
 
@@ -102,7 +102,7 @@ endif;
 if ( ! class_exists( 'CZR_nav_walker_page' ) ) :
   class CZR_nav_walker_page extends Walker_Page {
     function __construct() {
-      add_filter('page_css_class' , array($this, 'tc_add_bootstrap_classes'), 10, 5 );
+      add_filter('page_css_class' , array($this, 'czr_add_bootstrap_classes'), 10, 5 );
     }
 
 

--- a/inc/parts/class-header-nav_walker.php
+++ b/inc/parts/class-header-nav_walker.php
@@ -16,14 +16,14 @@ if ( ! class_exists( 'CZR_nav_walker' ) ) :
     function __construct($_location) {
       self::$instance =& $this;
       $this -> tc_location = $_location;
-      add_filter( 'tc_nav_menu_css_class' , array($this, 'czr_add_bootstrap_classes'), 10, 4 );
+      add_filter( 'tc_nav_menu_css_class' , array($this, 'czr_fn_add_bootstrap_classes'), 10, 4 );
     }
 
 
     /**
     * hook : nav_menu_css_class
     */
-    function czr_add_bootstrap_classes($classes, $item, $args, $depth ) {
+    function czr_fn_add_bootstrap_classes($classes, $item, $args, $depth ) {
       //cast $classes into array
       $classes = (array)$classes;
       //check if $item is a dropdown ( a parent )
@@ -53,7 +53,7 @@ if ( ! class_exists( 'CZR_nav_walker' ) ) :
       if ( $item->is_dropdown ) {
         //makes top menu not clickable (default bootstrap behaviour)
         $search         = '<a';
-        $replace        = ( ! wp_is_mobile() && 'hover' == esc_attr( CZR_utils::$inst->czr_opt( 'tc_menu_type' ) ) ) ? '<a data-test="joie"' : '<a class="dropdown-toggle" data-toggle="dropdown" data-target="#"';
+        $replace        = ( ! wp_is_mobile() && 'hover' == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_menu_type' ) ) ) ? '<a data-test="joie"' : '<a class="dropdown-toggle" data-toggle="dropdown" data-target="#"';
         $replace       .= strpos($item_html, 'href=') ? '' : ' href="#"' ;
         $replace        = apply_filters( 'tc_menu_open_on_click', $replace , $search, $this -> tc_location );
         $item_html      = str_replace( $search , $replace , $item_html);
@@ -88,7 +88,7 @@ endif;
 
 
 /**
-* Replace the walker for czr_page_menu()
+* Replace the walker for czr_fn_page_menu()
 * Used for the specific default page menu only
 *
 * Walker_Page is located in wp-includes/post-template.php
@@ -102,14 +102,14 @@ endif;
 if ( ! class_exists( 'CZR_nav_walker_page' ) ) :
   class CZR_nav_walker_page extends Walker_Page {
     function __construct() {
-      add_filter('page_css_class' , array($this, 'czr_add_bootstrap_classes'), 10, 5 );
+      add_filter('page_css_class' , array($this, 'czr_fn_add_bootstrap_classes'), 10, 5 );
     }
 
 
     /**
     * hook : page_css_class
     */
-    function czr_add_bootstrap_classes($css_class, $page = null, $depth = 0, $args = array(), $current_page = 0) {
+    function czr_fn_add_bootstrap_classes($css_class, $page = null, $depth = 0, $args = array(), $current_page = 0) {
       if ( is_array($css_class) && in_array('page_item_has_children', $css_class ) ) {
         if ( 0 === $depth) {
           $css_class[] = 'dropdown';
@@ -137,7 +137,7 @@ if ( ! class_exists( 'CZR_nav_walker_page' ) ) :
       if ( $args['has_children'] ) {
         //makes top menu not clickable (default bootstrap behaviour)
         $search         = '<a';
-        $replace        = ( ! wp_is_mobile() && 'hover' == esc_attr( CZR_utils::$inst->czr_opt( 'tc_menu_type' ) ) ) ? $search : '<a class="dropdown-toggle" data-toggle="dropdown" data-target="#"';
+        $replace        = ( ! wp_is_mobile() && 'hover' == esc_attr( CZR_utils::$inst->czr_fn_opt( 'tc_menu_type' ) ) ) ? $search : '<a class="dropdown-toggle" data-toggle="dropdown" data-target="#"';
         $replace       .= strpos($item_html, 'href=') ? '' : ' href="#"' ;
         $replace        = apply_filters( 'tc_menu_open_on_click', $replace , $search );
         $item_html      = str_replace( $search , $replace , $item_html);

--- a/inc/parts/class-header-nav_walker.php
+++ b/inc/parts/class-header-nav_walker.php
@@ -53,7 +53,7 @@ if ( ! class_exists( 'CZR_nav_walker' ) ) :
       if ( $item->is_dropdown ) {
         //makes top menu not clickable (default bootstrap behaviour)
         $search         = '<a';
-        $replace        = ( ! wp_is_mobile() && 'hover' == esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_type' ) ) ) ? '<a data-test="joie"' : '<a class="dropdown-toggle" data-toggle="dropdown" data-target="#"';
+        $replace        = ( ! wp_is_mobile() && 'hover' == esc_attr( CZR_utils::$inst->czr_opt( 'tc_menu_type' ) ) ) ? '<a data-test="joie"' : '<a class="dropdown-toggle" data-toggle="dropdown" data-target="#"';
         $replace       .= strpos($item_html, 'href=') ? '' : ' href="#"' ;
         $replace        = apply_filters( 'tc_menu_open_on_click', $replace , $search, $this -> tc_location );
         $item_html      = str_replace( $search , $replace , $item_html);
@@ -88,7 +88,7 @@ endif;
 
 
 /**
-* Replace the walker for tc_page_menu()
+* Replace the walker for czr_page_menu()
 * Used for the specific default page menu only
 *
 * Walker_Page is located in wp-includes/post-template.php
@@ -137,7 +137,7 @@ if ( ! class_exists( 'CZR_nav_walker_page' ) ) :
       if ( $args['has_children'] ) {
         //makes top menu not clickable (default bootstrap behaviour)
         $search         = '<a';
-        $replace        = ( ! wp_is_mobile() && 'hover' == esc_attr( CZR_utils::$inst->tc_opt( 'tc_menu_type' ) ) ) ? $search : '<a class="dropdown-toggle" data-toggle="dropdown" data-target="#"';
+        $replace        = ( ! wp_is_mobile() && 'hover' == esc_attr( CZR_utils::$inst->czr_opt( 'tc_menu_type' ) ) ) ? $search : '<a class="dropdown-toggle" data-toggle="dropdown" data-target="#"';
         $replace       .= strpos($item_html, 'href=') ? '' : ' href="#"' ;
         $replace        = apply_filters( 'tc_menu_open_on_click', $replace , $search );
         $item_html      = str_replace( $search , $replace , $item_html);

--- a/index.php
+++ b/index.php
@@ -17,7 +17,7 @@
 
             <?php do_action( '__before_article_container'); ##hook of left sidebar?>
 
-                <div id="content" class="<?php echo implode(' ', apply_filters( 'tc_article_container_class' , array( TC_utils::tc_get_layout( TC_utils::tc_id() , 'class' ) , 'article-container' ) ) ) ?>">
+                <div id="content" class="<?php echo implode(' ', apply_filters( 'tc_article_container_class' , array( CZR_utils::tc_get_layout( CZR_utils::tc_id() , 'class' ) , 'article-container' ) ) ) ?>">
 
                     <?php do_action ('__before_loop');##hooks the heading of the list of post : archive, search... ?>
 

--- a/index.php
+++ b/index.php
@@ -17,13 +17,13 @@
 
             <?php do_action( '__before_article_container'); ##hook of left sidebar?>
 
-                <div id="content" class="<?php echo implode(' ', apply_filters( 'tc_article_container_class' , array( CZR_utils::tc_get_layout( CZR_utils::tc_id() , 'class' ) , 'article-container' ) ) ) ?>">
+                <div id="content" class="<?php echo implode(' ', apply_filters( 'tc_article_container_class' , array( CZR_utils::czr_get_layout( CZR_utils::czr_id() , 'class' ) , 'article-container' ) ) ) ?>">
 
                     <?php do_action ('__before_loop');##hooks the heading of the list of post : archive, search... ?>
 
-                        <?php if ( tc__f('__is_no_results') || is_404() ) : ##no search results or 404 cases ?>
+                        <?php if ( czr__f('__is_no_results') || is_404() ) : ##no search results or 404 cases ?>
 
-                            <article <?php tc__f('__article_selectors') ?>>
+                            <article <?php czr__f('__article_selectors') ?>>
                                 <?php do_action( '__loop' ); ?>
                             </article>
 
@@ -34,7 +34,7 @@
                                 <?php the_post(); ?>
 
                                 <?php do_action ('__before_article') ?>
-                                    <article <?php tc__f('__article_selectors') ?>>
+                                    <article <?php czr__f('__article_selectors') ?>>
                                         <?php do_action( '__loop' ); ?>
                                     </article>
                                 <?php do_action ('__after_article') ?>

--- a/index.php
+++ b/index.php
@@ -17,13 +17,13 @@
 
             <?php do_action( '__before_article_container'); ##hook of left sidebar?>
 
-                <div id="content" class="<?php echo implode(' ', apply_filters( 'tc_article_container_class' , array( CZR_utils::czr_get_layout( CZR_utils::czr_id() , 'class' ) , 'article-container' ) ) ) ?>">
+                <div id="content" class="<?php echo implode(' ', apply_filters( 'tc_article_container_class' , array( CZR_utils::czr_fn_get_layout( CZR_utils::czr_fn_id() , 'class' ) , 'article-container' ) ) ) ?>">
 
                     <?php do_action ('__before_loop');##hooks the heading of the list of post : archive, search... ?>
 
-                        <?php if ( czr__f('__is_no_results') || is_404() ) : ##no search results or 404 cases ?>
+                        <?php if ( czr_fn__f('__is_no_results') || is_404() ) : ##no search results or 404 cases ?>
 
-                            <article <?php czr__f('__article_selectors') ?>>
+                            <article <?php czr_fn__f('__article_selectors') ?>>
                                 <?php do_action( '__loop' ); ?>
                             </article>
 
@@ -34,7 +34,7 @@
                                 <?php the_post(); ?>
 
                                 <?php do_action ('__before_article') ?>
-                                    <article <?php czr__f('__article_selectors') ?>>
+                                    <article <?php czr_fn__f('__article_selectors') ?>>
                                         <?php do_action( '__loop' ); ?>
                                     </article>
                                 <?php do_action ('__after_article') ?>

--- a/sidebar-left.php
+++ b/sidebar-left.php
@@ -8,5 +8,3 @@
  */
 
 dynamic_sidebar( 'left' );
-
-?>

--- a/sidebar-right.php
+++ b/sidebar-right.php
@@ -8,5 +8,3 @@
  */
 
 dynamic_sidebar( 'right' );
-
-?>


### PR DESCRIPTION
Change functions and class prefixes:
- Templates are impacted too (note for child-theme users)
- Constants have not been impacted (mostly for our plugins referring to them, see TC_BASE and wpml related)
- Filter names have not been impacted except for the options map related ones, as they are dynamically retrieved from the section populating method names.